### PR TITLE
gitignore: add generated test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 
 # macOS
 .DS_Store
+
+# Generated test artifacts
+tests/fixtures/defects/
+tests/workspace/
+tests/results.json
+tests/.promptfoo/


### PR DESCRIPTION
tests/fixtures/defects/ - created by generate-defect-fixtures.sh tests/workspace/ - created by behavioral evals (CLAUDE.md line 48) tests/results.json - output from promptfoo evals
tests/.promptfoo/ - promptfoo cache