### PR TITLE
Update install path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, th
 
 **Claude Code** (native plugin):
 ```bash
-claude plugin install github:nvk/llm-wiki
+claude plugin install wiki@llm-wiki
 ```
 
 **OpenAI Codex / Any LLM Agent** (idea file):


### PR DESCRIPTION
The actual install path in the README was returning an error:

```
$ claude plugin install github:nvk/llm-wiki
Installing plugin "github:nvk/llm-wiki"...
✘ Failed to install plugin "github:nvk/llm-wiki": Plugin "github:nvk/llm-wiki" not found in any configured marketplace
```

Modifying the plugin path as used in the `update` session solved the issue:
```
$ claude plugin install wiki@llm-wiki
Installing plugin "wiki@llm-wiki"...
✔ Successfully installed plugin: wiki@llm-wiki (scope: user)
```