### PR TITLE
Add research --resume/--continue protocol

### DIFF
--- a/claude-plugin/commands/query.md
+++ b/claude-plugin/commands/query.md
@@ -1,6 +1,6 @@
 ---
-description: "Ask questions against the compiled wiki. Supports quick/standard/deep depth levels, --list for browsing, and --resume to reload context after a session break. Answers from wiki content only, with citations."
-argument-hint: "<question> [--quick] [--deep] [--raw] [--list] [--resume] [--tag <tag>] [--category concepts|topics|references] [--with <wiki>...] [--wiki <name>] [--local]"
+description: "Ask questions against the compiled wiki. Supports quick/standard/deep depth levels, --list for browsing, and --resume/--continue to reload context after a session break. Answers from wiki content only, with citations."
+argument-hint: "<question> [--quick] [--deep] [--raw] [--list] [--resume|--continue] [--tag <tag>] [--category concepts|topics|references] [--with <wiki>...] [--wiki <name>] [--local]"
 allowed-tools: Read, Glob, Grep, Bash(ls:*), Edit
 ---
 
@@ -21,7 +21,7 @@ Answer the question in $ARGUMENTS using ONLY the knowledge in the wiki. Follow t
 - **--deep**: Thorough answer — read all related articles, follow all links, search raw, peek sibling wikis
 - **--raw**: Also search raw sources (implied by --deep)
 - **--list**: Return a ranked list of matching articles instead of a synthesized answer. Useful for browsing what the wiki has on a topic before diving in.
-- **--resume**: Load recent activity context and show a "where you left off" briefing. If a question is also provided, answer it after the briefing using standard depth.
+- **--resume** / **--continue**: Load recent activity context and show a "where you left off" briefing. These are aliases. If a question is also provided, answer it after the briefing using standard depth.
 - **--tag <tag>**: Filter to articles with this tag in frontmatter
 - **--category <cat>**: Search only in concepts, topics, or references
 - **--with <wiki>**: Load a supplementary wiki as additional context when answering. The primary wiki provides the subject; `--with` wikis provide craft/skill knowledge. Multiple `--with` flags allowed.
@@ -123,7 +123,7 @@ If no results found, suggest alternative search terms or `/wiki:ingest` to add s
 
 Skip the synthesized answer, sources used, and knowledge gaps sections. Just return the list.
 
-### Resume Mode (`--resume`)
+### Resume Mode (`--resume` / `--continue`)
 
 Context reload for new sessions. Reads persistent state and outputs a briefing so you can pick up where you left off.
 
@@ -170,7 +170,7 @@ Context reload for new sessions. Reads persistent state and outputs a briefing s
 
 **If no question**: Skip the Sources used / Knowledge gaps sections entirely — just the briefing.
 
-**Log**: Append `## [YYYY-MM-DD] query | --resume briefing`
+**Log**: Append `## [YYYY-MM-DD] query | --resume briefing` even when invoked via `--continue` (canonical log label stays `--resume`).
 
 ### Output Format (all depths, not --list)
 

--- a/claude-plugin/commands/research.md
+++ b/claude-plugin/commands/research.md
@@ -1,6 +1,6 @@
 ---
-description: "Deep multi-agent research on a topic, question, or thesis. Launches parallel agents to search the web, ingests sources, and compiles them into wiki articles. Thesis mode provides for/against evidence framing with a verdict."
-argument-hint: "<topic|question> [--plan] [--mode thesis \"<claim>\"] [--new-topic] [--sources <N>] [--deep] [--retardmax] [--min-time <duration>] [--wiki <name>] [--local] [--project <slug>]"
+description: "Deep multi-agent research on a topic, question, or thesis. Launches parallel agents to search the web, ingests sources, and compiles them into wiki articles. Supports --resume/--continue after interrupted runs."
+argument-hint: "<topic|question> [--plan] [--mode thesis \"<claim>\"] [--new-topic] [--sources <N>] [--deep] [--retardmax] [--min-time <duration>] [--resume|--continue] [--wiki <name>] [--local] [--project <slug>]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(ls:*), Bash(wc:*), Bash(date:*), Bash(mkdir:*), WebFetch, WebSearch, Agent
 ---
 
@@ -21,6 +21,7 @@ Conduct deep research on the topic in $ARGUMENTS. This is an automated pipeline:
 - **--local**: Use project-local `.wiki/`
 - **--plan**: Decompose the topic into 3-5 independent research paths, present the plan for confirmation, then execute all paths in parallel. Each path gets its own agent group (5 agents standard, 8 with `--deep`). Ingest runs in parallel across paths (each path writes unique raw files); compilation runs once after all paths complete (single pass sees all sources for better cross-referencing). Without `--plan`, research runs a single path as before. See Plan Mode below.
 - **--project <slug>**: Tag all new outputs with this project. The research playbook/summary artifact is saved inside `output/projects/<slug>/` instead of flat `output/`. Compiled wiki articles get `project: <slug>` frontmatter. If the project doesn't exist, fail early with a helpful error. See `references/projects.md` for the projects architecture.
+- **--resume** / **--continue**: Resume the last interrupted research run instead of replanning from scratch. These are aliases. Read `.research-session.json` first, fall back to `.session-checkpoint.json`, `.session-events.jsonl`, and `log.md`, then re-run only missing/unfinished agents or paths and continue to the final compile.
 
 ### `--project <slug>` flag
 
@@ -45,14 +46,33 @@ There is no ambient project focus — pass `--project` explicitly when you want 
 
 **When `--new-topic` is NOT set**, the standard prelude resolution applies, with one deviation: step 4 (fallback to HUB) becomes "ask which topic wiki to target" — research against an empty hub doesn't make sense.
 
+### Explicit Resume / Continue
+
+`--resume` and `--continue` are exact aliases. If either flag is present, do **not** create a new plan and do **not** relaunch the whole swarm until you have inspected prior state.
+
+Resume order:
+1. Read `<wiki-root>/.research-session.json` if it exists.
+2. If missing, read `<wiki-root>/.session-checkpoint.json` and the recent tail of `<wiki-root>/.session-events.jsonl`.
+3. Read recent `log.md` entries to identify the last research operation, ingested raw files, completed compile step, and any recorded gaps.
+4. Briefly report what was recovered: topic, mode, completed agents/paths, pending agents/paths, sources already ingested, and whether compilation already ran.
+5. Continue from the earliest incomplete phase:
+   - If source-discovery agents/paths are incomplete, relaunch only entries with `status: pending`, `in_progress`, or retryable `failed`.
+   - If all agents/paths completed but no compile event/artifact is recorded, skip search and run the final compile/synthesis only.
+   - If compile completed but summary/output is missing, regenerate only the summary/output artifact.
+6. If no recoverable research state exists, say so and ask whether to start fresh with the supplied topic. Do not pretend a clean run is a resume.
+
+For an interrupted `in_progress` agent/path, assume it may have partially written raw files. That is safe: keep any existing raw files, deduplicate by URL/content during the normal dedupe pass, and only launch the missing work. Never delete raw files during resume unless the user explicitly asks.
+
 ### Minimum Time Research (`--min-time`)
 
 #### Multi-Round Session State
 
-When `--min-time` is set, create and maintain:
+For every research run, create and maintain:
 
-- an **ephemeral session registry** for crash recovery and round-to-round state
+- an **ephemeral session registry** for crash recovery, agent/path status, and round-to-round state
 - **durable provenance artifacts** for replayable audit trails and resume briefings
+
+For a single standard run, the session still exists: it tracks Phase 2 agent completion and whether final compile/synthesis happened. `--min-time` adds multiple rounds on top of the same machinery.
 
 **Ephemeral location**: `<wiki-root>/.research-session.json`
 
@@ -69,6 +89,16 @@ When `--min-time` is set, create and maintain:
   "start_time": "ISO 8601",
   "min_time_budget": "2h",
   "current_round": 1,
+  "agents": [
+    {
+      "role": "Academic",
+      "focus": "Peer-reviewed / primary evidence",
+      "status": "pending|in_progress|completed|failed",
+      "sources_ingested": 3,
+      "raw_files": ["raw/articles/2026-04-30-example.md"],
+      "error": null
+    }
+  ],
   "paths": [
     {
       "name": "Path name",
@@ -78,6 +108,7 @@ When `--min-time` is set, create and maintain:
       "sources_ingested": 3
     }
   ],
+  "compile_status": "pending|in_progress|completed|failed",
   "rounds_completed": [
     {
       "round": 1,
@@ -93,21 +124,25 @@ When `--min-time` is set, create and maintain:
 }
 ```
 
-The `mode` field defaults to `"single"` for backward compatibility. When `--plan` is set, `mode` is `"plan"` and `paths` is populated. For single-path sessions, `paths` is omitted. See `references/research-infrastructure.md` § Research Plan Schema for the full schema and resume protocol.
+The `mode` field defaults to `"single"` for backward compatibility. Populate `agents` before launching the Phase 2 swarm so an interrupted run knows exactly which roles finished. When `--plan` is set, `mode` is `"plan"` and `paths` is populated; path agents may also maintain their own nested agent state. For single-path sessions, `paths` is omitted. See `references/research-infrastructure.md` § Research Plan Schema for the full schema and resume protocol.
 
 **Lifecycle**:
-1. **Create** `.research-session.json` at session start (Round 1 begins)
-2. **Append** `research_started` to `.session-events.jsonl` and write an initial `.session-checkpoint.json`
-3. **Update** after each round completes — sources, articles, gaps, progress score
-4. **Append** round and reflection events after each meaningful milestone; refresh `.session-checkpoint.json`
-5. **On completion** → set status to `completed`, append `research_completed`, refresh `.session-checkpoint.json`, delete only `.research-session.json`
-6. **On interruption** → `.research-session.json` persists with status `in_progress`; durable provenance files remain
+1. **Create** `.research-session.json` at session start before launching agents. Include topic, flags, mode, agent/path list, `compile_status: "pending"`, and `status: "in_progress"`.
+2. **Append** `research_started` to `.session-events.jsonl` and write an initial `.session-checkpoint.json`.
+3. **Update before and after each agent/path**: mark `in_progress` before launch; on return mark `completed`, record `sources_ingested` and `raw_files`; on failure mark `failed` with `error`.
+4. **After source dedupe and compile/synthesis**, update `compile_status` and append `research_compiled` / summary events.
+5. **For `--min-time` rounds**, additionally update rounds — sources, articles, gaps, progress score — after each round.
+6. **On completion** → set status to `completed`, append `research_completed`, refresh `.session-checkpoint.json`, delete only `.research-session.json`.
+7. **On interruption** → `.research-session.json` persists with status `in_progress`; durable provenance files remain.
 
-**Resume detection**: At command start, if `.research-session.json` exists with `status: "in_progress"`:
+**Resume detection**: At command start, if `.research-session.json` exists with `status: "in_progress"`, or if the user passed `--resume` / `--continue`:
 - Read the file to understand what was already done
-- Ask: "Found interrupted session (Round N, M sources so far). Continue from Round N+1, or start fresh?"
-- If continue: skip Phase 1, read round N's gaps as starting point for round N+1
-- If fresh: delete the file and start over
+- Ask only when the user's intent is ambiguous: "Found interrupted session (Round N, M sources so far). Continue, or start fresh?"
+- If the user explicitly passed `--resume` / `--continue`, continue without another confirmation unless destructive cleanup would be required
+- Relaunch only `agents[]` or `paths[]` whose status is `pending`, `in_progress`, or retryable `failed`
+- If all agents/paths are completed and `compile_status != "completed"`, skip search and run compile/synthesis only
+- If continue across rounds: skip Phase 1, read round N's gaps as starting point for round N+1
+- If fresh: delete only the ephemeral session file and start over; keep raw files and durable provenance
 
 If no active `.research-session.json` exists but `.session-checkpoint.json` does, read the checkpoint and recent `.session-events.jsonl` entries to summarize the most recent completed research before starting fresh.
 

--- a/claude-plugin/skills/wiki-manager/SKILL.md
+++ b/claude-plugin/skills/wiki-manager/SKILL.md
@@ -100,7 +100,7 @@ See [references/compilation.md](references/compilation.md).
 Flow: Survey uncompiled sources → plan articles → classify (concept/topic/reference) → write/update articles with cross-references → update all indexes.
 
 ### Query
-Flow: Read `_index.md` → identify relevant articles by summary/tag → read articles → follow See Also links → Grep for additional matches → synthesize answer with citations → note gaps → peek sibling wikis. Supports `--resume` to reload context after a session break — reads session files, recent log entries, wiki stats, and last-updated articles to produce a "where you left off" briefing.
+Flow: Read `_index.md` → identify relevant articles by summary/tag → read articles → follow See Also links → Grep for additional matches → synthesize answer with citations → note gaps → peek sibling wikis. Supports `--resume` / `--continue` to reload context after a session break — reads session files, recent log entries, wiki stats, and last-updated articles to produce a "where you left off" briefing.
 
 ### Linting
 See [references/linting.md](references/linting.md).
@@ -198,7 +198,7 @@ See [references/indexing.md](references/indexing.md) for the Derived Index Proto
 
 ### Research Session Registry
 
-When a `--min-time` research or thesis session is active, the wiki root contains a `.research-session.json` or `.thesis-session.json` file.
+When any research or thesis session is active, the wiki root contains a `.research-session.json` or `.thesis-session.json` file. Standard single-round research uses the same registry to track source-discovery agents and compile status; `--min-time` adds round tracking.
 
 Durable provenance should also live in the wiki root:
 
@@ -209,7 +209,7 @@ The session registry files are ephemeral crash-recovery state. The event log and
 checkpoint are the durable provenance trail.
 
 **Structural Guardian behavior**:
-- If a session file exists with `status: "in_progress"` and `start_time` > 7 days ago → warn: "Stale research session found. Clean up with `/wiki:research` or delete manually."
+- If a session file exists with `status: "in_progress"` and `start_time` > 7 days ago → warn: "Stale research session found. Resume with `/wiki:research --resume`, start fresh, or delete manually."
 - Session files are ephemeral — never included in structural health checks or index counts
 - Session files should NOT be committed to git
 - `.session-events.jsonl` and `.session-checkpoint.json` should normally be preserved after completion so `/wiki:audit` can classify provenance as `replayable` instead of `partial`

--- a/claude-plugin/skills/wiki-manager/references/research-infrastructure.md
+++ b/claude-plugin/skills/wiki-manager/references/research-infrastructure.md
@@ -369,27 +369,39 @@ Recommended fields:
 | `topic` / `thesis` / `scope` | string | Human-readable target |
 | `current_round` | number | Most recent completed round, when applicable |
 | `summary` | object | Compact state for resume briefings |
+| `agents` | array | Standard/deep/retardmax source-discovery agents with status, source count, raw files, and error |
+| `compile_status` | string | `pending`, `in_progress`, `completed`, or `failed` for the sequential compile/synthesis phase |
 | `artifacts` | array | Written artifact paths and hashes, when available |
 
 ### Lifecycle
 
 | Event | Action |
 |-------|--------|
-| --min-time research starts | Create `.research-session.json`; append `research_started`; write `.session-checkpoint.json` |
-| Round N completes | Update `.research-session.json`; append round event(s); refresh checkpoint |
+| Any research starts | Create `.research-session.json` before launching agents; append `research_started`; write `.session-checkpoint.json` |
+| Agent/path starts | Mark that `agents[]` or `paths[]` entry `in_progress`; refresh checkpoint |
+| Agent/path completes | Mark it `completed`; record source count and raw file paths; append event; refresh checkpoint |
+| Agent/path fails | Mark it `failed` with an error string; keep partial raw files |
+| Compile starts/completes | Update `compile_status`; append `research_compiled` on success |
+| Round N completes (`--min-time`) | Update `.research-session.json`; append round event(s); refresh checkpoint |
 | Research completes normally | Append completion event; refresh checkpoint; delete `.research-session.json` |
 | Session interrupted | `.research-session.json` persists with `status: "in_progress"`; durable files remain |
-| Next invocation detects file | Ask: continue or start fresh? |
+| Next invocation detects file | Ask: continue or start fresh, unless `--resume`/`--continue` was explicit |
 | File > 7 days old | Structural Guardian warns about stale session |
 
 ### Resume Protocol
 
-1. Detect `.research-session.json` or `.thesis-session.json` in wiki root
-2. If found, read it first and extract the last completed round
-3. If no active session exists, read `.session-checkpoint.json` and the tail of `.session-events.jsonl` for the latest durable context
-4. Ask user: "Found interrupted session (Round N, M sources). Continue or start fresh?"
-5. If continue: use round N's gaps/reflection as starting point for round N+1
-6. If fresh: delete only the ephemeral session file, preserve durable provenance
+`--resume` and `--continue` are aliases. The command should also offer resume automatically when it sees an active session file.
+
+1. Detect `.research-session.json` or `.thesis-session.json` in wiki root.
+2. If found, read it first and extract topic/thesis, mode, last completed round, `agents[]`, `paths[]`, and `compile_status`.
+3. If no active session exists, read `.session-checkpoint.json`, the tail of `.session-events.jsonl`, and recent `log.md` entries for the latest durable context.
+4. Ask user: "Found interrupted session (Round N, M sources). Continue or start fresh?" only when the user did not explicitly pass `--resume` or `--continue`.
+5. If continuing source discovery: relaunch only `pending`, `in_progress`, or retryable `failed` agents/paths. Treat `in_progress` as uncertain because the prior process may have died mid-write.
+6. If every agent/path is `completed` but `compile_status` is not `completed`, skip research and run compile/synthesis only.
+7. If compile completed but output/summary is missing, regenerate only the missing artifact.
+8. If fresh: delete only the ephemeral session file, preserve raw files and durable provenance.
+
+Resume must be conservative: never delete partially written raw files, and rely on URL/content dedupe to handle overlap from a re-run agent.
 
 ### Notes
 
@@ -411,7 +423,7 @@ The architectural insight: parallel ingest is safe (each path writes unique raw 
 
 ### Schema Extension
 
-When `mode: "plan"` is set in `.research-session.json`, the following fields are added:
+When `mode: "plan"` is set in `.research-session.json`, the following fields are added. Standard single-path research still uses top-level `agents[]` for the Phase 2 swarm; plan mode adds `paths[]` so the outer path dispatch can resume independently.
 
 | Field | Type | Purpose |
 |-------|------|---------|

--- a/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
+++ b/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
@@ -97,7 +97,7 @@ See [references/compilation.md](references/compilation.md).
 Flow: Survey uncompiled sources → plan articles → classify (concept/topic/reference) → write/update articles with cross-references → update all indexes.
 
 ### Query
-Flow: Read `_index.md` → identify relevant articles by summary/tag → read articles → follow See Also links → Grep for additional matches → synthesize answer with citations → note gaps → peek sibling wikis. Supports `--resume` to reload context after a session break — reads session files, recent log entries, wiki stats, and last-updated articles to produce a "where you left off" briefing.
+Flow: Read `_index.md` → identify relevant articles by summary/tag → read articles → follow See Also links → Grep for additional matches → synthesize answer with citations → note gaps → peek sibling wikis. Supports `--resume` / `--continue` to reload context after a session break — reads session files, recent log entries, wiki stats, and last-updated articles to produce a "where you left off" briefing.
 
 ### Linting
 See [references/linting.md](references/linting.md).
@@ -195,7 +195,7 @@ See [references/indexing.md](references/indexing.md) for the Derived Index Proto
 
 ### Research Session Registry
 
-When a `--min-time` research or thesis session is active, the wiki root contains a `.research-session.json` or `.thesis-session.json` file.
+When any research or thesis session is active, the wiki root contains a `.research-session.json` or `.thesis-session.json` file. Standard single-round research uses the same registry to track source-discovery agents and compile status; `--min-time` adds round tracking.
 
 Durable provenance should also live in the wiki root:
 
@@ -206,7 +206,7 @@ The session registry files are ephemeral crash-recovery state. The event log and
 checkpoint are the durable provenance trail.
 
 **Structural Guardian behavior**:
-- If a session file exists with `status: "in_progress"` and `start_time` > 7 days ago → warn: "Stale research session found. Resume or rerun the research workflow, or delete it manually."
+- If a session file exists with `status: "in_progress"` and `start_time` > 7 days ago → warn: "Stale research session found. Resume or rerun the research workflow, start fresh, or delete it manually."
 - Session files are ephemeral — never included in structural health checks or index counts
 - Session files should NOT be committed to git
 - `.session-events.jsonl` and `.session-checkpoint.json` should normally be preserved after completion so `/wiki:audit` can classify provenance as `replayable` instead of `partial`

--- a/plugins/llm-wiki/skills/wiki/references/research-infrastructure.md
+++ b/plugins/llm-wiki/skills/wiki/references/research-infrastructure.md
@@ -369,27 +369,39 @@ Recommended fields:
 | `topic` / `thesis` / `scope` | string | Human-readable target |
 | `current_round` | number | Most recent completed round, when applicable |
 | `summary` | object | Compact state for resume briefings |
+| `agents` | array | Standard/deep/retardmax source-discovery agents with status, source count, raw files, and error |
+| `compile_status` | string | `pending`, `in_progress`, `completed`, or `failed` for the sequential compile/synthesis phase |
 | `artifacts` | array | Written artifact paths and hashes, when available |
 
 ### Lifecycle
 
 | Event | Action |
 |-------|--------|
-| --min-time research starts | Create `.research-session.json`; append `research_started`; write `.session-checkpoint.json` |
-| Round N completes | Update `.research-session.json`; append round event(s); refresh checkpoint |
+| Any research starts | Create `.research-session.json` before launching agents; append `research_started`; write `.session-checkpoint.json` |
+| Agent/path starts | Mark that `agents[]` or `paths[]` entry `in_progress`; refresh checkpoint |
+| Agent/path completes | Mark it `completed`; record source count and raw file paths; append event; refresh checkpoint |
+| Agent/path fails | Mark it `failed` with an error string; keep partial raw files |
+| Compile starts/completes | Update `compile_status`; append `research_compiled` on success |
+| Round N completes (`--min-time`) | Update `.research-session.json`; append round event(s); refresh checkpoint |
 | Research completes normally | Append completion event; refresh checkpoint; delete `.research-session.json` |
 | Session interrupted | `.research-session.json` persists with `status: "in_progress"`; durable files remain |
-| Next invocation detects file | Ask: continue or start fresh? |
+| Next invocation detects file | Ask: continue or start fresh, unless `--resume`/`--continue` was explicit |
 | File > 7 days old | Structural Guardian warns about stale session |
 
 ### Resume Protocol
 
-1. Detect `.research-session.json` or `.thesis-session.json` in wiki root
-2. If found, read it first and extract the last completed round
-3. If no active session exists, read `.session-checkpoint.json` and the tail of `.session-events.jsonl` for the latest durable context
-4. Ask user: "Found interrupted session (Round N, M sources). Continue or start fresh?"
-5. If continue: use round N's gaps/reflection as starting point for round N+1
-6. If fresh: delete only the ephemeral session file, preserve durable provenance
+`--resume` and `--continue` are aliases. The command should also offer resume automatically when it sees an active session file.
+
+1. Detect `.research-session.json` or `.thesis-session.json` in wiki root.
+2. If found, read it first and extract topic/thesis, mode, last completed round, `agents[]`, `paths[]`, and `compile_status`.
+3. If no active session exists, read `.session-checkpoint.json`, the tail of `.session-events.jsonl`, and recent `log.md` entries for the latest durable context.
+4. Ask user: "Found interrupted session (Round N, M sources). Continue or start fresh?" only when the user did not explicitly pass `--resume` or `--continue`.
+5. If continuing source discovery: relaunch only `pending`, `in_progress`, or retryable `failed` agents/paths. Treat `in_progress` as uncertain because the prior process may have died mid-write.
+6. If every agent/path is `completed` but `compile_status` is not `completed`, skip research and run compile/synthesis only.
+7. If compile completed but output/summary is missing, regenerate only the missing artifact.
+8. If fresh: delete only the ephemeral session file, preserve raw files and durable provenance.
+
+Resume must be conservative: never delete partially written raw files, and rely on URL/content dedupe to handle overlap from a re-run agent.
 
 ### Notes
 
@@ -411,7 +423,7 @@ The architectural insight: parallel ingest is safe (each path writes unique raw 
 
 ### Schema Extension
 
-When `mode: "plan"` is set in `.research-session.json`, the following fields are added:
+When `mode: "plan"` is set in `.research-session.json`, the following fields are added. Standard single-path research still uses top-level `agents[]` for the Phase 2 swarm; plan mode adds `paths[]` so the outer path dispatch can resume independently.
 
 | Field | Type | Purpose |
 |-------|------|---------|

--- a/scripts/sync-codex-plugin.sh
+++ b/scripts/sync-codex-plugin.sh
@@ -112,8 +112,8 @@ replacements = [
         "Multiple Codex sessions can safely read and write to the same wiki simultaneously. No locks are needed.",
     ),
     (
-        'warn: "Stale research session found. Clean up with `/wiki:research` or delete manually."',
-        'warn: "Stale research session found. Resume or rerun the research workflow, or delete it manually."',
+        'warn: "Stale research session found. Resume with `/wiki:research --resume`, start fresh, or delete manually."',
+        'warn: "Stale research session found. Resume or rerun the research workflow, start fresh, or delete it manually."',
     ),
 ]
 

--- a/scripts/sync-opencode-plugin.sh
+++ b/scripts/sync-opencode-plugin.sh
@@ -91,8 +91,8 @@ replacements = [
         "Multiple OpenCode sessions can safely read and write to the same wiki simultaneously. No locks are needed.",
     ),
     (
-        'warn: "Stale research session found. Clean up with `/wiki:research` or delete manually."',
-        'warn: "Stale research session found. Resume or rerun the research workflow, or delete it manually."',
+        'warn: "Stale research session found. Resume with `/wiki:research --resume`, start fresh, or delete manually."',
+        'warn: "Stale research session found. Resume or rerun the research workflow, start fresh, or delete it manually."',
     ),
 ]
 


### PR DESCRIPTION
## Summary
- add `/wiki:research --resume` and `--continue` alias handling
- track standard research runs with `.research-session.json`, including agent/path statuses and compile status
- document conservative resume behavior: rerun only unfinished agents/paths, preserve partial raw files, and skip directly to compile when source discovery is already complete
- add `--continue` alias to `/wiki:query --resume`
- keep Codex/OpenCode mirrors and sync scripts aligned

Closes #30.

## Tests
- `./tests/test-plugin-validate.sh`
- `./tests/test-structure.sh`
- `./tests/test-codex-sync.sh`
- `./tests/test-opencode-sync.sh`