### PR TITLE
Add configurable hub path for iCloud/custom storage (v0.0.12)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,12 +10,22 @@ An LLM-compiled knowledge base. You (the LLM agent) are both the compiler and th
 
 ## Architecture
 
+### Hub Path
+
+Defaults to `~/wiki/`. Optionally configured via `~/.config/llm-wiki/config.json`:
+
+```json
+{ "hub_path": "~/Library/Mobile Documents/com~apple~CloudDocs/wiki" }
+```
+
+If the config exists, use `hub_path` (expand `~`) instead of `~/wiki/` everywhere below. Store as **HUB**. Use `/wiki config hub-path <path>` to set it up, or create the JSON manually.
+
 ### Hub (~/wiki/)
 
 The hub is lightweight — NO content, just a registry.
 
 ```
-~/wiki/
+~/wiki/                         # or custom path from config.json
 ├── wikis.json          # Registry of all topic wikis
 ├── _index.md           # Lists topic wikis with stats
 ├── log.md              # Global activity log

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@
 
 LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, thesis-driven investigation, source ingestion, wiki compilation, querying, and artifact generation. Ships as a Claude Code plugin or a portable AGENTS.md for Codex and others. Obsidian-compatible.
 
+## What's New in v0.0.12
+
+**Configurable Hub Path** — store your wiki on iCloud Drive, Dropbox, or any custom location:
+
+- **`/wiki config hub-path <path>`** — set a custom hub location (creates `~/.config/llm-wiki/config.json`)
+- Default remains `~/wiki/` — zero breaking changes if you don't configure anything
+- Offers to move existing wiki data when changing the path
+- All commands automatically resolve the hub path from config
+
+Example — move your wiki to iCloud:
+```bash
+/wiki config hub-path ~/Library/Mobile\ Documents/com~apple~CloudDocs/wiki
+```
+
 ## What's New in v0.0.11
 
 **Source Retraction** — cleanly remove regretted sources and their downstream effects:

--- a/README.md
+++ b/README.md
@@ -14,39 +14,13 @@
 
 LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, thesis-driven investigation, source ingestion, wiki compilation, querying, and artifact generation. Ships as a Claude Code plugin or a portable AGENTS.md for Codex and others. Obsidian-compatible.
 
-## What's New in v0.0.12
+## Changelog
 
-**Configurable Hub Path** — store your wiki on iCloud Drive, Dropbox, or any custom location:
+**v0.0.12** — **Configurable Hub Path.** Store wiki on iCloud, Dropbox, or any custom location via `/wiki config hub-path <path>`. Config at `~/.config/llm-wiki/config.json`. Default `~/wiki/` unchanged.
 
-- **`/wiki config hub-path <path>`** — set a custom hub location (creates `~/.config/llm-wiki/config.json`)
-- Default remains `~/wiki/` — zero breaking changes if you don't configure anything
-- Offers to move existing wiki data when changing the path
-- All commands automatically resolve the hub path from config
+**v0.0.11** — **Source Retraction.** `/wiki:retract` removes sources and cleans up all downstream references. `--recompile` rewrites affected articles, `--dry-run` previews blast radius. New lint rule C4b catches dangling refs.
 
-Example — move your wiki to iCloud:
-```bash
-/wiki config hub-path ~/Library/Mobile\ Documents/com~apple~CloudDocs/wiki
-```
-
-## What's New in v0.0.11
-
-**Source Retraction** — cleanly remove regretted sources and their downstream effects:
-
-- **`/wiki:retract`** — new command that handles the full blast radius: identifies all compiled articles referencing a source, removes metadata references, flags inline claims with retraction markers, deletes the raw source, and updates all indexes.
-- **`--recompile`** flag rewrites affected article sections from remaining sources, removing retraction markers automatically.
-- **`--dry-run`** shows the blast radius without making changes.
-- **New lint rule C4b** (Source Provenance): catches dangling source references and unresolved retraction markers.
-- Every retraction is logged permanently with the reason.
-
-## What's New in v0.0.10
-
-**Research Quality & Resilience** — 5 improvements backed by empirical research from the agentic AI knowledge base:
-
-1. **Session Registry** — Multi-round research (`--min-time`) now persists state to `.research-session.json`. If interrupted, resume from the last completed round instead of starting over.
-2. **Subagent Prompt Template** — Standardized prompt structure (Objective/Context/Constraints/Deliverables) for all research agents. "Most sub-agent failures aren't execution failures — they're invocation failures."
-3. **Credibility Critic** — New Phase 2b: independent credibility assessment of sources before ingestion. Scores peer-review status, recency, author authority, and bias. Prevents the "fox guarding the henhouse" problem.
-4. **Progress Scoring** — Each round now produces a 0-100 progress score. Enables principled termination (>=80 = quality ceiling) and low-yield detection (<40 = change strategy).
-5. **Plan Reflection** — Explicit reflection step between rounds that re-evaluates the overall research direction, not just picks gaps. Scores gaps by impact x feasibility x specificity. Catches 34% more cross-topic connections.
+**v0.0.10** — **Research Quality.** Session registry for crash recovery, standardized agent prompts, credibility scoring (Phase 2b), progress scoring (0-100) with smart termination, and inter-round plan reflection.
 
 ## Install
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wiki",
   "description": "LLM-compiled knowledge base. Topic-isolated wikis, parallel multi-agent research (topic + question auto-detect), thesis-driven investigation with verdicts, repo assessment, Obsidian dual-linking, retardmax mode, and --min-time sustained research.",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": {
     "name": "nvk"
   },

--- a/claude-plugin/commands/assess.md
+++ b/claude-plugin/commands/assess.md
@@ -6,13 +6,13 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash(ls:*), Bash(wc:*), Bash(date:
 
 ## Your task
 
-First, check if a wiki exists by trying to read `~/wiki/_index.md` (global) and `.wiki/_index.md` (local).
+First, resolve the hub path: read `~/.config/llm-wiki/config.json` — if it exists and has `hub_path`, use that (expand `~`), otherwise default to `~/wiki/`. Call this **HUB**. Then check if a wiki exists by trying to read `HUB/_index.md` (global hub) and `.wiki/_index.md` (local).
 
 Compare a local repository against the wiki's knowledge base and the broader market. Produce a comprehensive gap analysis.
 
 ### Resolve wiki location
 
-1. `--wiki <name>` → look up in `~/wiki/wikis.json`
+1. `--wiki <name>` → look up in `HUB/wikis.json`
 2. `--local` → `.wiki/` in current directory
 3. Otherwise → ask which topic wiki to compare against
 
@@ -141,6 +141,6 @@ generated: YYYY-MM-DD
 2. Update `output/_index.md`
 3. Update master `_index.md`
 4. Append to topic `log.md`: `## [YYYY-MM-DD] assess | {repo-name} → N alignments, N research gaps, N opportunities, N market gaps`
-5. Append to hub `~/wiki/log.md`
+5. Append to hub `HUB/log.md`
 
 6. Optionally suggest: specific `/wiki:research` commands for each gap found

--- a/claude-plugin/commands/compile.md
+++ b/claude-plugin/commands/compile.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash(ls:*), Bash(wc:*), Bash(date:
 
 ## Your task
 
-First, check if a wiki exists by trying to read `~/wiki/_index.md` (global) and `.wiki/_index.md` (local).
+First, resolve the hub path: read `~/.config/llm-wiki/config.json` — if it exists and has `hub_path`, use that (expand `~`), otherwise default to `~/wiki/`. Call this **HUB**. Then check if a wiki exists by trying to read `HUB/_index.md` (global hub) and `.wiki/_index.md` (local).
 
 
 Read the compilation protocol at `skills/wiki-manager/references/compilation.md` and the indexing protocol at `skills/wiki-manager/references/indexing.md`. Then compile raw sources into wiki articles.
@@ -14,9 +14,9 @@ Read the compilation protocol at `skills/wiki-manager/references/compilation.md`
 ### Resolve wiki location
 
 1. `--local` → `.wiki/`
-2. `--wiki <name>` → look up in `~/wiki/wikis.json`
+2. `--wiki <name>` → look up in `HUB/wikis.json`
 3. Current directory has `.wiki/` → use it
-4. Otherwise → `~/wiki/`
+4. Otherwise → HUB
 
 If wiki does not exist, stop: "No wiki found. Run `/wiki init` first."
 

--- a/claude-plugin/commands/ingest.md
+++ b/claude-plugin/commands/ingest.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash(ls:*), Bash(wc:*), Bash(date:
 
 ## Your task
 
-First, check if a wiki exists by trying to read `~/wiki/_index.md` (global) and `.wiki/_index.md` (local).
+First, resolve the hub path: read `~/.config/llm-wiki/config.json` — if it exists and has `hub_path`, use that (expand `~`), otherwise default to `~/wiki/`. Call this **HUB**. Then check if a wiki exists by trying to read `HUB/_index.md` (global hub) and `.wiki/_index.md` (local).
 
 
 Read the ingestion protocol at `skills/wiki-manager/references/ingestion.md` and the structure spec at `skills/wiki-manager/references/wiki-structure.md`. Then ingest source material.
@@ -14,9 +14,9 @@ Read the ingestion protocol at `skills/wiki-manager/references/ingestion.md` and
 ### Resolve wiki location
 
 1. `--local` flag → `.wiki/`
-2. `--wiki <name>` flag → look up in `~/wiki/wikis.json`
+2. `--wiki <name>` flag → look up in `HUB/wikis.json`
 3. Current directory has `.wiki/` → use it
-4. Otherwise → `~/wiki/`
+4. Otherwise → HUB
 
 If the resolved wiki does not exist, stop: "No wiki found. Run `/wiki init` first."
 
@@ -70,7 +70,7 @@ Follow the inbox processing protocol from `references/ingestion.md`:
 
 ### Topic Wiki Routing (when no --wiki specified)
 
-When the wiki resolved to the hub (`~/wiki/`) and no `--wiki` flag was provided, route content to the right topic wiki AFTER fetching the source content (title, summary, tags are now known).
+When the wiki resolved to the hub (HUB) and no `--wiki` flag was provided, route content to the right topic wiki AFTER fetching the source content (title, summary, tags are now known).
 
 **Skip this step entirely if** `--wiki` or `--local` was explicitly provided.
 
@@ -78,7 +78,7 @@ When the wiki resolved to the hub (`~/wiki/`) and no `--wiki` flag was provided,
 
 If `--auto-classify` is set, or the user didn't specify `--wiki`:
 
-1. Read `~/wiki/wikis.json` to list topic wikis
+1. Read `HUB/wikis.json` to list topic wikis
 2. For each topic wiki with a `config.md`, read the description/scope (first 5 lines is enough)
 3. Match the source's title + summary + tags against wiki scopes
 4. Present a simple numbered choice:

--- a/claude-plugin/commands/lint.md
+++ b/claude-plugin/commands/lint.md
@@ -6,16 +6,16 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash(ls:*), Bash(wc:*), Bash(date:
 
 ## Your task
 
-First, check if a wiki exists by trying to read `~/wiki/_index.md` (global) and `.wiki/_index.md` (local).
+First, resolve the hub path: read `~/.config/llm-wiki/config.json` — if it exists and has `hub_path`, use that (expand `~`), otherwise default to `~/wiki/`. Call this **HUB**. Then check if a wiki exists by trying to read `HUB/_index.md` (global hub) and `.wiki/_index.md` (local).
 
 Read the linting rules at `skills/wiki-manager/references/linting.md`. Then run health checks on the wiki.
 
 ### Resolve wiki location
 
 1. `--local` → `.wiki/`
-2. `--wiki <name>` → look up in `~/wiki/wikis.json`
+2. `--wiki <name>` → look up in `HUB/wikis.json`
 3. Current directory has `.wiki/` → use it
-4. Otherwise → `~/wiki/`
+4. Otherwise → HUB
 
 If wiki does not exist, stop: "No wiki found. Run `/wiki init` first."
 

--- a/claude-plugin/commands/output.md
+++ b/claude-plugin/commands/output.md
@@ -6,16 +6,16 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash(ls:*), Bash(date:*), Bash(pyt
 
 ## Your task
 
-First, check if a wiki exists by trying to read `~/wiki/_index.md` (global) and `.wiki/_index.md` (local).
+First, resolve the hub path: read `~/.config/llm-wiki/config.json` — if it exists and has `hub_path`, use that (expand `~`), otherwise default to `~/wiki/`. Call this **HUB**. Then check if a wiki exists by trying to read `HUB/_index.md` (global hub) and `.wiki/_index.md` (local).
 
 Generate an output artifact from wiki content based on $ARGUMENTS.
 
 ### Resolve wiki location
 
 1. `--local` → `.wiki/`
-2. `--wiki <name>` → look up in `~/wiki/wikis.json`
+2. `--wiki <name>` → look up in `HUB/wikis.json`
 3. Current directory has `.wiki/` → use it
-4. Otherwise → `~/wiki/`
+4. Otherwise → HUB
 
 If wiki does not exist or has no articles, stop: "No wiki found (or no articles). Run `/wiki init` and `/wiki:compile` first."
 

--- a/claude-plugin/commands/query.md
+++ b/claude-plugin/commands/query.md
@@ -6,16 +6,16 @@ allowed-tools: Read, Glob, Grep, Bash(ls:*), Edit
 
 ## Your task
 
-First, check if a wiki exists by trying to read `~/wiki/_index.md` (global) and `.wiki/_index.md` (local).
+First, resolve the hub path: read `~/.config/llm-wiki/config.json` — if it exists and has `hub_path`, use that (expand `~`), otherwise default to `~/wiki/`. Call this **HUB**. Then check if a wiki exists by trying to read `HUB/_index.md` (global hub) and `.wiki/_index.md` (local).
 
 Answer the question in $ARGUMENTS using ONLY the knowledge in the wiki. Follow the Q&A protocol below.
 
 ### Resolve wiki location
 
 1. `--local` → `.wiki/`
-2. `--wiki <name>` → look up in `~/wiki/wikis.json`
+2. `--wiki <name>` → look up in `HUB/wikis.json`
 3. Current directory has `.wiki/` → use it
-4. Otherwise → `~/wiki/`
+4. Otherwise → HUB
 
 If wiki does not exist or has no compiled articles, stop: "No wiki found (or no articles compiled). Run `/wiki init` and `/wiki:compile` first."
 
@@ -71,7 +71,7 @@ Most thorough. For complex questions requiring cross-referencing.
 4. **Read raw sources**: Read any raw sources that seem relevant but may not be fully compiled into articles yet
 
 5. **Sibling wiki peek**:
-   - Read `~/wiki/wikis.json`
+   - Read `HUB/wikis.json`
    - For each sibling wiki, read its `_index.md`
    - If overlap found, note it with specific article references
 

--- a/claude-plugin/commands/research.md
+++ b/claude-plugin/commands/research.md
@@ -21,16 +21,18 @@ Conduct deep research on the topic in $ARGUMENTS. This is an automated pipeline:
 
 ### Resolve wiki location
 
+First, resolve the hub path: read `~/.config/llm-wiki/config.json` — if it exists and has `hub_path`, use that (expand `~`), otherwise default to `~/wiki/`. Call this **HUB**.
+
 **If `--new-topic` is set:**
 1. Derive a slug from the topic: lowercase, hyphens, no special chars, max 40 chars
-2. If `~/wiki/` hub doesn't exist, create it (wikis.json + _index.md + log.md + topics/)
-3. Create the new topic wiki at `~/wiki/topics/<slug>/` following the full init protocol (directory structure, .obsidian/, empty _index.md files, config.md, log.md)
-4. Register in `~/wiki/wikis.json` and update hub `_index.md`
+2. If HUB doesn't exist, create it (wikis.json + _index.md + log.md + topics/)
+3. Create the new topic wiki at `HUB/topics/<slug>/` following the full init protocol (directory structure, .obsidian/, empty _index.md files, config.md, log.md)
+4. Register in `HUB/wikis.json` and update hub `_index.md`
 5. Target this new wiki for all research that follows
 
 **If `--new-topic` is NOT set:**
 1. `--local` → `.wiki/`
-2. `--wiki <name>` → look up in `~/wiki/wikis.json`
+2. `--wiki <name>` → look up in `HUB/wikis.json`
 3. Current directory has `.wiki/` → use it
 4. Otherwise → ask which topic wiki to target
 
@@ -132,7 +134,7 @@ Final:   Run /wiki:lint --fix to clean up
 ```
 /wiki:research "CRISPR gene therapy" --new-topic --min-time 2h --deep
 ```
-Creates `~/wiki/topics/crispr-gene-therapy/`, then runs ~3-5 research rounds over 2 hours, progressively drilling into subtopics the earlier rounds surfaced.
+Creates `HUB/topics/crispr-gene-therapy/`, then runs ~3-5 research rounds over 2 hours, progressively drilling into subtopics the earlier rounds surfaced.
 
 ### Input Detection: Topic vs Question
 
@@ -343,7 +345,7 @@ For each high-quality source (up to --sources count, ranked by quality score):
 #### Phase 5: Report & Log
 
 1. Append to topic wiki `log.md`: `## [YYYY-MM-DD] research | "topic" → N sources ingested, M articles compiled`
-2. Append to hub `~/wiki/log.md`: same entry
+2. Append to hub `HUB/log.md`: same entry
 
 3. Report:
    - **Topic researched**: the query

--- a/claude-plugin/commands/retract.md
+++ b/claude-plugin/commands/retract.md
@@ -19,10 +19,12 @@ Retract (remove) a source that was previously ingested into the wiki. This handl
 
 ### Resolve wiki location
 
+First, resolve the hub path: read `~/.config/llm-wiki/config.json` — if it exists and has `hub_path`, use that (expand `~`), otherwise default to `~/wiki/`. Call this **HUB**.
+
 1. `--local` flag → `.wiki/`
-2. `--wiki <name>` flag → look up in `~/wiki/wikis.json`
+2. `--wiki <name>` flag → look up in `HUB/wikis.json`
 3. Current directory has `.wiki/` → use it
-4. Otherwise → `~/wiki/`
+4. Otherwise → HUB
 
 If the resolved wiki does not exist, stop: "No wiki found."
 
@@ -92,7 +94,7 @@ Append to `log.md`:
 ## [YYYY-MM-DD] retract | "{title}" — reason: {reason} → {N} articles affected, {N} claims flagged for review
 ```
 
-Append same to hub `~/wiki/log.md`.
+Append same to hub `HUB/log.md`.
 
 ### Phase 6: Optional Recompile (--recompile)
 

--- a/claude-plugin/commands/search.md
+++ b/claude-plugin/commands/search.md
@@ -6,16 +6,16 @@ allowed-tools: Read, Glob, Grep, Bash(ls:*)
 
 ## Your task
 
-First, check if a wiki exists by trying to read `~/wiki/_index.md` (global) and `.wiki/_index.md` (local).
+First, resolve the hub path: read `~/.config/llm-wiki/config.json` — if it exists and has `hub_path`, use that (expand `~`), otherwise default to `~/wiki/`. Call this **HUB**. Then check if a wiki exists by trying to read `HUB/_index.md` (global hub) and `.wiki/_index.md` (local).
 
 Search the wiki for content matching $ARGUMENTS.
 
 ### Resolve wiki location
 
 1. `--local` → `.wiki/`
-2. `--wiki <name>` → look up in `~/wiki/wikis.json`
+2. `--wiki <name>` → look up in `HUB/wikis.json`
 3. Current directory has `.wiki/` → use it
-4. Otherwise → `~/wiki/`
+4. Otherwise → HUB
 
 If wiki does not exist, stop: "No wiki found. Run `/wiki init` first."
 

--- a/claude-plugin/commands/thesis.md
+++ b/claude-plugin/commands/thesis.md
@@ -32,10 +32,10 @@ Present this decomposition to the user for confirmation before proceeding.
 
 **If `--wiki` is set**: Use the existing topic wiki. Create a `theses/` subdirectory if it doesn't exist. The thesis research lives there alongside the wiki's regular articles.
 
-**If `--wiki` is NOT set**: Create a new topic wiki:
+**If `--wiki` is NOT set**: Create a new topic wiki. First, resolve the hub path: read `~/.config/llm-wiki/config.json` — if it exists and has `hub_path`, use that (expand `~`), otherwise default to `~/wiki/`. Call this **HUB**.
 1. Derive slug from the thesis (e.g., "sunlight reduces CAA independent of vitamin D" → `sunlight-caa-vitamin-d`)
-2. Create `~/wiki/topics/<slug>/` with full wiki structure
-3. Register in `wikis.json`, update hub `_index.md`
+2. Create `HUB/topics/<slug>/` with full wiki structure
+3. Register in `HUB/wikis.json`, update hub `_index.md`
 4. Set `config.md` description to the thesis statement
 
 In both cases, create a thesis file at `wiki/theses/<slug>.md`:
@@ -193,7 +193,7 @@ confidence: high|medium|low
 ### Phase 5: Report & Log
 
 1. Append to topic `log.md`: `## [YYYY-MM-DD] thesis | "<thesis>" → verdict: X (confidence: Y), N sources, M articles`
-2. Append to hub `~/wiki/log.md`: same
+2. Append to hub `HUB/log.md`: same
 
 3. Report:
    - **Thesis**: the claim

--- a/claude-plugin/commands/wiki.md
+++ b/claude-plugin/commands/wiki.md
@@ -1,39 +1,39 @@
 ---
-description: "LLM wiki knowledge base — initialize, show status, or list wikis. Subcommands: ingest, compile, query, lint, search, output, research."
-argument-hint: "[init <topic-name> [--local]] [--wiki <name>]"
-allowed-tools: Read, Write, Edit, Glob, Bash(ls:*), Bash(wc:*), Bash(mkdir:*), Bash(date:*)
+description: "LLM wiki knowledge base — initialize, show status, configure hub path, or list wikis. Subcommands: ingest, compile, query, lint, search, output, research."
+argument-hint: "[init <topic-name> [--local]] [config hub-path [<path>]] [--wiki <name>]"
+allowed-tools: Read, Write, Edit, Glob, Bash(ls:*), Bash(wc:*), Bash(mkdir:*), Bash(date:*), Bash(mv:*)
 ---
 
 ## Your task
 
-First, check if a wiki exists by trying to read `~/wiki/_index.md` (global hub) and `.wiki/_index.md` (local).
+First, resolve the hub path: read `~/.config/llm-wiki/config.json` — if it exists and has `hub_path`, use that (expand `~`), otherwise default to `~/wiki/`. Call this **HUB**. Then check if a wiki exists by trying to read `HUB/_index.md` (global hub) and `.wiki/_index.md` (local).
 
 You are the llm-wiki knowledge base manager. Read the skill at `skills/wiki-manager/SKILL.md` and structure reference at `skills/wiki-manager/references/wiki-structure.md` for full conventions.
 
 Resolve which wiki to use:
 1. If `--local` flag → `.wiki/` in current directory
-2. If `--wiki <name>` flag → look up in `~/wiki/wikis.json`
+2. If `--wiki <name>` flag → look up in `HUB/wikis.json`
 3. If current directory has `.wiki/` → use it
-4. Otherwise → `~/wiki/` (hub — show status of all topic wikis)
+4. Otherwise → HUB (hub — show status of all topic wikis)
 
 ---
 
 ### If $ARGUMENTS contains "init"
 
 Initialize a new wiki. Parse arguments:
-- `init <name>` → create topic wiki at `~/wiki/topics/<name>/`
+- `init <name>` → create topic wiki at `HUB/topics/<name>/`
 - `init <name> --local` → create local wiki at `.wiki/` in current project
 - `init` (no name) → ask: "What topic is this for?" Then create the topic wiki with their answer.
 
-**A topic name is always required.** There is no bare global wiki — `~/wiki/` is only a hub (wikis.json + _index.md + log.md). All content lives in topic sub-wikis.
+**A topic name is always required.** There is no bare global wiki — HUB is only a hub (wikis.json + _index.md + log.md). All content lives in topic sub-wikis.
 
 **Steps:**
 
-1. If `~/wiki/` doesn't exist yet, create the hub first:
-   - `~/wiki/wikis.json` (empty registry)
-   - `~/wiki/_index.md` (hub index with empty topic wiki table)
-   - `~/wiki/log.md` (global activity log)
-   - `~/wiki/topics/` directory
+1. If HUB doesn't exist yet, create the hub first:
+   - `HUB/wikis.json` (empty registry)
+   - `HUB/_index.md` (hub index with empty topic wiki table)
+   - `HUB/log.md` (global activity log)
+   - `HUB/topics/` directory
    - NO `raw/`, `wiki/`, `output/`, `inbox/`, `config.md`, or `.obsidian/` at the hub level.
 
 2. Create the topic wiki directory structure:
@@ -87,7 +87,7 @@ Initialize a new wiki. Parse arguments:
 
 6. Ask the user: "What is this wiki about?" Use their answer to create `config.md` with title, description, scope, and today's date.
 
-7. Register in `~/wiki/wikis.json` and update hub `_index.md` topic wiki table. For local wikis, add to the `local_wikis` array.
+7. Register in `HUB/wikis.json` and update hub `_index.md` topic wiki table. For local wikis, add to the `local_wikis` array.
 
 8. Report what was created and suggest:
    - `/wiki:research "topic" --sources 10` — auto-research to bootstrap
@@ -101,8 +101,8 @@ Initialize a new wiki. Parse arguments:
 
 Show wiki status:
 
-1. If at the hub level (`~/wiki/`):
-   - Read `~/wiki/_index.md` and `~/wiki/wikis.json`
+1. If at the hub level (HUB):
+   - Read `HUB/_index.md` and `HUB/wikis.json`
    - For each registered topic wiki, read its `_index.md` to get current stats
    - Show a summary table: wiki name, description, source count, article count
    - Show global log (last 5 entries)
@@ -122,8 +122,46 @@ Show wiki status:
 Tell the user:
 
 > No wiki found. Create one with:
-> - `/wiki init quantum-computing` — topic wiki at ~/wiki/topics/quantum-computing/
-> - `/wiki init ml` — topic wiki at ~/wiki/topics/ml/
+> - `/wiki init quantum-computing` — topic wiki at HUB/topics/quantum-computing/
+> - `/wiki init ml` — topic wiki at HUB/topics/ml/
 > - `/wiki init notes --local` — project-local wiki at .wiki/
 >
 > Each topic gets its own wiki with isolated indexes and articles. Queries automatically peek across topic wikis for relevant overlap.
+>
+> To change where the hub lives (e.g., iCloud Drive): `/wiki config hub-path <path>`
+
+---
+
+### If $ARGUMENTS contains "config"
+
+Configure the wiki system.
+
+#### `config hub-path <path>`
+
+Set a custom hub location. Creates `~/.config/llm-wiki/config.json`.
+
+**Steps:**
+
+1. If `<path>` is provided:
+   - Expand `~` in the path
+   - Check if the path exists as a directory. If not, offer to create it.
+   - Write `~/.config/llm-wiki/config.json` (create `~/.config/llm-wiki/` if needed):
+     ```json
+     { "hub_path": "<path>" }
+     ```
+   - If a wiki already exists at the OLD hub location (default `~/wiki/` or previous config):
+     - Ask: "Move existing wiki data from `<old>` to `<new>`? (y/n)"
+     - If yes: move contents (`mv <old>/* <new>/`), update `wikis.json` paths to reflect new base
+     - If no: just update the config — user will move data manually
+   - Report: "Hub path set to `<path>`. All wiki commands now use this location."
+
+2. If no `<path>` provided (just `config hub-path`):
+   - Read `~/.config/llm-wiki/config.json` if it exists
+   - Report: "Current hub path: `<path>`" or "Hub path: `~/wiki/` (default — no custom config)"
+
+#### `config` (no subcommand)
+
+Show all configuration:
+- **Hub path**: current resolved path (and whether it's from config or default)
+- **Config file**: `~/.config/llm-wiki/config.json` (exists / not found)
+- **Topic wikis**: count from wikis.json

--- a/claude-plugin/skills/wiki-manager/SKILL.md
+++ b/claude-plugin/skills/wiki-manager/SKILL.md
@@ -22,16 +22,30 @@ tools:
 
 You manage an LLM-compiled knowledge base. Source documents are ingested into `raw/`, then incrementally compiled into a wiki of interconnected markdown articles. Claude Code is both the compiler and the query engine — no Obsidian, no external tools.
 
+## Hub Path
+
+The hub defaults to `~/wiki/`. To use a different location (e.g., iCloud Drive), create `~/.config/llm-wiki/config.json`:
+
+```json
+{ "hub_path": "~/Library/Mobile Documents/com~apple~CloudDocs/wiki" }
+```
+
+**Resolution**: At the start of every operation, resolve the hub path:
+1. Read `~/.config/llm-wiki/config.json` — if it exists and has `hub_path`, use that (expand `~`)
+2. Otherwise, use `~/wiki/`
+
+Store the resolved path as **HUB** for the rest of the operation. All references to `~/wiki/` below mean HUB.
+
 ## Wiki Location
 
-**Topic sub-wikis are the default.** The global `~/wiki/` is a hub — content lives in `~/wiki/topics/<name>/`. Each topic gets isolated indexes, sources, and articles. This keeps queries focused and prevents unrelated topics from polluting each other's search space.
+**Topic sub-wikis are the default.** HUB is a hub — content lives in `HUB/topics/<name>/`. Each topic gets isolated indexes, sources, and articles. This keeps queries focused and prevents unrelated topics from polluting each other's search space.
 
 Resolution order:
 
 1. `--local` flag → `.wiki/` in current project
-2. `--wiki <name>` flag → named wiki from `~/wiki/wikis.json`
+2. `--wiki <name>` flag → named wiki from `HUB/wikis.json`
 3. Current directory has `.wiki/` → use it
-4. Otherwise → `~/wiki/` (the hub)
+4. Otherwise → HUB (the hub)
 
 When a command targets the hub and the hub has no content, suggest creating a topic sub-wiki instead.
 
@@ -53,13 +67,13 @@ See [references/wiki-structure.md](references/wiki-structure.md) for the complet
 
 7. **Honest gaps.** When answering questions, if the wiki doesn't have the answer, say so. Never hallucinate. Suggest what to ingest to fill the gap.
 
-8. **Multi-wiki awareness.** When querying, answer from the primary wiki first. Then peek at sibling wiki indexes (via `~/wiki/wikis.json`) for relevant overlap. Flag connections but never merge content across wikis.
+8. **Multi-wiki awareness.** When querying, answer from the primary wiki first. Then peek at sibling wiki indexes (via `HUB/wikis.json`) for relevant overlap. Flag connections but never merge content across wikis.
 
 ## Ambient Behavior
 
 When this skill activates outside of an explicit `/wiki:*` command:
 
-1. Check if `~/wiki/_index.md` or `.wiki/_index.md` exists
+1. Resolve the hub path (see Hub Path section above), then check if `HUB/_index.md` or `.wiki/_index.md` exists
 2. Read the master `_index.md` to assess if the wiki might cover the user's question
 3. If relevant content exists → read the relevant articles and answer with citations
 4. If no relevant content → answer normally, optionally suggest: "This could be added to your wiki with `/wiki:ingest`"
@@ -118,7 +132,7 @@ Automatically run a quick structural check when any of these triggers occur:
 
 ### Quick Structure Check (lightweight, runs inline — not a full lint)
 
-1. **Hub integrity**: The hub (`~/wiki/`) should ONLY contain `wikis.json`, `_index.md`, `log.md`, and `topics/`. If `raw/`, `wiki/`, `output/`, `inbox/`, or `config.md` exist at the hub level → delete them (they are traps for misplaced content).
+1. **Hub integrity**: The hub (HUB) should ONLY contain `wikis.json`, `_index.md`, `log.md`, and `topics/`. If `raw/`, `wiki/`, `output/`, `inbox/`, or `config.md` exist at the hub level → delete them (they are traps for misplaced content).
 
 2. **Index freshness**: For the active topic wiki, compare actual file count in `wiki/concepts/`, `wiki/topics/`, `wiki/references/` against the rows in their `_index.md`. If mismatched → auto-fix by adding missing entries or removing dead ones.
 
@@ -126,7 +140,7 @@ Automatically run a quick structural check when any of these triggers occur:
 
 4. **Missing directories**: Verify all expected subdirectories exist in the topic wiki (`raw/articles/`, `raw/papers/`, etc.). If missing → create them with empty `_index.md`.
 
-5. **wikis.json sync**: Check that all topic sub-wikis under `~/wiki/topics/` are registered in `wikis.json`. If a directory exists but isn't registered → add it. If registered but directory is missing → remove the entry.
+5. **wikis.json sync**: Check that all topic sub-wikis under `HUB/topics/` are registered in `wikis.json`. If a directory exists but isn't registered → add it. If registered but directory is missing → remove the entry.
 
 6. **Log existence**: Verify `log.md` exists in the active wiki and at the hub. If missing → create it.
 

--- a/claude-plugin/skills/wiki-manager/references/indexing.md
+++ b/claude-plugin/skills/wiki-manager/references/indexing.md
@@ -56,7 +56,7 @@ Use actual file counts for accuracy, not manual tracking:
 ## Cross-Wiki Index Peek
 
 When peeking at sibling wikis for overlap:
-1. Read `~/wiki/wikis.json` to get the list of all wikis
+1. Read `HUB/wikis.json` to get the list of all wikis
 2. For each sibling wiki, read ONLY its `_index.md` (not full articles)
 3. Check if any summaries or tags match the current query
 4. If overlap found, note it in the response — never read full articles from sibling wikis unless explicitly asked

--- a/claude-plugin/skills/wiki-manager/references/wiki-structure.md
+++ b/claude-plugin/skills/wiki-manager/references/wiki-structure.md
@@ -1,11 +1,13 @@
 # Wiki Directory Structure
 
+> **Configurable hub path**: `~/wiki/` is the default hub location. If `~/.config/llm-wiki/config.json` exists with a `hub_path` field, that path is used instead. Throughout this document, `~/wiki/` means "the resolved hub path" (HUB). See SKILL.md "Hub Path" section.
+
 ## Hub (~/wiki/)
 
 The hub is lightweight — it has NO content directories. It only tracks topic wikis.
 
 ```
-~/wiki/
+~/wiki/                            # or custom path from config.json
 ├── wikis.json                     # Registry of all topic wikis
 ├── _index.md                      # Lists topic wikis with stats
 ├── log.md                         # Global activity log
@@ -69,12 +71,12 @@ Same structure as above but rooted at `<project>/.wiki/` without `wikis.json` or
 
 ## Wiki Resolution Order
 
-When a command runs, resolve which wiki to use:
+When a command runs, first resolve the hub path (HUB) from `~/.config/llm-wiki/config.json`, defaulting to `~/wiki/`. Then resolve which wiki to use:
 
 1. `--local` flag present → `<cwd>/.wiki/`
-2. `--wiki <name>` flag present → look up name in `~/wiki/wikis.json`
+2. `--wiki <name>` flag present → look up name in `HUB/wikis.json`
 3. Current directory has `.wiki/` → use it
-4. Otherwise → `~/wiki/`
+4. Otherwise → HUB
 
 ## wikis.json Format
 
@@ -82,7 +84,7 @@ When a command runs, resolve which wiki to use:
 {
   "default": "~/wiki",
   "wikis": {
-    "main": { "path": "~/wiki", "description": "Global knowledge base" },
+    "hub": { "path": "~/wiki", "description": "Global knowledge base" },
     "<topic>": { "path": "~/wiki/topics/<topic>", "description": "..." }
   },
   "local_wikis": [


### PR DESCRIPTION
## Summary

- Hub location now resolves from `~/.config/llm-wiki/config.json` (`hub_path` field), defaulting to `~/wiki/` when no config exists — zero breaking changes
- New `/wiki config hub-path <path>` subcommand to set custom hub location with optional data migration
- All 11 commands, SKILL.md, and reference docs updated to use `HUB` variable instead of hardcoded `~/wiki/`
- AGENTS.md updated with self-contained Hub Path section for portability

## Test plan

- [ ] Run `/wiki` with no config file — should behave identically to before (default `~/wiki/`)
- [ ] Create `~/.config/llm-wiki/config.json` with `{ "hub_path": "/tmp/test-wiki" }` and run `/wiki` — should resolve to `/tmp/test-wiki`
- [ ] Run `/wiki config hub-path` — should report current path
- [ ] Run `/wiki config hub-path /tmp/new-wiki` — should create config and offer migration
- [ ] Verify all commands (ingest, compile, query, search, lint, output, research, thesis, assess, retract) resolve HUB correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)