### PR TITLE
Add /wiki:librarian — content-level maintenance agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,7 +225,7 @@ Automated pipeline: search → ingest → compile. Launch parallel agents. Auto-
 4. Auto-generate a playbook output artifact (the actionable deliverable)
 5. Suggest 2-3 testable theses from findings → feed into `--mode thesis`
 
-**Modifiers**: `--new-topic` (create wiki + research in one shot), `--mode thesis "<claim>"` (thesis-driven research with for/against framing and verdict), `--min-time <duration>` (sustained multi-round research), `--sources <N>` (per round).
+**Modifiers**: `--new-topic` (create wiki + research in one shot), `--plan` (decompose into 3-5 parallel paths, confirm, dispatch all at once — parallel ingest, sequential compile), `--mode thesis "<claim>"` (thesis-driven research with for/against framing and verdict), `--min-time <duration>` (sustained multi-round research), `--sources <N>` (per round).
 
 Each agent receives a standardized prompt template: Objective, Context, Current wiki state, Constraints, Return format, Quality scoring guide (5=peer-reviewed → 1=spam). Deduplicate across agents.
 
@@ -304,6 +304,55 @@ Compare a local repo against wiki research + market.
 4. **Market scan** (3-5 parallel agents): competitors, best practices, emerging trends
 
 Output: comparison report with feature matrix, competitive landscape, and recommended actions (specific research and build suggestions).
+
+### Librarian
+
+Content-level wiki maintenance: staleness detection, quality scoring, factual verification, semantic coherence, deduplication. Produces scored reports — never modifies content without confirmation.
+
+**Subcommands**:
+- **scan**: Score all wiki articles for staleness and quality. Two-tier: quick metadata scan first, deep content read only for articles below threshold or with `volatility: hot`. Checkpoints after each article for crash recovery. Results to `.librarian/scan-results.json` and `.librarian/REPORT.md`.
+- **report**: Display the latest scan report.
+- **fix <id>**: Apply a proposed fix from the report (Phase 3 — not yet implemented).
+
+**Staleness scoring** (0-100): four dimensions at 25 points each — source freshness, verification recency, compilation recency, source chain integrity. Decay curves scaled by article `volatility` tier (hot/warm/cold).
+
+**Quality scoring** (0-100): four dimensions at 25 points each — source diversity, content depth, cross-reference density, summary quality. Articles scoring below 40 on either dimension are flagged.
+
+Flags: `--article <path>` (single article), `--resume` (from checkpoint), `--passes <list>` (staleness, quality — future: verification, coherence, dedup).
+
+### Plan
+
+Generate implementation plans grounded in wiki research. Six-stage pipeline: context assembly → interview → gap research → synthesis → plan generation → save.
+
+1. **Context assembly**: Read wiki deeply, identify relevant articles, supporting context, and knowledge gaps
+2. **Interview** (skip with `--no-interview` or `--quick`): 3-7 clarifying questions informed by wiki content
+3. **Gap research** (skip with `--no-research` or `--quick`): Targeted web searches to fill knowledge gaps
+4. **Synthesis**: Merge wiki evidence + interview answers + gap research
+5. **Plan generation**: Output in requested format
+6. **Save**: Write to `output/plan-{slug}-{date}.md`, update indexes and log
+
+**Formats**: `--format roadmap` (default — phased plan with architecture decisions), `--format rfc` (Google/Uber style), `--format adr` (Architecture Decision Records), `--format spec` (technical specification).
+
+Use `--with <wiki>` to load supplementary wikis as craft/skill context alongside the primary domain wiki.
+
+### Project
+
+Manage projects within a topic wiki. Projects are folders under `output/projects/` that group related outputs with a goal captured in `WHY.md`.
+
+- **new <slug> "goal"**: Create project directory with `WHY.md`
+- **list**: Show all projects with status and output counts
+- **show <slug>**: Display project details, WHY.md, and outputs
+- **archive <slug>**: Mark project as archived
+
+Projects are a lightweight overlay — they don't move or copy wiki content.
+
+### Lessons Learned (ll)
+
+Extract lessons from the current session — error→fix patterns, user corrections, discoveries, gotchas — and save structured knowledge to the wiki pipeline.
+
+**7-stage pipeline**: scan conversation → extract patterns → target topic wiki → write raw note → update relevant articles → suggest rule additions → log.
+
+Flags: `--dry-run` (preview without writing), `--rules` (also propose CLAUDE.md/AGENTS.md rule additions).
 
 ## Structural Guardian
 

--- a/claude-plugin/commands/librarian.md
+++ b/claude-plugin/commands/librarian.md
@@ -1,0 +1,150 @@
+---
+description: "Review wiki content for staleness, quality, accuracy, and coherence. Produces scored reports; never modifies content without confirmation."
+argument-hint: "scan [--article <path>] [--resume] [--passes <list>] | report | fix <id> [--wiki <name>] [--local]"
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(ls:*), Bash(wc:*), Bash(date:*), Bash(mv:*), Bash(mkdir:*), WebFetch, WebSearch, Agent
+---
+
+## Your task
+
+Follow the standard prelude in `skills/wiki-manager/references/command-prelude.md` (variant: **wiki-required** — stop with "No wiki found. Run `/wiki init` first." if missing).
+
+Read the librarian reference at `skills/wiki-manager/references/librarian.md`. Then execute the requested subcommand.
+
+### Parse $ARGUMENTS
+
+First argument is the subcommand:
+
+- **scan**: Score all wiki articles for staleness and quality. Default subcommand if none specified.
+- **report**: Display the latest `.librarian/REPORT.md`. If no report exists, suggest running `scan` first.
+- **fix <id>**: (Phase 3, not yet implemented) Apply a proposed fix. Respond: "Fix operations are not yet available. Use the report to identify issues and address them manually."
+
+Flags (apply to `scan`):
+
+- **--article <path>**: Scan only this article instead of the full wiki. Path relative to wiki root (e.g., `wiki/concepts/librarian-agent.md`).
+- **--resume**: Explicitly resume from checkpoint. Also happens automatically if `checkpoint.json` exists.
+- **--passes <list>**: Comma-separated list of passes to run. Default: `staleness,quality`. Future: `verification,coherence,dedup`.
+- **--wiki <name>**: Target a specific topic wiki.
+- **--local**: Use project-local `.wiki/`.
+
+### Scan Protocol
+
+#### 0. Initialize
+
+1. Create `.librarian/` directory if it doesn't exist (`mkdir -p`).
+2. Check for existing `checkpoint.json`:
+   - If exists and `--resume` or no explicit flag: read it, report how many articles are already done, continue from where it left off.
+   - If exists and user started a fresh scan (no `--resume`): warn "Found checkpoint from [date] with N/M articles done. Resume? (y/n)". On "n", delete checkpoint and start fresh.
+3. Read `config.md` for `freshness_threshold` (default: 70).
+4. Build article list:
+   - Full scan: `Glob wiki/**/*.md`, exclude `_index.md` files.
+   - `--article`: just the one file.
+5. Subtract already-completed articles (from checkpoint) to get the pending list.
+
+#### 1. Staleness Pass (per article)
+
+For each pending article:
+
+1. Read the article's YAML frontmatter (do NOT read the full body yet — Tier 1 is metadata-only).
+2. Read `volatility` (default: `warm`), `verified`, `updated`, `created`, `sources`, `confidence`.
+3. For each entry in `sources:`, check if the raw file exists (Glob or Read). Record resolved count.
+4. For resolved sources, read their `ingested:` date from frontmatter.
+5. Compute staleness score using the formula in `references/librarian.md` § Staleness Scoring.
+6. Write result to `checkpoint.json` (atomic: write `.checkpoint.tmp`, rename).
+
+#### 2. Quality Pass (per article)
+
+For each article (same loop, immediately after staleness):
+
+**Tier 1 (all articles, metadata-only)**:
+
+1. Count sources and read their `confidence:` fields → source quality score (1-5).
+2. Get file size (`wc -w` or estimate from Read) and count `## ` headings → depth proxy (1-5).
+3. Check for "See Also" section presence → flag `no-see-also` if missing.
+4. Record Tier 1 quality scores in checkpoint.
+
+**Tier 2 escalation** — read the full article body if ANY of these are true:
+- Staleness score < threshold (from Pass 1)
+- `volatility: hot`
+- Tier 1 depth proxy = 1 or 2 (suspected stub)
+
+When escalated:
+
+5. Read the full article body.
+6. Score coherence (1-5): Does it flow logically? Are there unsupported jumps?
+7. Score utility (1-5): Would a reader find this actionable?
+8. Refine depth and source quality scores with body-level evidence.
+9. Apply quality flags per `references/librarian.md` § Quality Flags.
+10. Update checkpoint with Tier 2 results.
+
+**Non-escalated articles**: coherence and utility default to 3 (adequate). This avoids reading every article body on large wikis.
+
+#### 3. Stale Article Triage
+
+After all articles are scored:
+
+1. Sort articles by staleness score (ascending — worst first).
+2. Filter to those below the freshness threshold.
+3. For each stale article, recommend an action:
+   - `refresh` — sources are old, article may be outdated. Delegate to `/wiki:refresh`.
+   - `verify` — article lacks `verified:` date or it's been too long. User should read and confirm.
+   - `expand` — thin article with few sources. Suggest `/wiki:research` to find more sources.
+4. Present the triage list to the user:
+
+```
+## Stale Articles — Action Required
+
+1. [NVIDIA Spark Specs](wiki/topics/nvidia-spark.md) — score 31/100
+   Sources 180 days old, never verified.
+   → Refresh sources? (y/n/skip)
+
+2. [CLI UX Patterns](wiki/concepts/cli-ux-patterns.md) — score 45/100
+   Verified 120 days ago, warm volatility.
+   → Verify still accurate? (y/n/skip)
+```
+
+5. For articles the user selects to refresh: invoke the refresh protocol from `commands/refresh.md` for that article.
+6. For articles the user selects to verify: update `verified:` to today in the article's frontmatter.
+
+#### 4. Generate Reports
+
+1. Compile all results from checkpoint into `scan-results.json` (format per `references/librarian.md`).
+2. Generate `REPORT.md` from the JSON (format per `references/librarian.md`).
+3. Delete `checkpoint.json` (scan complete — no longer needed).
+4. Write both files to `.librarian/`.
+
+#### 5. Log and Report
+
+1. Append to `.librarian/log.md`:
+   `## [YYYY-MM-DD] scan | N articles, M stale, K low-quality (passes: staleness, quality)`
+
+2. Append to the wiki's `log.md`:
+   `## [YYYY-MM-DD] librarian | scanned N articles, M stale, K low-quality`
+
+3. Present the summary to the user:
+
+```
+## Librarian Scan Complete
+
+Scanned N articles in <wiki-name>.
+
+| Metric | Value |
+|--------|-------|
+| Below staleness threshold | M |
+| Low quality (< 50) | K |
+| Average staleness | X/100 |
+| Average quality | Y/100 |
+
+Full report: .librarian/REPORT.md
+Scan data: .librarian/scan-results.json
+```
+
+4. If stale articles were found and user hasn't triaged them yet, prompt for triage (step 3 above).
+
+### Report Subcommand
+
+When the user runs `report` (or `/wiki:librarian report`):
+
+1. Check if `.librarian/REPORT.md` exists. If not: "No librarian report found. Run `/wiki:librarian scan` first."
+2. Read and display `REPORT.md`.
+3. Note when the scan was run (from `scan-results.json` → `completed_at`).
+4. If the scan is older than the wiki's staleness threshold for hot articles (30 days), suggest re-scanning.

--- a/claude-plugin/commands/wiki.md
+++ b/claude-plugin/commands/wiki.md
@@ -106,7 +106,8 @@ The user typed something that isn't a known keyword. Detect their intent and rou
 | 5 | **Thesis** | "prove that", "is it true that", "verify", "test the claim", "test the hypothesis" | `Skill: wiki:research` with `--mode thesis "<claim>"` |
 | 6 | **Compile** | "compile", "process sources", "synthesize", "update articles" | `Skill: wiki:compile` |
 | 7 | **Lint** | "check health", "fix wiki", "broken", "problems", "cleanup" | `Skill: wiki:lint` |
-| 7b | **Refresh** | "check freshness", "still current", "up to date", "stale", "outdated", "refresh" | `Skill: wiki:refresh` |
+| 7b | **Librarian** | "librarian", "quality scan", "scan quality", "quality issues", "article quality", "content review", "review my wiki", "review articles", "librarian report", "quality report", "stale articles" | `Skill: wiki:librarian` |
+| 7c | **Refresh** | "check freshness", "still current", "up to date", "outdated", "refresh" | `Skill: wiki:refresh` |
 | 8 | **Output** | "write a summary", "generate a report", "slides", "create a", "write a" | `Skill: wiki:output` with the request |
 | 9 | **Assess** | "compare to", "assess", "gap analysis" | `Skill: wiki:assess` |
 | 10 | **Plan** | "plan for", "implementation plan", "architecture for" | `Skill: wiki:plan` |

--- a/claude-plugin/skills/wiki-manager/references/librarian.md
+++ b/claude-plugin/skills/wiki-manager/references/librarian.md
@@ -1,0 +1,232 @@
+# Librarian Reference
+
+Content-level wiki maintenance: staleness detection, quality scoring, factual verification, semantic coherence, deduplication. This reference defines the scoring algorithms, report formats, and operational protocols for `/wiki:librarian`.
+
+## Design Principles
+
+1. **Score then act.** The librarian produces scores and reports. It never modifies wiki content during a scan. Write operations (fix, auto-fix) are separate commands requiring explicit confirmation.
+2. **Conservative by default.** When uncertain, flag for human review rather than auto-classifying as clean. Lean toward false positives over false negatives.
+3. **Checkpoint everything.** After scoring each article, write the result to `.librarian/checkpoint.json`. If the session drops, the next invocation resumes from where it left off.
+4. **Two-tier escalation.** Quick metadata-only scan first (cheap). Deep content read only for articles that score below threshold or have `volatility: hot`. Token cost scales with problem density, not wiki size.
+5. **Machine-readable first.** `.librarian/scan-results.json` is the source of truth. `REPORT.md` is rendered from it. Other skills read the JSON.
+
+## Staleness Scoring (Pass 1)
+
+Composite score 0-100 across four dimensions, each contributing 0-25 points. Uses the same four dimensions as the freshness design in `wiki-structure.md`, applied per-article.
+
+### Dimensions
+
+| Dimension | Measures | Source Field | Computation |
+|-----------|----------|-------------|-------------|
+| Source freshness | Age of raw sources | `sources:` → each raw file's `ingested:` date | Average days since ingestion across all sources |
+| Verification recency | Last human confirmation | `verified:` date | Days since verified |
+| Compilation recency | Article currency | `updated:` date | Days since updated |
+| Source chain integrity | Referenced sources exist | `sources:` entries | Percentage of sources that resolve to actual files |
+
+### Decay Curves by Volatility
+
+Each dimension's raw day-count is converted to a 0-25 score using exponential decay scaled by the article's `volatility` tier:
+
+| Volatility | Half-life (days) | Effect |
+|------------|-----------------|--------|
+| `hot` | 30 | Score decays quickly — 60-day-old hot article scores ~50% |
+| `warm` | 90 | Moderate decay — 90-day-old warm article scores ~50% |
+| `cold` | 365 | Slow decay — cold articles stay fresh for a year |
+
+**Formula per dimension** (except source chain integrity):
+
+```
+dimension_score = 25 * 0.5^(days_old / half_life)
+```
+
+**Source chain integrity** (no decay — binary per source):
+
+```
+integrity_score = 25 * (resolved_sources / total_sources)
+```
+
+**Composite staleness score**:
+
+```
+staleness_score = source_freshness + verification_recency + compilation_recency + integrity
+```
+
+Range: 0 (completely stale) to 100 (perfectly fresh).
+
+### Missing Fields
+
+- Missing `volatility`: treat as `warm` (safe default, matches C15 auto-fix)
+- Missing `verified`: treat as never verified — verification_recency = 0
+- Missing `updated`: fall back to `created` date
+- Missing `sources`: integrity = 0 (no sources to verify)
+
+### Staleness Threshold
+
+Read `freshness_threshold` from the wiki's `config.md` (default: 70). Articles scoring below this threshold are flagged.
+
+## Quality Scoring (Pass 5)
+
+Four dimensions, each scored 1-5. Composite quality score is the average, mapped to 0-100.
+
+### Dimensions
+
+| Dimension | 1 (Stub) | 3 (Adequate) | 5 (Featured) |
+|-----------|----------|-------------|--------------|
+| **Depth** | Single paragraph, no structure | Multiple sections, covers key aspects | Comprehensive treatment with nuance, examples, and edge cases |
+| **Source quality** | No sources or single low-confidence source | 2-3 sources, mixed confidence | 4+ high-confidence sources that corroborate |
+| **Coherence** | Disjointed, no logical flow | Readable structure, minor gaps | Clear narrative arc, smooth transitions, no logical gaps |
+| **Utility** | Trivial or obvious information | Useful for understanding the topic | Actionable for decision-making, includes tradeoffs and recommendations |
+
+### Scoring Protocol
+
+**Tier 1 (metadata-only, all articles)**:
+- Source quality: count sources, read their `confidence:` fields. Score derivable without reading article body.
+- Depth (proxy): word count + heading count from file stats. <200 words or 0 headings = stub (1-2). >1000 words + 3+ headings = likely good (4-5).
+
+**Tier 2 (deep read, escalated articles only)**:
+- Read the full article body.
+- Score coherence and utility by analyzing the content.
+- Refine the depth and source quality scores from Tier 1.
+- Escalation triggers: staleness score < 70, volatility = hot, or Tier 1 depth proxy = 1-2.
+
+### Quality Flags
+
+In addition to numeric scores, tag articles with specific quality flags:
+
+| Flag | Trigger |
+|------|---------|
+| `thin-coverage` | Depth score 1-2 |
+| `single-source` | Only one source in `sources:` |
+| `low-confidence-sources` | Average source confidence below medium |
+| `no-see-also` | Zero "See Also" cross-references |
+| `stale` | Staleness score below threshold |
+| `unverified` | Missing `verified:` field |
+
+### Composite Quality Score
+
+```
+quality_score = ((depth + source_quality + coherence + utility) / 4) * 20
+```
+
+Range: 20 (worst possible — all 1s) to 100 (all 5s). Articles below 50 are surfaced for review.
+
+## Checkpoint Protocol
+
+The `.librarian/` directory lives inside each topic wiki (e.g., `~/wiki/topics/meta-llm-wiki/.librarian/`). Created on first scan.
+
+### checkpoint.json
+
+Written after each article is scored. If the session drops, the next `scan` or `scan --resume` reads this file and skips already-scored articles.
+
+```json
+{
+  "scan_id": "2026-04-22T10:30:00Z",
+  "wiki": "meta-llm-wiki",
+  "passes": ["staleness", "quality"],
+  "scope": "full",
+  "threshold": 70,
+  "completed": ["wiki/concepts/article-a.md", "wiki/concepts/article-b.md"],
+  "pending": ["wiki/topics/article-c.md"],
+  "results": {
+    "wiki/concepts/article-a.md": {
+      "staleness": { "score": 92, "factors": { "source_freshness": 23, "verification": 24, "compilation": 22, "integrity": 23 } },
+      "quality": { "score": 85, "dimensions": { "depth": 4, "source_quality": 5, "coherence": 4, "utility": 4 }, "flags": [] },
+      "tier": 1,
+      "scanned_at": "2026-04-22T10:31:00Z"
+    }
+  }
+}
+```
+
+**Atomic writes**: Write to `.librarian/.checkpoint.tmp`, then rename to `checkpoint.json`. Incomplete writes from crashes are detected (missing or unparseable tmp file) and the last article is rescanned.
+
+**Clearing**: Checkpoint is deleted when a scan completes successfully and `scan-results.json` is written.
+
+### scan-results.json
+
+The complete scan output. Source of truth for other skills.
+
+```json
+{
+  "scan_id": "2026-04-22T10:30:00Z",
+  "wiki": "meta-llm-wiki",
+  "completed_at": "2026-04-22T10:45:00Z",
+  "passes": ["staleness", "quality"],
+  "threshold": 70,
+  "summary": {
+    "articles_scanned": 29,
+    "stale_count": 4,
+    "low_quality_count": 2,
+    "avg_staleness": 78,
+    "avg_quality": 72,
+    "worst_staleness": { "article": "wiki/topics/some-topic.md", "score": 31 },
+    "worst_quality": { "article": "wiki/concepts/some-concept.md", "score": 42 }
+  },
+  "articles": {
+    "wiki/concepts/article-a.md": {
+      "staleness": { "score": 92, "factors": { "source_freshness": 23, "verification": 24, "compilation": 22, "integrity": 23 } },
+      "quality": { "score": 85, "dimensions": { "depth": 4, "source_quality": 5, "coherence": 4, "utility": 4 }, "flags": [] },
+      "tier": 1
+    }
+  }
+}
+```
+
+### REPORT.md
+
+Human-readable report generated from `scan-results.json`. Format:
+
+```markdown
+# Librarian Report — YYYY-MM-DD
+
+> Scanned N articles in <wiki-name>. Passes: staleness, quality.
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Articles scanned | N |
+| Below staleness threshold | N |
+| Low quality (< 50) | N |
+| Average staleness | N/100 |
+| Average quality | N/100 |
+
+## Stale Articles (staleness < threshold)
+
+| Article | Score | Top Factor | Recommendation |
+|---------|-------|-----------|----------------|
+| [Title](path) | 31/100 | sources 180d old | refresh |
+| [Title](path) | 45/100 | unverified 120d | verify |
+
+## Low Quality Articles (quality < 50)
+
+| Article | Score | Flags | Recommendation |
+|---------|-------|-------|----------------|
+| [Title](path) | 42/100 | thin-coverage, single-source | expand and add sources |
+
+## All Articles (sorted by combined score)
+
+| Article | Staleness | Quality | Flags |
+|---------|-----------|---------|-------|
+| ... | ... | ... | ... |
+```
+
+### log.md
+
+Append-only librarian activity log at `.librarian/log.md`:
+
+```
+## [YYYY-MM-DD] scan | N articles, M stale, K low-quality (passes: staleness, quality)
+## [YYYY-MM-DD] scan --article wiki/concepts/foo.md | staleness 45, quality 72
+```
+
+## Boundary with Other Commands
+
+| Command | Responsibility | Librarian Does NOT |
+|---------|---------------|-------------------|
+| `lint` | Structure: broken links, missing indexes, frontmatter schema, file placement | Lint's territory — librarian skips |
+| `lint --deep` (C7) | Quick spot-check: a few web searches for obvious staleness | Lightweight — librarian goes deeper |
+| `refresh` | Re-fetch sources, compare changes, offer recompilation | Librarian flags, then delegates to refresh |
+| `compile` | Transform raw sources into wiki articles | Librarian reviews compiled output, never compiles |
+
+When the librarian flags an article as stale and the user confirms, it delegates to the refresh protocol in `commands/refresh.md` for that article.

--- a/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
+++ b/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
@@ -2,10 +2,11 @@
 name: wiki-manager
 description: >
   LLM-compiled knowledge base manager for OpenCode. Use it to initialize, ingest,
-  compile, query, lint, research, and generate outputs from topic-scoped wikis.
+  compile, query, lint, research, plan, and generate outputs from topic-scoped wikis.
   Activates when the user mentions wiki workflows, knowledge-base management,
-  ingestion, compilation, querying, linting, research, or uses wiki-related
-  shorthand in a repo with .wiki/, ~/wiki/, or a configured hub path.
+  ingestion, compilation, querying, linting, research, librarian, scan quality,
+  article quality, content review, lessons learned, implementation plan, or uses
+  wiki-related shorthand in a repo with .wiki/, ~/wiki/, or a configured hub path.
 ---
 
 # LLM Wiki Manager

--- a/plugins/llm-wiki/skills/wiki-manager/SKILL.md
+++ b/plugins/llm-wiki/skills/wiki-manager/SKILL.md
@@ -2,10 +2,11 @@
 name: wiki-manager
 description: >
   LLM-compiled knowledge base manager for Codex. Use it to initialize, ingest,
-  compile, query, lint, research, and generate outputs from topic-scoped wikis.
+  compile, query, lint, research, plan, and generate outputs from topic-scoped wikis.
   Activates when the user mentions wiki workflows, knowledge-base management,
-  ingestion, compilation, querying, linting, research, or uses /wiki-style
-  shorthand in a repo with .wiki/, ~/wiki/, or a configured hub path.
+  ingestion, compilation, querying, linting, research, librarian, scan quality,
+  article quality, content review, lessons learned, implementation plan, or uses
+  /wiki-style shorthand in a repo with .wiki/, ~/wiki/, or a configured hub path.
 ---
 
 # LLM Wiki Manager

--- a/scripts/sync-codex-plugin.sh
+++ b/scripts/sync-codex-plugin.sh
@@ -67,10 +67,11 @@ frontmatter = """---
 name: wiki-manager
 description: >
   LLM-compiled knowledge base manager for Codex. Use it to initialize, ingest,
-  compile, query, lint, research, and generate outputs from topic-scoped wikis.
+  compile, query, lint, research, plan, and generate outputs from topic-scoped wikis.
   Activates when the user mentions wiki workflows, knowledge-base management,
-  ingestion, compilation, querying, linting, research, or uses /wiki-style
-  shorthand in a repo with .wiki/, ~/wiki/, or a configured hub path.
+  ingestion, compilation, querying, linting, research, librarian, scan quality,
+  article quality, content review, lessons learned, implementation plan, or uses
+  /wiki-style shorthand in a repo with .wiki/, ~/wiki/, or a configured hub path.
 ---
 """
 

--- a/scripts/sync-opencode-plugin.sh
+++ b/scripts/sync-opencode-plugin.sh
@@ -42,10 +42,11 @@ frontmatter = """---
 name: wiki-manager
 description: >
   LLM-compiled knowledge base manager for OpenCode. Use it to initialize, ingest,
-  compile, query, lint, research, and generate outputs from topic-scoped wikis.
+  compile, query, lint, research, plan, and generate outputs from topic-scoped wikis.
   Activates when the user mentions wiki workflows, knowledge-base management,
-  ingestion, compilation, querying, linting, research, or uses wiki-related
-  shorthand in a repo with .wiki/, ~/wiki/, or a configured hub path.
+  ingestion, compilation, querying, linting, research, librarian, scan quality,
+  article quality, content review, lessons learned, implementation plan, or uses
+  wiki-related shorthand in a repo with .wiki/, ~/wiki/, or a configured hub path.
 ---
 """
 

--- a/tests/promptfooconfig.yaml
+++ b/tests/promptfooconfig.yaml
@@ -10,10 +10,11 @@ providers:
   - id: anthropic:claude-agent-sdk
     config:
       model: claude-sonnet-4-6
-      working_dir: ./tests/workspace
+      # Paths here resolve relative to this config file.
+      working_dir: ./workspace
       plugins:
         - type: local
-          path: ./claude-plugin
+          path: ../claude-plugin
       append_allowed_tools: ['Skill', 'Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep']
       permission_mode: acceptEdits
       max_budget_usd: 2.00

--- a/tests/promptfooconfig.yaml
+++ b/tests/promptfooconfig.yaml
@@ -113,6 +113,31 @@ tests:
       - type: cost
         threshold: 0.50
 
+  # --- Librarian routing ---
+  - description: "Router: quality scan routes to librarian"
+    vars:
+      prompt: "Scan my wiki for quality issues and stale articles"
+    assert:
+      - type: skill-used
+        value: wiki
+      - type: llm-rubric
+        value: "Recognized as a librarian/quality scan request and routed to the librarian command, not lint or refresh."
+        threshold: 0.75
+      - type: cost
+        threshold: 0.50
+
+  - description: "Router: librarian report routes correctly"
+    vars:
+      prompt: "Show me the librarian report"
+    assert:
+      - type: skill-used
+        value: wiki
+      - type: llm-rubric
+        value: "Recognized as a request for the librarian report, not a generic query."
+        threshold: 0.75
+      - type: cost
+        threshold: 0.50
+
   # --- Negative controls ---
   - description: "Router: ambiguous single word asks for clarification"
     vars:

--- a/tests/test-plugin-validate.sh
+++ b/tests/test-plugin-validate.sh
@@ -180,7 +180,7 @@ if [ -L "$OC_REFS_LINK" ]; then
   log_pass "OpenCode references is a symlink"
   if [ -e "$OC_REFS_LINK" ]; then
     log_pass "OpenCode references symlink resolves"
-    for ref in command-prelude compilation hub-resolution indexing ingestion linting projects research-infrastructure wiki-structure; do
+    for ref in command-prelude compilation hub-resolution indexing ingestion librarian linting projects research-infrastructure wiki-structure; do
       if [ -f "$OC_REFS_LINK/${ref}.md" ]; then
         log_pass "OpenCode references/$ref.md reachable via symlink"
       else

--- a/tests/test-plugin-validate.sh
+++ b/tests/test-plugin-validate.sh
@@ -56,7 +56,7 @@ fi
 # Reference files exist
 echo ""
 echo "--- Reference files ---"
-for ref in command-prelude compilation hub-resolution indexing ingestion linting projects research-infrastructure wiki-structure; do
+for ref in command-prelude compilation hub-resolution indexing ingestion librarian linting projects research-infrastructure wiki-structure; do
   reffile="$PLUGIN_DIR/skills/wiki-manager/references/${ref}.md"
   if [ -f "$reffile" ]; then
     log_pass "references/$ref.md exists"
@@ -93,7 +93,7 @@ if [ -L "$REFS_LINK" ]; then
   log_pass "references is a symlink"
   if [ -e "$REFS_LINK" ]; then
     log_pass "references symlink resolves"
-    for ref in command-prelude compilation hub-resolution indexing ingestion linting projects research-infrastructure wiki-structure; do
+    for ref in command-prelude compilation hub-resolution indexing ingestion librarian linting projects research-infrastructure wiki-structure; do
       if [ -f "$REFS_LINK/${ref}.md" ]; then
         log_pass "references/$ref.md reachable via symlink"
       else


### PR DESCRIPTION
## Summary

- Adds `/wiki:librarian` command for content-level wiki maintenance (Phase 1 MVP: staleness + quality scoring)
- Score-then-act architecture: produces reports, never modifies content without confirmation
- Checkpoint/resume for multi-session resilience — API drops don't lose scan progress
- Two-tier escalation: cheap metadata scan first, deep read only for flagged/hot articles
- Integrates with `/wiki:refresh` for stale article triage

## Files

- `commands/librarian.md` — command definition (scan, report, fix subcommands)
- `references/librarian.md` — scoring algorithms, checkpoint/report JSON schemas, boundary table
- `test-plugin-validate.sh` — librarian added to both reference validation loops
- `promptfooconfig.yaml` — 2 new routing evals

## Test plan

- [x] Plugin validation: 49/49 pass
- [x] Structure tests: 90/90 pass
- [x] Codex sync: OK
- [ ] Behavioral evals (promptfoo): routing tests for librarian scan + report
- [ ] Run `scan` on meta-llm-wiki (29 articles) — verify checkpoint survives interruption
- [ ] Verify REPORT.md ranks hot stale articles worse than cold stale articles