### PR TITLE
ci: add Codex plugin sync test to GitHub Actions structural job

### DIFF
--- a/tests/ci/plugin-tests.yml
+++ b/tests/ci/plugin-tests.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Run structural tests
         run: chmod +x tests/test-structure.sh && ./tests/test-structure.sh
 
+      - name: Verify Codex plugin sync
+        run: chmod +x tests/test-codex-sync.sh && ./tests/test-codex-sync.sh
+
   behavioral:
     name: "Layer 2: Behavioral Evals"
     runs-on: ubuntu-latest


### PR DESCRIPTION
test-codex-sync.sh catches generated file drift between plugins/llm-wiki/ and claude-plugin/ — the most common LLM-caused bug when editing plugin files by hand.

CLAUDE.md lists 3 structural tests that 'always' run; CI was only running 2 of them.