### PR TITLE
docs: remove stale focus-session references

### DIFF
--- a/claude-plugin/skills/wiki-manager/references/command-prelude.md
+++ b/claude-plugin/skills/wiki-manager/references/command-prelude.md
@@ -60,7 +60,7 @@ Anything command-specific stays in the command file:
 
 - `### Parse $ARGUMENTS` sections (flag docs)
 - Command-specific deviations from the 4-step wiki resolution (e.g., `assess` asks which wiki to compare against when none is specified, `thesis` has its own `--new-topic`-equivalent branching in Phase 1)
-- Per-command focus-aware behavior details (which flags are focus-sticky)
+- Per-command `--project` behavior details (which commands support it and how they scope outputs)
 - The command's actual work (the reason the command exists)
 
 ## When to edit this file
@@ -70,6 +70,6 @@ Edit `command-prelude.md` when:
 - The hub resolution protocol changes (e.g., new config location, new fallback path)
 - The wiki resolution order changes (e.g., a new flag like `--wiki` or `--local` is added)
 - A new wiki-requirement variant is introduced (e.g., a command that wants to lazy-create a wiki on write)
-- The focus-session mechanism changes
+- The explicit project-scoping rules change
 
 Do **not** edit this file for command-specific changes. Those stay in the command.

--- a/claude-plugin/skills/wiki-manager/references/wiki-structure.md
+++ b/claude-plugin/skills/wiki-manager/references/wiki-structure.md
@@ -75,7 +75,7 @@ All content lives here. Each topic wiki has the full structure:
     └── *.md                       # Loose outputs (backward compatible)
 ```
 
-See [projects.md](projects.md) for the full projects architecture (lifecycle, multi-membership, focus session state).
+See [projects.md](projects.md) for the full projects architecture (lifecycle, multi-membership, explicit `--project <slug>` scoping).
 
 ## Local Wiki (--local flag)
 


### PR DESCRIPTION
PR title:

docs: remove stale focus-session references

PR body:

## Summary

This cleans up a few stale references left over from the v0.2 project simplification.

The docs now consistently describe project scoping as explicit `--project <slug>` usage, rather than implying the old focus/session-state mechanism still exists.

## Changes

- update `wiki-structure.md` to describe explicit `--project <slug>` scoping
- update `command-prelude.md` to remove stale focus-aware / focus-session wording

## Why

After v0.2 removed ambient project focus, a couple docs still used the older language. Since this repo is heavily protocol/documentation driven, keeping those references aligned helps avoid confusion for users and contributors.
