### PR TITLE
UX: first-run onboarding flow + website guides

### DIFF
--- a/claude-plugin/commands/wiki.md
+++ b/claude-plugin/commands/wiki.md
@@ -165,16 +165,49 @@ Show wiki status. Before reading any `_index.md`, stale-check it: count `.md` fi
 
 ### If no wiki exists and no "init" argument
 
-Tell the user:
+The user is new or hasn't initialized a wiki yet. Instead of dumping a command list, walk them through getting started.
 
-> No wiki found. Create one with:
-> - `/wiki init quantum-computing` — topic wiki at HUB/topics/quantum-computing/
-> - `/wiki init ml` — topic wiki at HUB/topics/ml/
-> - `/wiki init notes --local` — project-local wiki at .wiki/
+**Step 1: Welcome and orient.** Explain what llm-wiki does in one sentence, then ask what they want to research:
+
+> **Welcome to llm-wiki** — a knowledge base that researches topics, ingests sources, and compiles them into articles you can query.
 >
-> Each topic gets its own wiki with isolated indexes and articles. Queries automatically peek across topic wikis for relevant overlap.
+> To get started, what topic would you like to research? For example:
+> - Quantum computing
+> - Nutrition and supplements
+> - Kubernetes deployment patterns
 >
-> To change where the hub lives (e.g., iCloud Drive): `/wiki config hub-path <path>`
+> Just tell me the topic, and I'll set everything up.
+
+**Step 2: On user response,** derive a slug from their topic (lowercase, hyphens, max 40 chars) and run the full init protocol:
+1. Create the hub if it doesn't exist (`~/wiki/` with wikis.json, _index.md, log.md, topics/)
+2. Create the topic wiki at `HUB/topics/<slug>/` with full directory structure
+3. Register in wikis.json and update hub _index.md
+4. Create config.md using the user's topic description
+
+**Step 3: After init completes,** suggest the immediate next action based on what's most likely useful:
+
+> **Wiki created at `~/wiki/topics/<slug>/`**
+>
+> What would you like to do first?
+>
+> 1. **Research** — I'll search the web and build your knowledge base automatically
+>    → Just say: `/wiki:research "<your topic>" --wiki <slug>`
+>
+> 2. **Add a specific source** — paste a URL or file path
+>    → Just say: `/wiki:ingest <url>`
+>
+> 3. **Import existing notes** — drop files into `~/wiki/topics/<slug>/inbox/`
+>    → Then run: `/wiki:ingest --inbox`
+
+Do NOT show the full command reference, config options, or advanced flags during onboarding. Keep it to these three options. The user can discover the rest via `/wiki` (status view) once they have a wiki.
+
+**Permission hint (one-time):** If this is the first wiki being created, also append:
+
+> **Tip:** Research sessions fetch many URLs. To skip approval prompts, add this to your project's `.claude/settings.local.json`:
+> ```json
+> "WebFetch", "WebSearch"
+> ```
+> in the `permissions.allow` array.
 
 ---
 

--- a/claude-plugin/skills/wiki-manager/SKILL.md
+++ b/claude-plugin/skills/wiki-manager/SKILL.md
@@ -143,6 +143,7 @@ Automatically run a quick structural check when any of these triggers occur:
 - **When the skill activates** and the wiki hasn't been linted in 7+ days (check "Last lint" in `_index.md`)
 - **When content is found in the wrong place** — articles in the global hub instead of a topic sub-wiki
 - **When a user mentions wiki problems** — "wiki is broken", "empty", "missing", "wrong"
+- **When no wiki exists** (first-run) — switch to guided onboarding flow instead of showing a command list. Walk the user through topic selection → init → first action suggestion. See `commands/wiki.md` § "If no wiki exists".
 
 ### Quick Structure Check (lightweight, runs inline — not a full lint)
 

--- a/plugins/llm-wiki/skills/wiki-manager/SKILL.md
+++ b/plugins/llm-wiki/skills/wiki-manager/SKILL.md
@@ -136,6 +136,7 @@ Automatically run a quick structural check when any of these triggers occur:
 - **When the skill activates** and the wiki hasn't been linted in 7+ days (check "Last lint" in `_index.md`)
 - **When content is found in the wrong place** — articles in the global hub instead of a topic sub-wiki
 - **When a user mentions wiki problems** — "wiki is broken", "empty", "missing", "wrong"
+- **When no wiki exists** (first-run) — switch to guided onboarding flow instead of showing a command list. Walk the user through topic selection → init → first action suggestion. See `commands/wiki.md` § "If no wiki exists".
 
 ### Quick Structure Check (lightweight, runs inline — not a full lint)
 

--- a/tests/promptfooconfig.yaml
+++ b/tests/promptfooconfig.yaml
@@ -87,6 +87,19 @@ tests:
       - type: cost
         threshold: 0.50
 
+  # --- Onboarding flow ---
+  - description: "First-run: no wiki shows guided onboarding, not just command list"
+    vars:
+      prompt: "What can you help me with?"
+    assert:
+      - type: skill-used
+        value: wiki
+      - type: llm-rubric
+        value: "If no wiki exists, showed a welcoming onboarding message asking what topic the user wants to research, rather than just dumping a list of commands. If a wiki already exists, showed status."
+        threshold: 0.75
+      - type: cost
+        threshold: 0.50
+
   # --- Negative controls ---
   - description: "Router: ambiguous single word asks for clarification"
     vars:


### PR DESCRIPTION
## Summary

- **First-run onboarding**: When no wiki exists, replaces the flat "No wiki found" message with a guided 3-step flow — welcome → topic selection → init → next-action menu. Includes one-time WebFetch/WebSearch permission hint
- **SKILL.md trigger**: Added first-run detection to structural guardian triggers
- **Behavioral eval**: Test verifying onboarding shows a welcome message, not a command dump

Website changes shipped separately to `llm-wiki-web` (already pushed):
- Guides section with 4 expandable guides: Quick Start, Research Workflow, How the Wiki Works, Permissions Setup
- Nav link and llms.txt updated

## Test plan

- [x] `test-plugin-validate.sh` — 45/45 pass
- [x] `test-codex-sync.sh` — in sync
- [ ] `npx promptfoo@latest eval` — behavioral eval for onboarding flow (~$2)
- [ ] Manual test: fresh user with no `~/wiki/` — verify onboarding flow appears
- [ ] Visual check: llm-wiki.net/#guides renders correctly