### PR TITLE
Add Cowork distribution for non-coder org users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,12 @@ plugins/llm-wiki/               — generated Codex packaging mirror (do NOT han
   .codex-plugin/plugin.json     — Codex manifest (version synced from Claude)
 .agents/plugins/marketplace.json — repo-local Codex marketplace entry
 scripts/sync-codex-plugin.sh    — regenerates plugins/llm-wiki/ from claude-plugin/
+scripts/sync-cowork-plugin.sh   — regenerates cowork/ from claude-plugin/
+cowork/                         — generated Cowork packaging mirror (do NOT hand-edit)
+  skills/wiki-manager/
+    SKILL.md                    — patched copy for non-technical Cowork users
+    references → ../../../claude-plugin/skills/wiki-manager/references  (symlink)
+  .claude-plugin/plugin.json    — Cowork manifest (version synced from Claude)
 AGENTS.md                       — portable single-file protocol for non-Claude agents
 tests/                          — test suite (see above)
 ```

--- a/README.md
+++ b/README.md
@@ -70,31 +70,34 @@ cp AGENTS.md ~/your-project/AGENTS.md
 
 The `AGENTS.md` file contains the complete wiki protocol as a single portable document — works with any LLM agent that can read/write files and search the web.
 
-## Claude-First, Codex-Compatible
+## Claude-First, Multi-Runtime
 
-If Claude Code is the principal user, do not try to make one plugin manifest serve both runtimes. Keep one shared behavior layer and two thin packaging layers:
+Claude Code is the principal user. One shared behavior layer, three thin packaging layers:
 
-- `claude-plugin/` is the primary distribution target and UX surface.
-- `claude-plugin/skills/wiki-manager/` is the behavioral source of truth.
-- `plugins/llm-wiki/` is the Codex packaging target.
-- `.agents/plugins/marketplace.json` makes the Codex plugin installable from this repo.
+- `claude-plugin/` — primary distribution target and UX surface (Claude Code CLI, Desktop, Web, IDE extensions).
+- `claude-plugin/skills/wiki-manager/` — behavioral source of truth. All wiki logic lives here.
+- `plugins/llm-wiki/` — Codex packaging target (generated, do not hand-edit).
+- `cowork/` — Cowork packaging target for non-technical org users (generated, do not hand-edit).
+- `.agents/plugins/marketplace.json` — makes the Codex plugin installable from this repo.
 
-The Codex plugin should stay generated, not hand-maintained. Rebuild it from the Claude source of truth with:
+Each runtime target is generated from the Claude source and stays generated:
 
 ```bash
-./scripts/sync-codex-plugin.sh
+./scripts/sync-codex-plugin.sh   # regenerates plugins/llm-wiki/
+./scripts/sync-cowork-plugin.sh  # regenerates cowork/
 ```
 
-That script:
+Both scripts:
 
-- copies `claude-plugin/skills/wiki-manager/SKILL.md` into the Codex tree and reapplies a small list of Codex-specific wording patches
-- (re)creates `plugins/llm-wiki/skills/wiki-manager/references` as a **symlink** to `claude-plugin/skills/wiki-manager/references` — references are runtime-neutral and shared verbatim, no copy
-- recreates `agents/openai.yaml` for Codex UI metadata
-- syncs the Codex plugin version to match `claude-plugin/.claude-plugin/plugin.json`
+- copy `claude-plugin/skills/wiki-manager/SKILL.md` into the target tree and reapply runtime-specific wording patches
+- (re)create `references/` as a **symlink** to `claude-plugin/skills/wiki-manager/references/` — references are runtime-neutral and shared verbatim, no copy
+- sync the plugin version to match `claude-plugin/.claude-plugin/plugin.json`
 
-Drift between the two trees is caught by `./tests/test-codex-sync.sh`, which runs the sync script and fails (with a self-healing fix instruction) if `plugins/` differs from `HEAD`. This runs alongside the other structural tests, so any LLM following the test-before-done rule catches a missed sync inside its own loop.
+The Codex script also creates `agents/openai.yaml` for Codex UI metadata. The Cowork script rewrites the SKILL.md description for non-technical users (natural language instead of slash commands, folder-picker guidance instead of `~/wiki/`).
 
-Practical rule: design workflows first for Claude commands and behavior, but keep the underlying knowledge model and references runtime-neutral. The Codex wrapper should adapt invocation and metadata, not fork the wiki logic.
+Drift is caught by sync tests (`test-codex-sync.sh`, `test-cowork-sync.sh`), which run the sync scripts and fail with self-healing fix instructions if the generated trees differ from `HEAD`.
+
+Practical rule: design workflows for Claude Code commands and behavior first. Keep references runtime-neutral. Packaging layers adapt invocation style and metadata, never fork wiki logic.
 
 ## Nono Sandbox Permissions
 

--- a/cowork/.claude-plugin/plugin.json
+++ b/cowork/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "wiki",
+  "version": "0.3.6",
+  "description": "Research any topic, build a knowledge base, ask questions, and generate reports. Works with local folders \u2014 mount your wiki folder in Cowork to get started.",
+  "author": {
+    "name": "nvk"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/nvk/llm-wiki",
+  "repository": "https://github.com/nvk/llm-wiki",
+  "keywords": [
+    "wiki",
+    "knowledge-base",
+    "research",
+    "cowork",
+    "non-technical"
+  ]
+}

--- a/cowork/skills/wiki-manager/SKILL.md
+++ b/cowork/skills/wiki-manager/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: wiki-manager
+description: >
+  Knowledge base for non-technical teams. Research topics, build wikis,
+  ask questions, and generate reports — all in natural language. Mount
+  your wiki folder in Cowork to get started. Also activates when user
+  says "wiki", "knowledge base", "research", "what do we know about",
+  or asks a factual question in a session with a mounted wiki folder.
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - WebFetch
+  - WebSearch
+---
+
+# LLM Wiki Manager
+
+You manage an LLM-compiled knowledge base. Source documents are ingested into `raw/`, then incrementally compiled into a wiki of interconnected markdown articles. Claude Cowork is both the compiler and the query engine.
+
+## Cowork Notes
+
+Cowork runs inside a local VM. Only folders mounted via the Cowork folder picker are visible. When resolving the wiki hub path, check mounted folder roots for `_index.md` before falling back to `~/wiki/`. iCloud and cloud-synced paths may not work reliably — use a local folder.
+
+If no wiki is found, guide the user: "Mount a folder in Cowork's folder picker, then tell me what you'd like to research."
+
+## Hub Path
+
+The hub defaults to `~/wiki/`. If `~/wiki/` exists and is initialized (has `_index.md`), it is used directly — no config file needed. This is the simplest, most reliable path.
+
+To use a different location (e.g., iCloud Drive) when `~/wiki/` is not set up, create `~/.config/llm-wiki/config.json`:
+
+```json
+{ "hub_path": "~/Library/Mobile Documents/com~apple~CloudDocs/wiki" }
+```
+
+**Resolution**: At the start of every operation, resolve **HUB** by following the protocol in [references/hub-resolution.md](references/hub-resolution.md) — check `~/wiki/` first, then fall back to config. This handles tilde expansion, paths with spaces, and iCloud directory names correctly. All references to `~/wiki/` below mean HUB.
+
+## Wiki Location
+
+**Topic sub-wikis are the default.** HUB is a hub — content lives in `HUB/topics/<name>/`. Each topic gets isolated indexes, sources, and articles. This keeps queries focused and prevents unrelated topics from polluting each other's search space.
+
+Resolution order:
+
+1. `--local` flag → `.wiki/` in current project
+2. `--wiki <name>` flag → named wiki from `HUB/wikis.json`
+3. Current directory has `.wiki/` → use it
+4. Otherwise → HUB (the hub)
+
+When a command targets the hub and the hub has no content, suggest creating a topic sub-wiki instead.
+
+See [references/wiki-structure.md](references/wiki-structure.md) for the complete directory layout and all file format conventions.
+
+## Core Principles
+
+1. **Indexes are a derived cache.** The `.md` files and their YAML frontmatter are the source of truth. `_index.md` files are a cached view rebuilt on read when stale. Always read indexes first for navigation — but before trusting one, stale-check it (file count vs row count). See [references/indexing.md](references/indexing.md) for the Derived Index Protocol.
+
+2. **Raw is immutable.** Once ingested into `raw/`, sources are never modified. They are a record of what was ingested and when. All synthesis happens in `wiki/`.
+
+3. **Articles are synthesized, not copied.** A wiki article draws from multiple sources, contextualizes, and connects to other concepts. Think textbook, not clipboard.
+
+4. **Dual-linking for Obsidian + Cowork.** Cross-references use both `[[wikilink]]` (for Obsidian graph view) and standard markdown `[text](path)` (for Cowork navigation) on the same line: `[[slug|Name]] ([Name](../category/slug.md))`. Bidirectional when it makes sense.
+
+5. **Frontmatter is structured data.** Every `.md` file has YAML frontmatter with title, summary, tags, dates. This makes the wiki searchable without full-text scans.
+
+6. **Incremental over wholesale.** Compilation processes only new sources by default. Full recompilation is expensive and explicit (`--full`).
+
+7. **Honest gaps.** When answering questions, if the wiki doesn't have the answer, say so. Never hallucinate. Suggest what to ingest to fill the gap.
+
+8. **Multi-wiki awareness.** When querying, answer from the primary wiki first. Then peek at sibling wiki indexes (via `HUB/wikis.json`) for relevant overlap. Flag connections but never merge content across wikis.
+
+9. **Chunk large writes.** Never create files longer than ~200 lines in a single Write call — the API stream idles during large generations, causing timeout errors. Write the skeleton (frontmatter + headers + first section) first, then use sequential Edit calls to append remaining sections. For plans, articles, and raw notes: write one section per tool call.
+
+## Ambient Behavior
+
+When this skill activates outside of an explicit wiki command:
+
+1. Resolve the hub path (see Hub Path section above), then check if `HUB/_index.md` or `.wiki/_index.md` exists
+2. Read the master `_index.md` to assess if the wiki might cover the user's question
+3. If relevant content exists → read the relevant articles and answer with citations
+4. If no relevant content → answer normally, optionally suggest: "This could be added to your wiki — just paste the URL or text."
+5. When peeking at sibling wikis, only read their `_index.md` — do not read full articles unless the user asks
+
+## Workflows
+
+### Ingestion
+See [references/ingestion.md](references/ingestion.md).
+Flow: Source (URL/file/text/tweet/inbox) → fetch/read → extract metadata → write to `raw/{type}/` → update indexes → suggest compile if many uncompiled.
+
+### Compilation
+See [references/compilation.md](references/compilation.md).
+Flow: Survey uncompiled sources → plan articles → classify (concept/topic/reference) → write/update articles with cross-references → update all indexes.
+
+### Query
+Flow: Read `_index.md` → identify relevant articles by summary/tag → read articles → follow See Also links → Grep for additional matches → synthesize answer with citations → note gaps → peek sibling wikis. Supports `--resume` to reload context after a session break — reads session files, recent log entries, wiki stats, and last-updated articles to produce a "where you left off" briefing.
+
+### Linting
+See [references/linting.md](references/linting.md).
+Flow: Check structure → indexes → links → content → coverage → report → optionally auto-fix.
+
+### Search
+Flow: Scan indexes for summary/tag matches → Grep full-text → rank results → present.
+
+### Output
+Flow: Gather relevant articles → generate artifact (summary/report/slides/etc) → save to `output/` → update indexes.
+
+### Lessons Learned (ll)
+Flow: Scan session for error→fix patterns, corrections, discoveries → extract structured lessons → write to `raw/notes/` with `type: lessons-learned` → optionally update relevant articles → optionally suggest CLAUDE.md rules.
+
+## Links: File Paths and URLs
+
+Terminal links break when they wrap to a second line. Rules for all wiki operations:
+
+1. **Full absolute paths** — expand `~`, HUB, and all relative segments. Relative paths are not clickable.
+2. **Markdown link syntax for URLs** — use `[short text](url)`, never bare long URLs that wrap and break.
+3. **No indentation before links** — indentation eats terminal width. Put links flush-left on their own line.
+4. **One link per line** — don't embed a long path mid-sentence. Break it out:
+   ```
+   Saved to:
+   /Users/name/wiki/topics/my-topic/output/report-2026-04-08.md
+   ```
+
+See `references/research-infrastructure.md` § Agent Prompt Templates for examples. Applies to ingest, compile, research, output, assess.
+
+## Activity Log
+
+Every wiki operation appends to `log.md` in the wiki root. Format: `## [YYYY-MM-DD] operation | Description`. See [references/wiki-structure.md](references/wiki-structure.md) for full format. Never edit or delete existing log entries — append only.
+
+## Confidence Scoring
+
+Wiki articles include a `confidence` field in frontmatter: `high`, `medium`, or `low`.
+
+- **high**: Multiple peer-reviewed sources agree, well-established knowledge
+- **medium**: Single source, or sources partially agree, or recent findings not yet replicated
+- **low**: Anecdotal, single non-peer-reviewed source, or sources disagree
+
+When answering queries, note confidence levels. When linting, flag `low` confidence articles for review.
+
+## Compilation Nudge
+
+Track uncompiled sources by comparing `raw/_index.md` ingestion dates against the last compile date in `_index.md`. If 5+ uncompiled sources exist after an ingestion, suggest: "You have N uncompiled sources. Want me to compile them into articles?"
+
+## Structural Guardian
+
+Automatically run a quick structural check when any of these triggers occur:
+
+### Triggers
+- **After any write operation** (ingest, compile, research, output) — verify what was just written
+- **When the skill activates** and the wiki hasn't been linted in 7+ days (check "Last lint" in `_index.md`)
+- **When content is found in the wrong place** — articles in the global hub instead of a topic sub-wiki
+- **When a user mentions wiki problems** — "wiki is broken", "empty", "missing", "wrong"
+- **When no wiki exists** (first-run) — switch to guided onboarding flow instead of showing a command list. Walk the user through topic selection → init → first action suggestion. See `commands/wiki.md` § "If no wiki exists".
+
+### Quick Structure Check (lightweight, runs inline — not a full lint)
+
+1. **Hub integrity**: The hub (HUB) should ONLY contain `wikis.json`, `_index.md`, `log.md`, and `topics/`. If `raw/`, `wiki/`, `output/`, `inbox/`, or `config.md` exist at the hub level → **warn, do not delete**. These may hold user data from an older wiki layout. Suggest running a health check to fix the issue.
+
+2. **Index freshness**: For the active topic wiki, compare actual file count in `wiki/concepts/`, `wiki/topics/`, `wiki/references/` against the rows in their `_index.md`. If mismatched → auto-fix by adding missing entries or removing dead ones.
+
+3. **Orphan detection**: Check if any `.md` files exist in wiki directories but are not listed in any `_index.md`. If found → add them to the index.
+
+4. **Missing directories**: Verify all expected subdirectories exist in the topic wiki (`raw/articles/`, `raw/papers/`, etc.). If missing → create them with empty `_index.md`.
+
+5. **wikis.json sync**: Check that all topic sub-wikis under `HUB/topics/` are registered in `wikis.json`. If a directory exists but isn't registered → add it. If registered but directory is missing → remove the entry.
+
+6. **Log existence**: Verify `log.md` exists in the active wiki and at the hub. If missing → create it.
+
+### Behavior
+
+- **Silent when clean** — don't report anything if everything checks out
+- **Auto-fix trivial issues** — missing indexes, unregistered wikis, orphan files. Just fix and note in log.
+- **Warn on structural problems** — content in wrong place, missing directories, stale indexes. Tell the user what's wrong and offer to fix it.
+- **Never block the user's request** — run the check, fix what you can, report issues, then continue with what the user actually asked for.
+
+## Concurrency
+
+Multiple Cowork sessions can safely read and write to the same wiki simultaneously. No locks are needed.
+
+- **Indexes** are derived from the actual files on disk. If two sessions write articles at the same time, the next read rebuilds the index from whatever files exist. Both rebuilds converge to the same correct result.
+- **log.md** is append-only with small atomic writes. Concurrent appends are safe.
+- **Article/source files** are written independently. Two sessions creating different files never conflict. Two sessions editing the same file is unlikely and handled by last-write-wins (acceptable for a wiki — the content is always rebuildable from raw sources).
+
+See [references/indexing.md](references/indexing.md) for the Derived Index Protocol.
+
+## Session Management
+
+### Research Session Registry
+
+When a `--min-time` research or thesis session is active, the wiki root contains a `.research-session.json` or `.thesis-session.json` file.
+
+**Structural Guardian behavior**:
+- If a session file exists with `status: "in_progress"` and `start_time` > 7 days ago → warn: "Stale research session found. Want to resume it or start fresh?"
+- Session files are ephemeral — never included in structural health checks or index counts
+- Session files should NOT be committed to git

--- a/cowork/skills/wiki-manager/references
+++ b/cowork/skills/wiki-manager/references
@@ -1,0 +1,1 @@
+../../../claude-plugin/skills/wiki-manager/references

--- a/scripts/sync-cowork-plugin.sh
+++ b/scripts/sync-cowork-plugin.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_SKILL="$ROOT/claude-plugin/skills/wiki-manager"
+TARGET_PLUGIN="$ROOT/cowork"
+TARGET_SKILL="$TARGET_PLUGIN/skills/wiki-manager"
+CLAUDE_MANIFEST="$ROOT/claude-plugin/.claude-plugin/plugin.json"
+COWORK_MANIFEST="$TARGET_PLUGIN/.claude-plugin/plugin.json"
+
+if [ ! -d "$SOURCE_SKILL" ]; then
+  echo "Missing source skill: $SOURCE_SKILL" >&2
+  exit 1
+fi
+
+if [ ! -f "$CLAUDE_MANIFEST" ]; then
+  echo "Missing Claude manifest: $CLAUDE_MANIFEST" >&2
+  exit 1
+fi
+
+if [ ! -f "$COWORK_MANIFEST" ]; then
+  echo "Missing Cowork manifest: $COWORK_MANIFEST" >&2
+  exit 1
+fi
+
+mkdir -p "$TARGET_PLUGIN/skills"
+# references/ is a symlink into the Claude source — exclude from rsync so it's
+# preserved, and recreate it idempotently below.
+rsync -a --delete \
+  --exclude='references/' \
+  --exclude='references' \
+  "$SOURCE_SKILL/" "$TARGET_SKILL/"
+
+# Recreate the references symlink (idempotent).
+rm -rf "$TARGET_SKILL/references"
+ln -s "../../../claude-plugin/skills/wiki-manager/references" "$TARGET_SKILL/references"
+
+python3 - "$TARGET_SKILL" "$CLAUDE_MANIFEST" "$COWORK_MANIFEST" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+target_skill = Path(sys.argv[1])
+claude_manifest = Path(sys.argv[2])
+cowork_manifest = Path(sys.argv[3])
+
+skill_path = target_skill / "SKILL.md"
+text = skill_path.read_text()
+
+# Replace frontmatter with Cowork-specific version
+frontmatter = """---
+name: wiki-manager
+description: >
+  Knowledge base for non-technical teams. Research topics, build wikis,
+  ask questions, and generate reports — all in natural language. Mount
+  your wiki folder in Cowork to get started. Also activates when user
+  says "wiki", "knowledge base", "research", "what do we know about",
+  or asks a factual question in a session with a mounted wiki folder.
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - WebFetch
+  - WebSearch
+---
+"""
+
+start = text.find("---\n")
+end = text.find("\n---\n", start + 4)
+if start != 0 or end == -1:
+    raise SystemExit(f"Unexpected frontmatter in {skill_path}")
+text = frontmatter + text[end + 5 :]
+
+replacements = [
+    # Core identity
+    (
+        "You manage an LLM-compiled knowledge base. Source documents are ingested into `raw/`, then incrementally compiled into a wiki of interconnected markdown articles. Claude Code is both the compiler and the query engine — no Obsidian, no external tools.\n",
+        "You manage an LLM-compiled knowledge base. Source documents are ingested into `raw/`, then incrementally compiled into a wiki of interconnected markdown articles. Claude Cowork is both the compiler and the query engine.\n\n## Cowork Notes\n\nCowork runs inside a local VM. Only folders mounted via the Cowork folder picker are visible. When resolving the wiki hub path, check mounted folder roots for `_index.md` before falling back to `~/wiki/`. iCloud and cloud-synced paths may not work reliably — use a local folder.\n\nIf no wiki is found, guide the user: \"Mount a folder in Cowork's folder picker, then tell me what you'd like to research.\"\n",
+    ),
+    # Dual-linking
+    (
+        "**Dual-linking for Obsidian + Claude.** Cross-references use both `[[wikilink]]` (for Obsidian graph view) and standard markdown `[text](path)` (for Claude navigation) on the same line: `[[slug|Name]] ([Name](../category/slug.md))`. Bidirectional when it makes sense.",
+        "**Dual-linking for Obsidian + Cowork.** Cross-references use both `[[wikilink]]` (for Obsidian graph view) and standard markdown `[text](path)` (for Cowork navigation) on the same line: `[[slug|Name]] ([Name](../category/slug.md))`. Bidirectional when it makes sense.",
+    ),
+    # Ambient behavior
+    (
+        "When this skill activates outside of an explicit `/wiki:*` command:",
+        "When this skill activates outside of an explicit wiki command:",
+    ),
+    # Suggestions
+    (
+        '4. If no relevant content → answer normally, optionally suggest: "This could be added to your wiki with `/wiki:ingest`"',
+        '4. If no relevant content → answer normally, optionally suggest: "This could be added to your wiki — just paste the URL or text."',
+    ),
+    # Compilation nudge
+    (
+        'Track uncompiled sources by comparing `raw/_index.md` ingestion dates against the last compile date in `_index.md`. If 5+ uncompiled sources exist after an ingestion, suggest: "You have N uncompiled sources. Run `/wiki:compile` to integrate them."',
+        'Track uncompiled sources by comparing `raw/_index.md` ingestion dates against the last compile date in `_index.md`. If 5+ uncompiled sources exist after an ingestion, suggest: "You have N uncompiled sources. Want me to compile them into articles?"',
+    ),
+    # Lint suggestions
+    (
+        'Suggest `/wiki:lint --fix`, which will move contents to the appropriate topic wiki or quarantine to `inbox/.unknown/` per C11/C12 in `references/linting.md`.',
+        'Suggest running a health check to fix the issue.',
+    ),
+    (
+        "Tell the user what's wrong and suggest `/wiki:lint --fix`.",
+        "Tell the user what's wrong and offer to fix it.",
+    ),
+    # Concurrency
+    (
+        "Multiple Claude Code sessions can safely read and write to the same wiki simultaneously. No locks are needed.",
+        "Multiple Cowork sessions can safely read and write to the same wiki simultaneously. No locks are needed.",
+    ),
+    # Session cleanup
+    (
+        'warn: "Stale research session found. Clean up with `/wiki:research` or delete manually."',
+        'warn: "Stale research session found. Want to resume it or start fresh?"',
+    ),
+]
+
+for old, new in replacements:
+    if old not in text:
+        raise SystemExit(f"Expected text not found in {skill_path}: {old[:80]!r}")
+    text = text.replace(old, new)
+
+skill_path.write_text(text)
+
+# Sync version from Claude manifest
+claude = json.loads(claude_manifest.read_text())
+cowork = json.loads(cowork_manifest.read_text())
+cowork["version"] = claude["version"]
+cowork_manifest.write_text(json.dumps(cowork, indent=2) + "\n")
+PY
+
+echo "Synced Cowork plugin skill from Claude source."
+echo "Source: $SOURCE_SKILL"
+echo "Target: $TARGET_SKILL"

--- a/tests/test-cowork-sync.sh
+++ b/tests/test-cowork-sync.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Verify the Cowork plugin mirror matches the Claude source.
+# Self-healing: the sync script has already regenerated cowork/ if this fails.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Re-sync from Claude source
+"$PROJECT_ROOT/scripts/sync-cowork-plugin.sh" >/dev/null
+
+# Check for uncommitted changes
+if ! git diff --quiet HEAD -- cowork/; then
+  cat >&2 <<'MSG'
+FAIL: Cowork plugin mirror is out of sync with claude-plugin/skills/wiki-manager/.
+
+The sync script has already regenerated cowork/. To fix:
+  1. git diff -- cowork/           # review the regenerated changes
+  2. git add cowork/               # stage them alongside the Claude-side edit
+  3. git commit                    # fold into the same commit
+  4. ./tests/test-cowork-sync.sh   # re-run to confirm clean
+
+This guards against the Cowork copy drifting from the Claude source.
+MSG
+  exit 1
+fi
+
+echo "OK: Cowork plugin mirror is in sync."


### PR DESCRIPTION
## Summary

- Adds a `cowork/` distribution for Claude Cowork, targeting non-technical org users
- Same pattern as the existing Codex mirror: generated from `claude-plugin/` via a sync script
- **Zero changes to the Claude Code plugin** — separate distribution, separate SKILL.md

## What's adapted for Cowork

- SKILL.md description rewritten for non-coders: "Research, ask questions, generate reports"
- Slash command references replaced with natural language ("Want me to compile?" not "Run `/wiki:compile`")
- Hub resolution notes for VirtioFS-mounted folders (Cowork runs in a Linux VM)
- Warning about iCloud path issues in Cowork VM (open bugs #40783, #32637)
- Plugin manifest description is user-friendly, not developer-friendly

## Files

- `cowork/.claude-plugin/plugin.json` — Cowork plugin manifest
- `cowork/skills/wiki-manager/SKILL.md` — generated, Cowork-adapted
- `cowork/skills/wiki-manager/references/` — symlink to Claude source (shared)
- `scripts/sync-cowork-plugin.sh` — generates cowork/ from Claude source
- `tests/test-cowork-sync.sh` — verifies mirror matches source

## Test plan

- [x] Plugin validation: 47/47 pass (existing tests unaffected)
- [x] Structure tests: 92/92 pass
- [x] Codex sync: OK (unaffected)
- [x] Cowork sync: generates correctly, references symlink resolves
- [x] SKILL.md: 7 Cowork mentions, 0 "Claude Code" mentions
- [ ] Install in Cowork and test full flow (research → query → output)