### PR TITLE
v0.0.11: /wiki:retract — source removal with blast radius mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@
 
 LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, thesis-driven investigation, source ingestion, wiki compilation, querying, and artifact generation. Ships as a Claude Code plugin or a portable AGENTS.md for Codex and others. Obsidian-compatible.
 
+## What's New in v0.0.11
+
+**Source Retraction** — cleanly remove regretted sources and their downstream effects:
+
+- **`/wiki:retract`** — new command that handles the full blast radius: identifies all compiled articles referencing a source, removes metadata references, flags inline claims with retraction markers, deletes the raw source, and updates all indexes.
+- **`--recompile`** flag rewrites affected article sections from remaining sources, removing retraction markers automatically.
+- **`--dry-run`** shows the blast radius without making changes.
+- **New lint rule C4b** (Source Provenance): catches dangling source references and unresolved retraction markers.
+- Every retraction is logged permanently with the reason.
+
 ## What's New in v0.0.10
 
 **Research Quality & Resilience** — 5 improvements backed by empirical research from the agentic AI knowledge base:

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wiki",
   "description": "LLM-compiled knowledge base. Topic-isolated wikis, parallel multi-agent research (topic + question auto-detect), thesis-driven investigation with verdicts, repo assessment, Obsidian dual-linking, retardmax mode, and --min-time sustained research.",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "author": {
     "name": "nvk"
   },

--- a/claude-plugin/commands/retract.md
+++ b/claude-plugin/commands/retract.md
@@ -1,0 +1,147 @@
+---
+description: "Retract a source from the wiki. Removes the raw source, identifies all compiled articles that reference it, cleans up references, and flags claims for review. Optionally recompiles affected articles from remaining sources."
+argument-hint: "<source-path> [--reason \"why\"] [--recompile] [--dry-run] [--wiki <name>] [--local]"
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(ls:*), Bash(wc:*), Bash(date:*), Bash(rm:*), Bash(grep:*)
+---
+
+## Your task
+
+Retract (remove) a source that was previously ingested into the wiki. This handles the full blast radius: raw source deletion, compiled article cleanup, index updates, and optional recompilation.
+
+### Parse $ARGUMENTS
+
+- **source-path**: Path to the raw source file to retract (e.g., `raw/articles/2026-shitcoiner-article.md`). Can be a filename only — will search raw/ for a match.
+- **--reason "why"**: Reason for retraction (logged permanently). Required.
+- **--recompile**: After cleanup, recompile affected articles from their remaining sources. Without this flag, articles are cleaned but not resynthesized.
+- **--dry-run**: Show what would happen without making changes.
+- **--wiki <name>**: Target wiki (same resolution as other commands)
+- **--local**: Use project-local `.wiki/`
+
+### Resolve wiki location
+
+1. `--local` flag → `.wiki/`
+2. `--wiki <name>` flag → look up in `~/wiki/wikis.json`
+3. Current directory has `.wiki/` → use it
+4. Otherwise → `~/wiki/`
+
+If the resolved wiki does not exist, stop: "No wiki found."
+
+### Phase 1: Identify the Source
+
+1. If the source-path is a full path (e.g., `raw/articles/2026-shitcoiner.md`), verify it exists
+2. If it's a filename or slug, search `raw/` recursively for a match
+3. If multiple matches, present them and ask which one
+4. Read the source file — extract title, URL, tags, quality, summary
+5. Report: "Found: **{title}** ({path}), ingested {date}"
+
+### Phase 2: Map the Blast Radius
+
+Scan ALL compiled wiki articles to find references to this source:
+
+1. **Grep** all files in `wiki/` for the source filename (e.g., `2026-shitcoiner.md`)
+2. For each match, classify the reference type:
+   - **frontmatter**: Listed in `sources:` field → will be removed
+   - **body-inline**: Mentioned or cited in article body text → flag for review
+   - **see-also**: Listed in "See Also" or "Sources" section → will be removed
+3. Also check `_index.md` files for references
+
+Report the blast radius:
+```
+Blast radius for "Shitcoiner's Guide to Bitcoin Scaling":
+
+| Article | Reference Types | Impact |
+|---------|----------------|--------|
+| wiki/concepts/bitcoin-scaling.md | frontmatter + 2 body-inline | HIGH — claims may need rewriting |
+| wiki/concepts/lightning-network.md | frontmatter + see-also | LOW — only metadata, no inline claims |
+| wiki/topics/layer-2.md | frontmatter + 1 body-inline | MEDIUM — one claim needs review |
+
+Total: 3 articles affected, 3 inline claims to review
+```
+
+If `--dry-run`, stop here and report what would happen.
+
+### Phase 3: Clean Up Compiled Articles
+
+For each affected article:
+
+1. **Remove from `sources:` frontmatter** — delete the line referencing the retracted source
+2. **Remove from "Sources" section** — delete the link/reference line
+3. **Flag inline claims** — for each body-inline reference:
+   - Wrap the claim in a retraction marker:
+     ```markdown
+     <!--RETRACTED-SOURCE: claim below originally sourced from {filename}, retracted {date}: {reason}-->
+     [Claim text that needs review]
+     <!--/RETRACTED-SOURCE-->
+     ```
+   - This makes flagged claims visible and searchable without deleting potentially valid information
+4. **Update `updated:` date** in frontmatter
+5. **Check if article still has sources** — if `sources:` is now empty, flag: "WARNING: {article} has no remaining sources. Consider deleting or recompiling."
+6. **Adjust confidence** — if the retracted source was the only high-credibility source, downgrade confidence
+
+### Phase 4: Delete the Raw Source
+
+1. Delete the raw source file
+2. Remove its entry from `raw/{type}/_index.md`
+3. Decrement source count in `raw/_index.md`
+4. Decrement source count in master `_index.md`
+
+### Phase 5: Log the Retraction
+
+Append to `log.md`:
+```
+## [YYYY-MM-DD] retract | "{title}" — reason: {reason} → {N} articles affected, {N} claims flagged for review
+```
+
+Append same to hub `~/wiki/log.md`.
+
+### Phase 6: Optional Recompile (--recompile)
+
+If `--recompile` is set, for each affected article with body-inline claims:
+
+1. Read the article's remaining sources (from updated `sources:` frontmatter)
+2. Re-read each remaining raw source file
+3. Rewrite the flagged sections using only the remaining sources
+4. Remove the `<!--RETRACTED-SOURCE-->` markers
+5. If no remaining sources cover the claim, delete it entirely and note the deletion
+6. Update the article's `updated:` date
+
+Report:
+```
+Recompiled 2 articles:
+- bitcoin-scaling.md: 2 claims rewritten from remaining sources, 0 claims removed
+- layer-2.md: 0 claims rewritten, 1 claim removed (no other source covers this)
+```
+
+### Phase 7: Final Report
+
+```markdown
+## Retraction Complete
+
+**Source retracted**: {title} ({path})
+**Reason**: {reason}
+**Date**: YYYY-MM-DD
+
+### Impact
+- Articles affected: N
+- Inline claims flagged: N
+- Claims recompiled: N (if --recompile)
+- Claims removed: N (if --recompile, no remaining source)
+
+### Articles Modified
+| Article | Changes |
+|---------|---------|
+| {path} | Removed from sources, {N} claims flagged/rewritten |
+
+### Remaining Review Items
+- [ ] {article}: review claim at line {N} (flagged but not recompiled)
+
+### Verification
+Run `/wiki:lint` to verify no dangling references remain.
+```
+
+### Edge Cases
+
+- **Source used by 0 articles**: Just delete it, update indexes, log it. No article cleanup needed.
+- **Source is the ONLY source for an article**: Warn prominently. With `--recompile`, the article would be gutted. Recommend deletion instead: "Article {name} has no remaining sources after retraction. Consider `/wiki:retract` on the article itself, or manually rewriting with new sources."
+- **Multiple sources to retract**: Run retract once per source. Each run is atomic and logged independently.
+- **Retracted source referenced in another raw source**: Raw sources are immutable — don't modify them. Only compiled articles are cleaned up.

--- a/claude-plugin/skills/wiki-manager/references/linting.md
+++ b/claude-plugin/skills/wiki-manager/references/linting.md
@@ -38,6 +38,12 @@
 - [ ] All "See Also" links are bidirectional (if A→B, then B→A)
 - [ ] All "Sources" links in wiki articles point to existing raw files
 
+### C4b: Source Provenance (Warning)
+
+- [ ] All `sources:` entries in wiki article frontmatter point to existing raw files (no dangling references to deleted/retracted sources)
+- [ ] No `<!--RETRACTED-SOURCE-->` markers remain in article body (these should be resolved via `--recompile` or manual review)
+- [ ] No raw source file is referenced by zero wiki articles (orphan source — suggest compilation or removal)
+
 ### C5: Tag Hygiene (Warning)
 
 - [ ] No near-duplicate tags (e.g., `ml` and `machine-learning`, `nlp` and `natural-language-processing`)
@@ -69,6 +75,8 @@
 | Missing bidirectional link | Add "See Also" entry to the article missing the backlink |
 | Empty frontmatter field | Infer: title from `# heading`, summary from first paragraph |
 | Near-duplicate tags | Replace all instances with the canonical form |
+| Dangling source reference | Remove the entry from `sources:` frontmatter |
+| Unresolved retraction marker | Warn: "Retracted claim not yet reviewed — run `/wiki:retract --recompile` or edit manually" |
 
 ## Report Format
 


### PR DESCRIPTION
## Summary

New `/wiki:retract` command for cleanly removing regretted sources and their downstream effects.

## The Problem

Raw sources are immutable by design, but sometimes you ingest something you later regret — the author turns out to be unreliable, data is fabricated, a paper is retracted. Currently there's no way to purge a source without 30-60 minutes of manual grep, edit, and index updates with high risk of leaving dangling references.

## The Solution

```
/wiki:retract raw/articles/2026-shitcoiner-article.md --reason "author is unreliable"
```

**7-phase workflow**:
1. **Identify** — find and confirm the source
2. **Map blast radius** — grep all wiki articles for references, classify as frontmatter/body-inline/see-also
3. **Clean up articles** — remove metadata refs, flag inline claims with `<!--RETRACTED-SOURCE-->` markers
4. **Delete raw source** — remove file, update indexes
5. **Log** — permanent retraction record with reason
6. **Recompile** (optional `--recompile`) — rewrite flagged sections from remaining sources
7. **Report** — summary of all changes + remaining review items

**Flags**: `--reason` (required), `--recompile`, `--dry-run`, `--wiki`, `--local`

## Supporting changes

- **Lint rule C4b** (Source Provenance): catches dangling `sources:` references to deleted files and unresolved `<!--RETRACTED-SOURCE-->` markers
- **Auto-fix rules** for dangling references and retraction marker warnings

## Files changed

- `claude-plugin/commands/retract.md` (NEW) — the retract command
- `claude-plugin/skills/wiki-manager/references/linting.md` — added C4b + auto-fix rules
- `claude-plugin/.claude-plugin/plugin.json` — version 0.0.11
- `README.md` — changelog

## Test plan

- [ ] Ingest a test source, compile an article from it, then retract it
- [ ] Verify blast radius report shows the affected article
- [ ] Verify `<!--RETRACTED-SOURCE-->` markers appear in article body
- [ ] Verify `--recompile` removes markers and rewrites from remaining sources
- [ ] Verify `--dry-run` makes no changes
- [ ] Run `/wiki:lint` and verify C4b catches dangling refs and unresolved markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)