### PR TITLE
OpenCode: add first-class sync script, tests, and docs

### DIFF
--- a/.claude/release-checklist.md
+++ b/.claude/release-checklist.md
@@ -10,12 +10,14 @@ Standard process for testing and shipping a new version of the llm-wiki plugin.
 
 ## Test
 
-2. **Run structural + Codex packaging checks**:
+2. **Run structural + packaging checks**:
    ```bash
    ./scripts/sync-codex-plugin.sh
+   ./scripts/sync-opencode-plugin.sh
    ./tests/test-plugin-validate.sh
    ./tests/test-structure.sh
    ./tests/test-codex-sync.sh
+   ./tests/test-opencode-sync.sh
    ./tests/test-codex-runtime.sh
    ```
 
@@ -27,7 +29,11 @@ Standard process for testing and shipping a new version of the llm-wiki plugin.
    - If verify reports `PENDING`, open `/plugins`, enable `LLM Wiki`, restart Codex if needed, and rerun the verify command
    - If project scope fails outright, confirm the project is trusted before assuming the plugin is broken
 
-5. **Test the changed feature** — whatever was added/fixed in this release:
+5. **Verify OpenCode skill loads** — start OpenCode with the instruction file and ask "what wiki commands do you know?"
+   - Load via: `"instructions": ["plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md"]` in `opencode.json`
+   - Verify web search works with `OPENCODE_ENABLE_EXA=1`
+
+6. **Test the changed feature** — whatever was added/fixed in this release:
    - Invoke the relevant `/wiki:*` subcommand
    - Confirm expected behavior, no errors
 
@@ -80,7 +86,8 @@ Standard process for testing and shipping a new version of the llm-wiki plugin.
 11. **Verify install**:
    - Claude Code: start a fresh session and run `/wiki status`
    - Codex: start a fresh session and run `@wiki test` or `./scripts/verify-codex-plugin.sh --scope project`
-   - If the verify script reports `PENDING`, finish the first-time enable in `/plugins` and rerun it
+   - OpenCode: start a session with the SKILL.md loaded and ask "wiki status"
+   - If the Codex verify script reports `PENDING`, finish the first-time enable in `/plugins` and rerun it
 
 ## Post-ship: README
 
@@ -103,6 +110,7 @@ Standard process for testing and shipping a new version of the llm-wiki plugin.
 
 - Claude marketplace plugin name: `wiki@llm-wiki`
 - Codex plugin invocation name: `@wiki`
+- OpenCode: loaded via `"instructions"` in `opencode.json` or copied to `~/.config/opencode/AGENTS.md`
 - Claude plugin cache path: `~/.claude/plugins/cache/llm-wiki/wiki/<version>/`
 - Claude marketplace repo: `~/.claude/plugins/marketplaces/llm-wiki/`
 - Codex project config path: `<project>/.codex/config.toml` (local, gitignored in this repo)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Run tests before declaring any change to plugin code done.
 ./tests/test-plugin-validate.sh   # plugin manifest + command frontmatter
 ./tests/test-structure.sh          # wiki fixture validation (84 assertions)
 ./tests/test-codex-sync.sh         # Codex plugin mirror matches Claude source
+./tests/test-opencode-sync.sh     # OpenCode plugin mirror matches Claude source
 ```
 
 ### Codex runtime smoke test (run when touching Codex packaging/docs)
@@ -18,9 +19,9 @@ Run tests before declaring any change to plugin code done.
 ./tests/test-codex-runtime.sh      # bootstrap + headless prompt-input check for @wiki
 ```
 
-`test-codex-sync.sh` is self-healing: if it fails, the sync script has already
-regenerated `plugins/llm-wiki/` — stage and commit the result, then re-run.
-Read its FAIL message; it tells you exactly what to do.
+`test-codex-sync.sh` and `test-opencode-sync.sh` are self-healing: if they fail,
+the sync script has already regenerated the target directory — stage and commit
+the result, then re-run. Read the FAIL message; it tells you exactly what to do.
 
 If you changed the golden wiki fixture, regenerate defect fixtures first:
 
@@ -42,10 +43,10 @@ Requires `ANTHROPIC_API_KEY`. Costs ~$2-5 per run.
 - **Changed frontmatter schema** (new required field, renamed enum): update the golden wiki fixture files to match, update `test-structure.sh` field/enum lists, regenerate defect fixtures.
 - **Added a new command**: add a frontmatter check to `test-plugin-validate.sh` if it's not picked up by the wildcard. Add a behavioral eval in `promptfooconfig.yaml` for routing.
 - **Changed the fuzzy router**: add or update test cases in `promptfooconfig.yaml` covering the new routing behavior plus negative controls.
-- **Added a new reference file**: `test-plugin-validate.sh` has two `for ref in ...` loops (one Claude-side existence, one Codex-side symlink reachability) — add the new filename to both.
+- **Added a new reference file**: `test-plugin-validate.sh` has three `for ref in ...` loops (Claude-side existence, Codex-side symlink reachability, OpenCode-side symlink reachability) — add the new filename to all three.
 - **Changed directory structure** (new `raw/` or `wiki/` subdirectory): update `test-structure.sh` C1 directory list and C11 placement checks. Update the golden wiki fixture if needed.
-- **Edited `claude-plugin/skills/wiki-manager/`**: `test-codex-sync.sh` will fail until you re-run `./scripts/sync-codex-plugin.sh` and commit `plugins/llm-wiki/`. Never edit `plugins/llm-wiki/skills/wiki-manager/` by hand — it is generated, and `references/` is a symlink into the Claude source.
-- **Added a Codex-specific text rewrite to the sync script**: also update `scripts/sync-codex-plugin.sh`'s SKILL.md replacement list. References are runtime-neutral and shared verbatim — do not add per-file replacements there.
+- **Edited `claude-plugin/skills/wiki-manager/`**: both `test-codex-sync.sh` and `test-opencode-sync.sh` will fail until you re-run both sync scripts and commit `plugins/`. Never edit `plugins/llm-wiki/` or `plugins/llm-wiki-opencode/` by hand — they are generated, and `references/` is a symlink into the Claude source.
+- **Added a runtime-specific text rewrite to a sync script**: update the corresponding sync script's SKILL.md replacement list. References are runtime-neutral and shared verbatim — do not add per-file replacements there.
 - **Changed Codex install docs or bootstrap flow**: run `./tests/test-codex-runtime.sh` to verify the bootstrap flow either resolves `@wiki` from a clean scratch Codex home or cleanly reports that `/plugins` still needs to be opened once for first-time materialization.
 
 ### Test file locations
@@ -72,12 +73,18 @@ plugins/llm-wiki/               — generated Codex packaging mirror (do NOT han
     references → ../../../../claude-plugin/skills/wiki-manager/references  (symlink)
     agents/openai.yaml          — Codex UI metadata (generated)
   .codex-plugin/plugin.json     — Codex manifest (version synced from Claude)
+plugins/llm-wiki-opencode/      — generated OpenCode packaging mirror (do NOT hand-edit)
+  skills/wiki-manager/
+    SKILL.md                    — patched copy of claude-plugin SKILL.md
+    references → ../../../../claude-plugin/skills/wiki-manager/references  (symlink)
+  README.md                     — OpenCode install instructions
 .agents/plugins/marketplace.json — repo-local Codex marketplace entry
 scripts/sync-codex-plugin.sh    — regenerates plugins/llm-wiki/ from claude-plugin/
+scripts/sync-opencode-plugin.sh — regenerates plugins/llm-wiki-opencode/ from claude-plugin/
 AGENTS.md                       — portable single-file protocol for non-Claude agents
 tests/                          — test suite (see above)
 ```
 
 ## Release Process
 
-See `.claude/release-checklist.md` for the full ship process. Run all three structural tests before bumping version.
+See `.claude/release-checklist.md` for the full ship process. Run all structural tests before bumping version.

--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@
 
 [github.com/nvk/llm-wiki](https://github.com/nvk/llm-wiki)
 
-LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, thesis-driven investigation, source ingestion, wiki compilation, querying, and artifact generation. Ships as a Claude Code plugin, an OpenAI Codex plugin, or a portable AGENTS.md for any other LLM agent. Obsidian-compatible.
+LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, thesis-driven investigation, source ingestion, wiki compilation, querying, and artifact generation. Ships as a Claude Code plugin, an OpenAI Codex plugin, an OpenCode instruction file, or a portable AGENTS.md for any other LLM agent. Obsidian-compatible.
 
 ---
 
-[Install](#install) · [Quick Start](#quick-start) · [Commands](#commands) · [How It Works](#how-it-works) · [Research Modes](#research-modes) · [Thesis Research](#thesis-driven-research) · [Query Depths](#query-depths) · [Linking](#linking-works-everywhere) · [Obsidian](#obsidian-integration) · [Architecture](#claude-first-codex-compatible) · [Nono Sandbox](#nono-sandbox-permissions) · [Upgrade](#upgrade) · [Changelog](#changelog) · [Credits](#credits)
+[Install](#install) · [Quick Start](#quick-start) · [Commands](#commands) · [How It Works](#how-it-works) · [Research Modes](#research-modes) · [Thesis Research](#thesis-driven-research) · [Query Depths](#query-depths) · [Linking](#linking-works-everywhere) · [Obsidian](#obsidian-integration) · [Architecture](#claude-first-multi-runtime) · [Nono Sandbox](#nono-sandbox-permissions) · [Upgrade](#upgrade) · [Changelog](#changelog) · [Credits](#credits)
 
 ---
 
 ## Changelog
+
+**v0.3.7** — **OpenCode First-Class Support.** Added OpenCode as a third distribution target alongside Claude Code and Codex. New `scripts/sync-opencode-plugin.sh` generates `plugins/llm-wiki-opencode/` from the Claude source with OpenCode-specific wording patches. `tests/test-opencode-sync.sh` guards against drift. `test-plugin-validate.sh` extended with 15 OpenCode mirror checks (SKILL.md, references symlink, no leaked Claude Code references, README). Install via `opencode.json`'s `"instructions"` key or copy to `~/.config/opencode/AGENTS.md`. Architecture section renamed to "Claude-First, Multi-Runtime".
 
 **v0.3.6** — **Codex Bootstrap & Runtime Guidance.** Added a first-class Codex bootstrap helper that registers the local marketplace and writes managed `@wiki` enable config, plus a headless verify script and smoke test for the generated Codex plugin. The new verifier distinguishes real misconfiguration from Codex's current first-install `/plugins` materialization behavior and reports a concrete `PENDING` next step instead of failing opaquely. README, repo workflow docs, and release checklist now document the Codex-local install path and troubleshooting.
 
@@ -28,8 +30,6 @@ LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, th
 **v0.2.1** — **Codex packaging.** Repo-local Codex plugin (`plugins/llm-wiki/`) and marketplace entry alongside the Claude plugin — same wiki-manager skill, two thin packaging layers. References are a single source of truth: the Codex tree symlinks into `claude-plugin/skills/wiki-manager/references/`. `./scripts/sync-codex-plugin.sh` regenerates the mirror; `tests/test-codex-sync.sh` catches drift inside the agent's own test loop with self-healing fix instructions. `tests/test-plugin-validate.sh` extended with 19 checks for symlink integrity, Codex manifests, and `agents/openai.yaml`.
 
 **v0.2.0t** — **Tests.** Three-layer test suite: structural validation (84 assertions, no LLM, runs in seconds), behavioral evals via Promptfoo with Claude Agent SDK, and GitHub Actions CI workflow. Golden wiki fixture with 11 defect variants (one per lint rule) for negative testing. `CLAUDE.md` dev guide added.
-
-**v0.2.0** — **Nice Cleanup.** Lint is the migration — `lint --fix` heals misplaced files and legacy layouts automatically. No migrate command needed. Projects simplified — `_project.md` manifest → plain `WHY.md`. Focus sessions removed. Thesis folded into research — `/wiki:research --mode thesis "<claim>"` replaces `/wiki:thesis`. Same logic, no duplication. Old command still works as shim. Hub resolution hardened — `resolved_path` cached in config, symlink recommended for iCloud. Tilde expansion runs at most once. −8% plugin size (3,933 → 3,610 lines) with zero rationale loss.
 
 ## Install
 
@@ -68,7 +68,23 @@ Troubleshooting:
 - If you run Codex under a sandbox wrapper like `nono`, Codex needs its own profile allowances for `~/.codex`, any symlink targets, and the wiki data paths.
 - The Codex plugin lives at `plugins/llm-wiki/` and is a thin wrapper around the same wiki-manager skill.
 
-**OpenAI Codex / Any LLM Agent** (idea file):
+**OpenCode** (instruction file):
+
+Option A — load via `opencode.json`:
+```json
+{
+  "instructions": ["path/to/llm-wiki/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md"]
+}
+```
+
+Option B — copy to global config:
+```bash
+cp plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md ~/.config/opencode/AGENTS.md
+```
+
+Web search requires `export OPENCODE_ENABLE_EXA=1`. The OpenCode SKILL.md provides activation triggers, fuzzy routing, and ambient behavior. OpenCode also reads the repo's `AGENTS.md` automatically for the portable protocol.
+
+**Any LLM Agent** (idea file):
 ```bash
 # Copy AGENTS.md into your agent's context or project root
 cp AGENTS.md ~/your-project/AGENTS.md
@@ -76,31 +92,32 @@ cp AGENTS.md ~/your-project/AGENTS.md
 
 The `AGENTS.md` file contains the complete wiki protocol as a single portable document — works with any LLM agent that can read/write files and search the web.
 
-## Claude-First, Codex-Compatible
+## Claude-First, Multi-Runtime
 
-If Claude Code is the principal user, do not try to make one plugin manifest serve both runtimes. Keep one shared behavior layer and two thin packaging layers:
+Claude Code is the principal user. Keep one shared behavior layer and three thin packaging layers:
 
 - `claude-plugin/` is the primary distribution target and UX surface.
 - `claude-plugin/skills/wiki-manager/` is the behavioral source of truth.
 - `plugins/llm-wiki/` is the Codex packaging target.
+- `plugins/llm-wiki-opencode/` is the OpenCode packaging target.
 - `.agents/plugins/marketplace.json` makes the Codex plugin installable from this repo.
 
-The Codex plugin should stay generated, not hand-maintained. Rebuild it from the Claude source of truth with:
+Both runtime mirrors are generated, not hand-maintained. Rebuild from the Claude source of truth:
 
 ```bash
-./scripts/sync-codex-plugin.sh
+./scripts/sync-codex-plugin.sh      # regenerates plugins/llm-wiki/
+./scripts/sync-opencode-plugin.sh   # regenerates plugins/llm-wiki-opencode/
 ```
 
-That script:
+Each sync script:
 
-- copies `claude-plugin/skills/wiki-manager/SKILL.md` into the Codex tree and reapplies a small list of Codex-specific wording patches
-- (re)creates `plugins/llm-wiki/skills/wiki-manager/references` as a **symlink** to `claude-plugin/skills/wiki-manager/references` — references are runtime-neutral and shared verbatim, no copy
-- recreates `agents/openai.yaml` for Codex UI metadata
-- syncs the Codex plugin version to match `claude-plugin/.claude-plugin/plugin.json`
+- copies `claude-plugin/skills/wiki-manager/SKILL.md` into the target tree and reapplies a small list of runtime-specific wording patches
+- (re)creates `references` as a **symlink** to `claude-plugin/skills/wiki-manager/references` — references are runtime-neutral and shared verbatim, no copy
+- (Codex only) recreates `agents/openai.yaml` for Codex UI metadata and syncs the plugin version
 
-Drift between the two trees is caught by `./tests/test-codex-sync.sh`, which runs the sync script and fails (with a self-healing fix instruction) if `plugins/` differs from `HEAD`. This runs alongside the other structural tests, so any LLM following the test-before-done rule catches a missed sync inside its own loop.
+Drift is caught by `./tests/test-codex-sync.sh` and `./tests/test-opencode-sync.sh`, which run the sync scripts and fail (with self-healing fix instructions) if the generated directories differ from `HEAD`.
 
-Practical rule: design workflows first for Claude commands and behavior, but keep the underlying knowledge model and references runtime-neutral. The Codex wrapper should adapt invocation and metadata, not fork the wiki logic.
+Practical rule: design workflows first for Claude commands and behavior, but keep the underlying knowledge model and references runtime-neutral. Runtime wrappers adapt invocation and metadata, not wiki logic.
 
 ## Nono Sandbox Permissions
 
@@ -166,6 +183,14 @@ cd ~/llm-wiki
 ```
 
 The Codex plugin is generated from the same Claude source — `plugins/llm-wiki/`'s `references/` is a symlink into `claude-plugin/skills/wiki-manager/references/`, so updates land identically across both runtimes. If `--verify` reports `PENDING`, finish the first-time enable in `/plugins` and rerun the verify command.
+
+**OpenCode** — pull the repo and re-copy:
+```bash
+git -C ~/llm-wiki pull
+cp ~/llm-wiki/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md ~/.config/opencode/AGENTS.md
+```
+
+Or if using `opencode.json` instructions, just pull — the path already points at the repo.
 
 **AGENTS.md** — just pull the latest and replace:
 ```bash
@@ -299,7 +324,7 @@ The hub is just a registry — no content directories, no `.obsidian/`. All cont
 - **Confidence scoring** — articles rated high/medium/low based on source quality and corroboration.
 - **Structural guardian** — auto-checks wiki integrity after operations, fixes trivial issues silently.
 - **Activity log** — `log.md` tracks every operation, append-only, grep-friendly.
-- **Zero dependencies** — runs entirely on Claude Code built-in tools.
+- **Zero dependencies** — runs entirely on built-in tools (Claude Code, OpenCode, or Codex).
 
 ## Research Modes
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wiki",
   "description": "LLM-compiled knowledge base. Natural language routing, session resume, concurrent-safe derived indexes, topic-isolated wikis, parallel multi-agent research, thesis-driven investigation, repo assessment, Obsidian dual-linking, retardmax mode, and --min-time sustained research.",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "author": {
     "name": "nvk"
   },

--- a/plugins/llm-wiki-opencode/README.md
+++ b/plugins/llm-wiki-opencode/README.md
@@ -1,0 +1,50 @@
+# llm-wiki for OpenCode
+
+Load this skill as an instruction file in OpenCode.
+
+## Quick Install
+
+Add to your project's `opencode.json`:
+
+```json
+{
+  "instructions": ["path/to/llm-wiki/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md"]
+}
+```
+
+Or copy to your global config:
+
+```bash
+cp plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md ~/.config/opencode/AGENTS.md
+```
+
+## Web Search
+
+Research operations require web search. Enable it:
+
+```bash
+export OPENCODE_ENABLE_EXA=1
+```
+
+## Usage
+
+Talk to OpenCode naturally:
+
+- "Initialize a wiki about quantum computing"
+- "Research Kubernetes deployment patterns"
+- "Ingest https://example.com/article into my wiki"
+- "Compile the wiki"
+- "What does my wiki know about X?"
+- "Lint the wiki and fix issues"
+
+## Alternative: AGENTS.md
+
+The repo root also contains `AGENTS.md`, which OpenCode reads automatically. It provides the portable wiki protocol. This SKILL.md provides a richer experience with activation triggers, fuzzy routing, and ambient behavior.
+
+## Alternative: opencode-agent-skills
+
+The [opencode-agent-skills](https://github.com/joshuadavidthomas/opencode-agent-skills) plugin loads Claude Code skills directly in OpenCode. Add `"opencode-agent-skills"` to the `"plugin"` array in `opencode.json` and the Claude plugin at `claude-plugin/` works without modification.
+
+## This directory is generated
+
+Do not edit files here by hand. Run `scripts/sync-opencode-plugin.sh` to regenerate from the Claude source. The `references/` directory is a symlink into `claude-plugin/skills/wiki-manager/references/`.

--- a/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
+++ b/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: wiki-manager
+description: >
+  LLM-compiled knowledge base manager for OpenCode. Use it to initialize, ingest,
+  compile, query, lint, research, and generate outputs from topic-scoped wikis.
+  Activates when the user mentions wiki workflows, knowledge-base management,
+  ingestion, compilation, querying, linting, research, or uses wiki-related
+  shorthand in a repo with .wiki/, ~/wiki/, or a configured hub path.
+---
+
+# LLM Wiki Manager
+
+You manage an LLM-compiled knowledge base. Source documents are ingested into `raw/`, then incrementally compiled into a wiki of interconnected markdown articles. OpenCode is both the compiler and the query engine.
+
+## OpenCode Integration Notes
+
+This skill is loaded as an instruction file. OpenCode does not have Claude-style `/wiki:*` slash commands or Codex-style `@wiki` invocations. Treat any `/wiki:*` references in this skill and its references as shorthand for the equivalent natural-language request. For example, `/wiki:compile` means the user is asking you to compile the wiki.
+
+OpenCode's built-in tools (`read`, `write`, `edit`, `glob`, `grep`, `bash`, `webfetch`, `websearch`) map directly to the tools this skill requires. Web search requires `OPENCODE_ENABLE_EXA=1` in the environment.
+
+## Hub Path
+
+The hub defaults to `~/wiki/`. If `~/wiki/` exists and is initialized (has `_index.md`), it is used directly — no config file needed. This is the simplest, most reliable path.
+
+To use a different location (e.g., iCloud Drive) when `~/wiki/` is not set up, create `~/.config/llm-wiki/config.json`:
+
+```json
+{ "hub_path": "~/Library/Mobile Documents/com~apple~CloudDocs/wiki" }
+```
+
+**Resolution**: At the start of every operation, resolve **HUB** by following the protocol in [references/hub-resolution.md](references/hub-resolution.md) — check `~/wiki/` first, then fall back to config. This handles tilde expansion, paths with spaces, and iCloud directory names correctly. All references to `~/wiki/` below mean HUB.
+
+## Wiki Location
+
+**Topic sub-wikis are the default.** HUB is a hub — content lives in `HUB/topics/<name>/`. Each topic gets isolated indexes, sources, and articles. This keeps queries focused and prevents unrelated topics from polluting each other's search space.
+
+Resolution order:
+
+1. `--local` flag → `.wiki/` in current project
+2. `--wiki <name>` flag → named wiki from `HUB/wikis.json`
+3. Current directory has `.wiki/` → use it
+4. Otherwise → HUB (the hub)
+
+When a command targets the hub and the hub has no content, suggest creating a topic sub-wiki instead.
+
+See [references/wiki-structure.md](references/wiki-structure.md) for the complete directory layout and all file format conventions.
+
+## Core Principles
+
+1. **Indexes are a derived cache.** The `.md` files and their YAML frontmatter are the source of truth. `_index.md` files are a cached view rebuilt on read when stale. Always read indexes first for navigation — but before trusting one, stale-check it (file count vs row count). See [references/indexing.md](references/indexing.md) for the Derived Index Protocol.
+
+2. **Raw is immutable.** Once ingested into `raw/`, sources are never modified. They are a record of what was ingested and when. All synthesis happens in `wiki/`.
+
+3. **Articles are synthesized, not copied.** A wiki article draws from multiple sources, contextualizes, and connects to other concepts. Think textbook, not clipboard.
+
+4. **Dual-linking for Obsidian + OpenCode.** Cross-references use both `[[wikilink]]` (for Obsidian graph view) and standard markdown `[text](path)` (for OpenCode navigation) on the same line: `[[slug|Name]] ([Name](../category/slug.md))`. Bidirectional when it makes sense.
+
+5. **Frontmatter is structured data.** Every `.md` file has YAML frontmatter with title, summary, tags, dates. This makes the wiki searchable without full-text scans.
+
+6. **Incremental over wholesale.** Compilation processes only new sources by default. Full recompilation is expensive and explicit (`--full`).
+
+7. **Honest gaps.** When answering questions, if the wiki doesn't have the answer, say so. Never hallucinate. Suggest what to ingest to fill the gap.
+
+8. **Multi-wiki awareness.** When querying, answer from the primary wiki first. Then peek at sibling wiki indexes (via `HUB/wikis.json`) for relevant overlap. Flag connections but never merge content across wikis.
+
+9. **Chunk large writes.** Never create files longer than ~200 lines in a single Write call — the API stream idles during large generations, causing timeout errors. Write the skeleton (frontmatter + headers + first section) first, then use sequential Edit calls to append remaining sections. For plans, articles, and raw notes: write one section per tool call.
+
+## Ambient Behavior
+
+When this skill activates outside of an explicit wiki-related request:
+
+1. Resolve the hub path (see Hub Path section above), then check if `HUB/_index.md` or `.wiki/_index.md` exists
+2. Read the master `_index.md` to assess if the wiki might cover the user's question
+3. If relevant content exists → read the relevant articles and answer with citations
+4. If no relevant content → answer normally, optionally suggest: "This could be added to your wiki — just ask me to ingest it."
+5. When peeking at sibling wikis, only read their `_index.md` — do not read full articles unless the user asks
+
+## Workflows
+
+### Ingestion
+See [references/ingestion.md](references/ingestion.md).
+Flow: Source (URL/file/text/tweet/inbox) → fetch/read → extract metadata → write to `raw/{type}/` → update indexes → suggest compile if many uncompiled.
+
+### Compilation
+See [references/compilation.md](references/compilation.md).
+Flow: Survey uncompiled sources → plan articles → classify (concept/topic/reference) → write/update articles with cross-references → update all indexes.
+
+### Query
+Flow: Read `_index.md` → identify relevant articles by summary/tag → read articles → follow See Also links → Grep for additional matches → synthesize answer with citations → note gaps → peek sibling wikis. Supports `--resume` to reload context after a session break — reads session files, recent log entries, wiki stats, and last-updated articles to produce a "where you left off" briefing.
+
+### Linting
+See [references/linting.md](references/linting.md).
+Flow: Check structure → indexes → links → content → coverage → report → optionally auto-fix.
+
+### Search
+Flow: Scan indexes for summary/tag matches → Grep full-text → rank results → present.
+
+### Output
+Flow: Gather relevant articles → generate artifact (summary/report/slides/etc) → save to `output/` → update indexes.
+
+### Lessons Learned (ll)
+Flow: Scan session for error→fix patterns, corrections, discoveries → extract structured lessons → write to `raw/notes/` with `type: lessons-learned` → optionally update relevant articles → optionally suggest CLAUDE.md rules.
+
+## Links: File Paths and URLs
+
+Terminal links break when they wrap to a second line. Rules for all wiki operations:
+
+1. **Full absolute paths** — expand `~`, HUB, and all relative segments. Relative paths are not clickable.
+2. **Markdown link syntax for URLs** — use `[short text](url)`, never bare long URLs that wrap and break.
+3. **No indentation before links** — indentation eats terminal width. Put links flush-left on their own line.
+4. **One link per line** — don't embed a long path mid-sentence. Break it out:
+   ```
+   Saved to:
+   /Users/name/wiki/topics/my-topic/output/report-2026-04-08.md
+   ```
+
+See `references/research-infrastructure.md` § Agent Prompt Templates for examples. Applies to ingest, compile, research, output, assess.
+
+## Activity Log
+
+Every wiki operation appends to `log.md` in the wiki root. Format: `## [YYYY-MM-DD] operation | Description`. See [references/wiki-structure.md](references/wiki-structure.md) for full format. Never edit or delete existing log entries — append only.
+
+## Confidence Scoring
+
+Wiki articles include a `confidence` field in frontmatter: `high`, `medium`, or `low`.
+
+- **high**: Multiple peer-reviewed sources agree, well-established knowledge
+- **medium**: Single source, or sources partially agree, or recent findings not yet replicated
+- **low**: Anecdotal, single non-peer-reviewed source, or sources disagree
+
+When answering queries, note confidence levels. When linting, flag `low` confidence articles for review.
+
+## Compilation Nudge
+
+Track uncompiled sources by comparing `raw/_index.md` ingestion dates against the last compile date in `_index.md`. If 5+ uncompiled sources exist after an ingestion, suggest: "You have N uncompiled sources. Ask me to compile them."
+
+## Structural Guardian
+
+Automatically run a quick structural check when any of these triggers occur:
+
+### Triggers
+- **After any write operation** (ingest, compile, research, output) — verify what was just written
+- **When the skill activates** and the wiki hasn't been linted in 7+ days (check "Last lint" in `_index.md`)
+- **When content is found in the wrong place** — articles in the global hub instead of a topic sub-wiki
+- **When a user mentions wiki problems** — "wiki is broken", "empty", "missing", "wrong"
+- **When no wiki exists** (first-run) — switch to guided onboarding flow instead of showing a command list. Walk the user through topic selection → init → first action suggestion. See `commands/wiki.md` § "If no wiki exists".
+
+### Quick Structure Check (lightweight, runs inline — not a full lint)
+
+1. **Hub integrity**: The hub (HUB) should ONLY contain `wikis.json`, `_index.md`, `log.md`, and `topics/`. If `raw/`, `wiki/`, `output/`, `inbox/`, or `config.md` exist at the hub level → **warn, do not delete**. These may hold user data from an older wiki layout. Suggest running the lint --fix workflow, which will move contents to the appropriate topic wiki or quarantine to `inbox/.unknown/` per C11/C12 in `references/linting.md`.
+
+2. **Index freshness**: For the active topic wiki, compare actual file count in `wiki/concepts/`, `wiki/topics/`, `wiki/references/` against the rows in their `_index.md`. If mismatched → auto-fix by adding missing entries or removing dead ones.
+
+3. **Orphan detection**: Check if any `.md` files exist in wiki directories but are not listed in any `_index.md`. If found → add them to the index.
+
+4. **Missing directories**: Verify all expected subdirectories exist in the topic wiki (`raw/articles/`, `raw/papers/`, etc.). If missing → create them with empty `_index.md`.
+
+5. **wikis.json sync**: Check that all topic sub-wikis under `HUB/topics/` are registered in `wikis.json`. If a directory exists but isn't registered → add it. If registered but directory is missing → remove the entry.
+
+6. **Log existence**: Verify `log.md` exists in the active wiki and at the hub. If missing → create it.
+
+### Behavior
+
+- **Silent when clean** — don't report anything if everything checks out
+- **Auto-fix trivial issues** — missing indexes, unregistered wikis, orphan files. Just fix and note in log.
+- **Warn on structural problems** — content in wrong place, missing directories, stale indexes. Tell the user what's wrong and suggest running lint with --fix.
+- **Never block the user's request** — run the check, fix what you can, report issues, then continue with what the user actually asked for.
+
+## Concurrency
+
+Multiple OpenCode sessions can safely read and write to the same wiki simultaneously. No locks are needed.
+
+- **Indexes** are derived from the actual files on disk. If two sessions write articles at the same time, the next read rebuilds the index from whatever files exist. Both rebuilds converge to the same correct result.
+- **log.md** is append-only with small atomic writes. Concurrent appends are safe.
+- **Article/source files** are written independently. Two sessions creating different files never conflict. Two sessions editing the same file is unlikely and handled by last-write-wins (acceptable for a wiki — the content is always rebuildable from raw sources).
+
+See [references/indexing.md](references/indexing.md) for the Derived Index Protocol.
+
+## Session Management
+
+### Research Session Registry
+
+When a `--min-time` research or thesis session is active, the wiki root contains a `.research-session.json` or `.thesis-session.json` file.
+
+**Structural Guardian behavior**:
+- If a session file exists with `status: "in_progress"` and `start_time` > 7 days ago → warn: "Stale research session found. Resume or rerun the research workflow, or delete it manually."
+- Session files are ephemeral — never included in structural health checks or index counts
+- Session files should NOT be committed to git

--- a/plugins/llm-wiki-opencode/skills/wiki-manager/references
+++ b/plugins/llm-wiki-opencode/skills/wiki-manager/references
@@ -1,0 +1,1 @@
+../../../../claude-plugin/skills/wiki-manager/references

--- a/plugins/llm-wiki/.codex-plugin/plugin.json
+++ b/plugins/llm-wiki/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "LLM-compiled knowledge bases for Codex. Build topic-scoped wikis, ingest sources, compile articles, query, lint, research, and generate outputs.",
   "author": {
     "name": "nvk",

--- a/scripts/sync-opencode-plugin.sh
+++ b/scripts/sync-opencode-plugin.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_SKILL="$ROOT/claude-plugin/skills/wiki-manager"
+TARGET_PLUGIN="$ROOT/plugins/llm-wiki-opencode"
+TARGET_SKILL="$TARGET_PLUGIN/skills/wiki-manager"
+CLAUDE_MANIFEST="$ROOT/claude-plugin/.claude-plugin/plugin.json"
+
+if [ ! -d "$SOURCE_SKILL" ]; then
+  echo "Missing source skill: $SOURCE_SKILL" >&2
+  exit 1
+fi
+
+if [ ! -f "$CLAUDE_MANIFEST" ]; then
+  echo "Missing Claude manifest: $CLAUDE_MANIFEST" >&2
+  exit 1
+fi
+
+mkdir -p "$TARGET_PLUGIN/skills"
+# references/ is a symlink into the Claude source — exclude from rsync so it's
+# preserved, and recreate it idempotently below.
+rsync -a --delete \
+  --exclude='references/' \
+  --exclude='references' \
+  "$SOURCE_SKILL/" "$TARGET_SKILL/"
+
+# Recreate the references symlink (idempotent — works on fresh checkout too).
+rm -rf "$TARGET_SKILL/references"
+ln -s "../../../../claude-plugin/skills/wiki-manager/references" "$TARGET_SKILL/references"
+
+python3 - "$TARGET_SKILL" <<'PY'
+import sys
+from pathlib import Path
+
+target_skill = Path(sys.argv[1])
+
+skill_path = target_skill / "SKILL.md"
+text = skill_path.read_text()
+
+frontmatter = """---
+name: wiki-manager
+description: >
+  LLM-compiled knowledge base manager for OpenCode. Use it to initialize, ingest,
+  compile, query, lint, research, and generate outputs from topic-scoped wikis.
+  Activates when the user mentions wiki workflows, knowledge-base management,
+  ingestion, compilation, querying, linting, research, or uses wiki-related
+  shorthand in a repo with .wiki/, ~/wiki/, or a configured hub path.
+---
+"""
+
+start = text.find("---\n")
+end = text.find("\n---\n", start + 4)
+if start != 0 or end == -1:
+    raise SystemExit(f"Unexpected frontmatter in {skill_path}")
+text = frontmatter + text[end + 5 :]
+
+replacements = [
+    (
+        "You manage an LLM-compiled knowledge base. Source documents are ingested into `raw/`, then incrementally compiled into a wiki of interconnected markdown articles. Claude Code is both the compiler and the query engine — no Obsidian, no external tools.\n",
+        "You manage an LLM-compiled knowledge base. Source documents are ingested into `raw/`, then incrementally compiled into a wiki of interconnected markdown articles. OpenCode is both the compiler and the query engine.\n\n## OpenCode Integration Notes\n\nThis skill is loaded as an instruction file. OpenCode does not have Claude-style `/wiki:*` slash commands or Codex-style `@wiki` invocations. Treat any `/wiki:*` references in this skill and its references as shorthand for the equivalent natural-language request. For example, `/wiki:compile` means the user is asking you to compile the wiki.\n\nOpenCode's built-in tools (`read`, `write`, `edit`, `glob`, `grep`, `bash`, `webfetch`, `websearch`) map directly to the tools this skill requires. Web search requires `OPENCODE_ENABLE_EXA=1` in the environment.\n",
+    ),
+    (
+        "**Dual-linking for Obsidian + Claude.** Cross-references use both `[[wikilink]]` (for Obsidian graph view) and standard markdown `[text](path)` (for Claude navigation) on the same line: `[[slug|Name]] ([Name](../category/slug.md))`. Bidirectional when it makes sense.",
+        "**Dual-linking for Obsidian + OpenCode.** Cross-references use both `[[wikilink]]` (for Obsidian graph view) and standard markdown `[text](path)` (for OpenCode navigation) on the same line: `[[slug|Name]] ([Name](../category/slug.md))`. Bidirectional when it makes sense.",
+    ),
+    (
+        "When this skill activates outside of an explicit `/wiki:*` command:",
+        "When this skill activates outside of an explicit wiki-related request:",
+    ),
+    (
+        '4. If no relevant content → answer normally, optionally suggest: "This could be added to your wiki with `/wiki:ingest`"',
+        '4. If no relevant content → answer normally, optionally suggest: "This could be added to your wiki — just ask me to ingest it."',
+    ),
+    (
+        'Track uncompiled sources by comparing `raw/_index.md` ingestion dates against the last compile date in `_index.md`. If 5+ uncompiled sources exist after an ingestion, suggest: "You have N uncompiled sources. Run `/wiki:compile` to integrate them."',
+        'Track uncompiled sources by comparing `raw/_index.md` ingestion dates against the last compile date in `_index.md`. If 5+ uncompiled sources exist after an ingestion, suggest: "You have N uncompiled sources. Ask me to compile them."',
+    ),
+    (
+        'Suggest `/wiki:lint --fix`, which will move contents to the appropriate topic wiki or quarantine to `inbox/.unknown/` per C11/C12 in `references/linting.md`.',
+        'Suggest running the lint --fix workflow, which will move contents to the appropriate topic wiki or quarantine to `inbox/.unknown/` per C11/C12 in `references/linting.md`.',
+    ),
+    (
+        "Tell the user what's wrong and suggest `/wiki:lint --fix`.",
+        "Tell the user what's wrong and suggest running lint with --fix.",
+    ),
+    (
+        "Multiple Claude Code sessions can safely read and write to the same wiki simultaneously. No locks are needed.",
+        "Multiple OpenCode sessions can safely read and write to the same wiki simultaneously. No locks are needed.",
+    ),
+    (
+        'warn: "Stale research session found. Clean up with `/wiki:research` or delete manually."',
+        'warn: "Stale research session found. Resume or rerun the research workflow, or delete it manually."',
+    ),
+]
+
+for old, new in replacements:
+    if old not in text:
+        raise SystemExit(f"Expected text not found in {skill_path}: {old[:80]!r}")
+    text = text.replace(old, new)
+
+skill_path.write_text(text)
+
+# references/ is a symlink to claude-plugin/skills/wiki-manager/references and
+# is shared verbatim — no per-file replacements needed. Source references use
+# runtime-neutral wording ("the agent") so they read correctly under all runtimes.
+PY
+
+echo "Synced OpenCode plugin skill from Claude source."
+echo "Source: $SOURCE_SKILL"
+echo "Target: $TARGET_SKILL"

--- a/tests/test-opencode-sync.sh
+++ b/tests/test-opencode-sync.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Local-CI: verify the OpenCode plugin mirror (plugins/llm-wiki-opencode/)
+# stays in sync with the Claude source of truth (claude-plugin/skills/wiki-manager/).
+#
+# Self-healing — on failure the sync script has ALREADY regenerated the
+# OpenCode tree. The agent just needs to stage and commit the result.
+#
+# Mirrors test-codex-sync.sh for the Codex target.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+./scripts/sync-opencode-plugin.sh >/dev/null
+
+if ! git diff --quiet HEAD -- plugins/llm-wiki-opencode/; then
+  cat >&2 <<'MSG'
+FAIL: OpenCode plugin mirror is out of sync with claude-plugin/skills/wiki-manager/.
+
+The sync script has already regenerated plugins/llm-wiki-opencode/. To fix:
+  1. git diff -- plugins/llm-wiki-opencode/   # review the regenerated changes
+  2. git add plugins/llm-wiki-opencode/        # stage them
+  3. git commit                                # fold into the same commit
+  4. ./tests/test-opencode-sync.sh             # re-run to confirm clean
+
+This guards against the OpenCode copy drifting from the Claude source.
+MSG
+  exit 1
+fi
+
+echo "OK: OpenCode plugin mirror is in sync."

--- a/tests/test-plugin-validate.sh
+++ b/tests/test-plugin-validate.sh
@@ -163,6 +163,64 @@ else
   log_fail "agents/openai.yaml not found" "missing file"
 fi
 
+# OpenCode mirror validation — the artifacts that OpenCode loads via the
+# "instructions" key in opencode.json. Drift between Claude source and this
+# mirror is covered by test-opencode-sync.sh; what's checked here is whether
+# the mirror itself is well-formed.
+echo ""
+echo "=== OpenCode Mirror Validation ==="
+OPENCODE_PLUGIN="$PROJECT_ROOT/plugins/llm-wiki-opencode"
+OPENCODE_SKILL="$OPENCODE_PLUGIN/skills/wiki-manager"
+
+# References symlink
+echo ""
+echo "--- OpenCode references symlink ---"
+OC_REFS_LINK="$OPENCODE_SKILL/references"
+if [ -L "$OC_REFS_LINK" ]; then
+  log_pass "OpenCode references is a symlink"
+  if [ -e "$OC_REFS_LINK" ]; then
+    log_pass "OpenCode references symlink resolves"
+    for ref in command-prelude compilation hub-resolution indexing ingestion linting projects research-infrastructure wiki-structure; do
+      if [ -f "$OC_REFS_LINK/${ref}.md" ]; then
+        log_pass "OpenCode references/$ref.md reachable via symlink"
+      else
+        log_fail "OpenCode references/$ref.md not reachable via symlink" "broken target"
+      fi
+    done
+  else
+    log_fail "OpenCode references symlink target does not exist" "$(readlink "$OC_REFS_LINK")"
+  fi
+else
+  log_fail "OpenCode references is not a symlink" "expected symlink to claude-plugin source"
+fi
+
+# OpenCode SKILL.md
+echo ""
+echo "--- OpenCode skill files ---"
+if [ -f "$OPENCODE_SKILL/SKILL.md" ]; then
+  log_pass "OpenCode SKILL.md exists"
+  if head -1 "$OPENCODE_SKILL/SKILL.md" | grep -q "^---$"; then
+    log_pass "OpenCode SKILL.md has frontmatter"
+  else
+    log_fail "OpenCode SKILL.md has no frontmatter" "missing ---"
+  fi
+  # Verify no Claude Code references leaked through
+  if ! grep -q "Claude Code" "$OPENCODE_SKILL/SKILL.md"; then
+    log_pass "OpenCode SKILL.md has no 'Claude Code' references"
+  else
+    log_fail "OpenCode SKILL.md contains 'Claude Code'" "sync script missed a replacement"
+  fi
+else
+  log_fail "OpenCode SKILL.md not found" "missing file"
+fi
+
+# OpenCode README
+if [ -f "$OPENCODE_PLUGIN/README.md" ]; then
+  log_pass "OpenCode README.md exists"
+else
+  log_fail "OpenCode README.md not found" "missing file"
+fi
+
 echo ""
 echo "==========================================="
 printf "Results: \033[32m%d passed\033[0m, \033[31m%d failed\033[0m, %d total\n" "$PASS" "$FAIL" "$TOTAL"


### PR DESCRIPTION
## Summary

- Add OpenCode as a third distribution target alongside Claude Code and Codex
- New `scripts/sync-opencode-plugin.sh` generates `plugins/llm-wiki-opencode/` from Claude source with OpenCode-specific wording patches and symlinked references
- `tests/test-opencode-sync.sh` guards against drift (self-healing, mirrors `test-codex-sync.sh`)
- `tests/test-plugin-validate.sh` extended with 15 OpenCode mirror checks (SKILL.md, references symlink, no leaked Claude Code refs, README)
- README: OpenCode install section, changelog v0.3.7, architecture section renamed to "Claude-First, Multi-Runtime"
- Release checklist and CLAUDE.md updated with OpenCode verification steps and contributor workflow

## How it works

OpenCode reads `AGENTS.md` natively, but that's the lowest-fidelity path (no activation triggers, no fuzzy router, no ambient behavior). This PR generates a richer SKILL.md with all of those features, patched for OpenCode conventions. Users load it via `opencode.json`'s `"instructions"` key or copy to `~/.config/opencode/AGENTS.md`.

Same pattern as Codex: one Claude source of truth, generated mirrors, symlinked references, self-healing sync tests.

## Test plan

- [x] `test-plugin-validate.sh` — 62 passed, 0 failed (15 new OpenCode checks)
- [x] `test-opencode-sync.sh` — OK
- [x] `test-codex-sync.sh` — OK (no regression)
- [x] `test-structure.sh` — 92 passed, 0 failed (no regression)
- [ ] Manual: load SKILL.md in OpenCode, run a wiki workflow end-to-end