### PR TITLE
tests: fix set -e counter bug in test-plugin-validate.sh + add C5/C6 …

### DIFF
--- a/tests/test-plugin-validate.sh
+++ b/tests/test-plugin-validate.sh
@@ -10,8 +10,8 @@ PASS=0
 FAIL=0
 TOTAL=0
 
-log_pass() { ((PASS++)); ((TOTAL++)); printf "  \033[32mPASS\033[0m: %s\n" "$1"; }
-log_fail() { ((FAIL++)); ((TOTAL++)); printf "  \033[31mFAIL\033[0m: %s — %s\n" "$1" "$2"; }
+log_pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); printf "  \033[32mPASS\033[0m: %s\n" "$1"; }
+log_fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); printf "  \033[31mFAIL\033[0m: %s — %s\n" "$1" "$2"; }
 
 echo "=== Plugin Validation ==="
 

--- a/tests/test-structure.sh
+++ b/tests/test-structure.sh
@@ -264,6 +264,19 @@ if [ -d "$DEFECTS" ]; then
       || log_fail "retracted-marker: no marker" "fixture broken"
   }
 
+  [ -d "$DEFECTS/duplicate-tags" ] && {
+    grep -q "tags: \[ml, patterns\]" "$DEFECTS/duplicate-tags/raw/articles/2026-01-01-sample-article.md" 2>/dev/null \
+      && grep -q "tags: \[machine-learning, patterns, evals\]" "$DEFECTS/duplicate-tags/wiki/concepts/sample-concept.md" 2>/dev/null \
+      && log_pass "duplicate-tags: C5 defect present" \
+      || log_fail "duplicate-tags: defect not correct" "fixture broken"
+  }
+
+  [ -d "$DEFECTS/orphan-source" ] && {
+    [ -f "$DEFECTS/orphan-source/raw/articles/2026-01-03-orphan.md" ] \
+      && log_pass "orphan-source: C6 defect present" \
+      || log_fail "orphan-source: no orphan file" "fixture broken"
+  }
+
   [ -d "$DEFECTS/misplaced-file" ] && {
     [ -f "$DEFECTS/misplaced-file/wiki/references/sample-concept.md" ] \
       && grep -q "^category: concept" "$DEFECTS/misplaced-file/wiki/references/sample-concept.md" 2>/dev/null \


### PR DESCRIPTION
…defect assertions

- Fix (PASS++)) set -e latent crash in test-plugin-validate.sh (same bug fixed in test-structure.sh by PR #10)
- Add C5 (duplicate-tags) and C6 (orphan-source) defect fixture assertions to test-structure.sh — 2 of 12 fixtures were generated but never validated