### PR TITLE
docs(contrib): activate CI, add .github scaffolding, README Develop section

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,138 @@
+# Contributing to llm-wiki
+
+Thanks for your interest in contributing. This guide covers the dev loop, the
+test layers, and the few non-obvious rules that will save you a round-trip
+on review.
+
+If you're an LLM agent reading this, the deeper "why" lives in
+[`CLAUDE.md`](../CLAUDE.md) at the repo root. This file is the human-facing
+quickstart.
+
+## Quick start
+
+```bash
+git clone https://github.com/nvk/llm-wiki.git
+cd llm-wiki
+./tests/test-plugin-validate.sh   # ~1s, no API key required
+./tests/test-structure.sh         # ~1s, no API key required
+```
+
+If both pass, your environment is good.
+
+## Repository layout
+
+The single source of truth is `claude-plugin/`. Everything in `plugins/` is
+**generated** — never hand-edit those files.
+
+```
+claude-plugin/                         # Source of truth for the Claude plugin
+  commands/*.md                        # Slash commands
+  skills/wiki-manager/SKILL.md         # Skill definition + fuzzy router
+  skills/wiki-manager/references/      # Behavioral reference docs
+
+plugins/llm-wiki/                      # GENERATED — Codex plugin mirror
+plugins/llm-wiki-opencode/             # GENERATED — OpenCode mirror
+
+scripts/sync-codex-plugin.sh           # Regenerates plugins/llm-wiki/
+scripts/sync-opencode-plugin.sh        # Regenerates plugins/llm-wiki-opencode/
+
+AGENTS.md                              # Portable single-file protocol
+
+tests/                                 # See "Test layers" below
+```
+
+If you change anything under `claude-plugin/skills/wiki-manager/`, both sync
+scripts must run before your PR will pass CI.
+
+## Test layers
+
+There are three tiers of tests. Run them in order — the cheap ones first.
+
+### 1. Structural (instant, no API key)
+
+These run on every PR. Run them locally before pushing.
+
+```bash
+./tests/test-plugin-validate.sh   # plugin manifest + command frontmatter
+./tests/test-structure.sh         # wiki fixture validation (~90 assertions)
+./tests/test-codex-sync.sh        # Codex mirror matches Claude source
+./tests/test-opencode-sync.sh     # OpenCode mirror matches Claude source
+```
+
+The two sync tests are **self-healing**: if they fail, the sync script has
+already regenerated the target directory. Stage the changes, commit, re-run.
+Read the FAIL message — it tells you exactly what to do.
+
+If you changed the golden wiki fixture, regenerate defect fixtures first:
+
+```bash
+./tests/generate-defect-fixtures.sh
+```
+
+### 2. Codex runtime smoke test (~30s, optional)
+
+Run this when you touch Codex packaging or the bootstrap flow.
+
+```bash
+./tests/test-codex-runtime.sh
+```
+
+### 3. Behavioral evals (slow, costs money)
+
+Run these when you change command logic or the fuzzy router.
+
+```bash
+npx promptfoo@latest eval -c tests/promptfooconfig.yaml
+```
+
+Requires `ANTHROPIC_API_KEY`. ~$2-5 per run. CI runs this automatically on
+every PR using the repo's API key.
+
+## The non-obvious rules
+
+A few rules that aren't enforced by the tests but will get a PR rejected:
+
+1. **Never hand-edit `plugins/llm-wiki/` or `plugins/llm-wiki-opencode/`.**
+   They are generated from `claude-plugin/`. If you need a runtime-specific
+   wording change, edit the corresponding sync script's replacement list.
+
+2. **Re-run both sync scripts after any change to
+   `claude-plugin/skills/wiki-manager/`.** The two sync tests will fail
+   otherwise.
+
+3. **Update `AGENTS.md` when the portable protocol changes.** AGENTS.md is
+   the single-file fallback for non-Claude agents — it has to stay in sync
+   with the canonical SKILL.md and references.
+
+4. **If you add a new lint rule:** add a defect fixture in
+   `generate-defect-fixtures.sh` and a negative test case in
+   `test-structure.sh`. CLAUDE.md has the full "When to update tests" list.
+
+5. **If you add a new reference file under
+   `claude-plugin/skills/wiki-manager/references/`:** `test-plugin-validate.sh`
+   has three `for ref in ...` loops (Claude existence, Codex copied-reference
+   validation, OpenCode symlink reachability) — add the new filename to all
+   three.
+
+## Pull request checklist
+
+Before opening a PR, please confirm:
+
+- [ ] Structural tests pass locally (`./tests/test-plugin-validate.sh && ./tests/test-structure.sh`)
+- [ ] If you edited `claude-plugin/skills/wiki-manager/`, both sync scripts have been re-run and the resulting `plugins/` changes are committed
+- [ ] If you added or removed a command, both `SKILL.md` and `README.md`'s command table are updated
+- [ ] If the portable protocol changed, `AGENTS.md` is updated to match
+- [ ] If you added a new lint rule, the defect fixture and structural test were both updated
+
+## Filing issues
+
+Use the issue templates — they ask for the information reviewers actually need:
+
+- **Bug report** — for something that's broken or behaves unexpectedly
+- **Feature request** — for new commands, new flags, or behavior changes
+
+## Questions?
+
+Open a `question`-labeled issue or comment on an existing one. Small process
+suggestions (better dev ergonomics, missing tests, doc gaps) are very
+welcome — most of them become good-first-issue tickets.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Something is broken or behaves unexpectedly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please include enough detail for someone else
+        to reproduce the issue without asking follow-up questions.
+
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime
+      description: Which client/runtime are you using?
+      options:
+        - Claude Code (native plugin)
+        - Codex (marketplace plugin)
+        - OpenCode (instructions URL)
+        - Pi (instructions file)
+        - Other / portable AGENTS.md
+        - Not runtime-specific
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: llm-wiki version
+      description: Output of `claude plugin list` / `codex plugin marketplace list` / commit SHA if running from source.
+      placeholder: "v0.5.1 (or commit 717e250)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the actual behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: A clear description of the expected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimum sequence of commands or actions to trigger the bug.
+      placeholder: |
+        1. Run `/wiki:research "topic" --new-topic`
+        2. Wait for round 2
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / output
+      description: Paste any error messages, stack traces, or anomalous output. Wrap in triple backticks.
+      render: shell
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, shell, anything else that might matter (e.g. running under nono sandbox, custom hub path).
+      placeholder: "macOS 14.5, zsh, hub at ~/Library/Mobile Documents/.../wiki"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Suggest a new command, flag, or behavior change
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Before filing, please scan the
+        existing issues — there's a good chance someone has already asked.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the user-facing pain point. Skip the proposed solution for a moment — what's the underlying gap?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work? A new command? A flag? A behavior change to an existing command?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways to solve the same problem, and why you didn't pick them.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Which surface does this touch?
+      multiple: true
+      options:
+        - A specific command
+        - The fuzzy router
+        - The skill / reference docs
+        - A sync script (Codex / OpenCode)
+        - Tests / CI
+        - Documentation
+        - Cross-runtime (Claude + Codex + OpenCode)
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this is done? List concrete, verifiable items.
+      placeholder: |
+        - [ ] `/wiki:research --new-flag` produces ...
+        - [ ] Promptfoo eval covers the new behavior
+        - [ ] README command table includes the flag

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for opening a PR. Please fill in the sections below — short answers
+are fine, but each one helps reviewers understand intent and scope.
+-->
+
+## What does this PR do?
+
+<!-- One or two sentences. The "why," not just the "what." -->
+
+## Linked issue
+
+<!-- e.g. Closes #42, Fixes #43, Refs #45. If there's no issue, briefly say why. -->
+
+## Type of change
+
+<!-- Check any that apply. -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Docs / dev experience only (no plugin behavior change)
+- [ ] Test or CI improvement
+
+## Pre-flight checklist
+
+- [ ] Structural tests pass locally (`./tests/test-plugin-validate.sh && ./tests/test-structure.sh`)
+- [ ] If I edited `claude-plugin/skills/wiki-manager/`, I re-ran both sync scripts and committed the resulting `plugins/` changes
+- [ ] If I edited a command or added a new one, the README command table is up to date
+- [ ] If the portable protocol changed, `AGENTS.md` matches the canonical Claude source
+- [ ] If I added a new lint rule, both `generate-defect-fixtures.sh` and `test-structure.sh` were updated
+- [ ] No files in `plugins/llm-wiki/` or `plugins/llm-wiki-opencode/` were hand-edited
+
+## Anything reviewers should know?
+
+<!-- Tradeoffs, follow-up work, areas you'd specifically like a second pair of eyes on. -->

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -6,10 +6,12 @@ on:
       - 'claude-plugin/**'
       - 'tests/**'
       - 'AGENTS.md'
+      - '.github/workflows/plugin-tests.yml'
   pull_request:
     paths:
       - 'claude-plugin/**'
       - 'tests/**'
+      - '.github/workflows/plugin-tests.yml'
 
 jobs:
   structural:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .claude/worktrees/
 .claude/plans/
 
+# Git worktrees (superpowers convention)
+.worktrees/
+
 # Codex local/project-local state
 .codex/
 .tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Requires `ANTHROPIC_API_KEY`. Costs ~$2-5 per run.
 - `tests/fixtures/defects/` — generated broken wikis (one per lint rule)
 - `tests/promptfooconfig.yaml` — Promptfoo behavioral eval config
 - `tests/evals/assertions/*.js` — custom JS assertions for file-system checks
-- `tests/ci/plugin-tests.yml` — GitHub Actions workflow (copy to `.github/workflows/` to activate)
+- `.github/workflows/plugin-tests.yml` — GitHub Actions workflow (runs on every PR + push)
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 [github.com/nvk/llm-wiki](https://github.com/nvk/llm-wiki)
 
+[![Plugin Tests](https://github.com/nvk/llm-wiki/actions/workflows/plugin-tests.yml/badge.svg)](https://github.com/nvk/llm-wiki/actions/workflows/plugin-tests.yml)
+
 LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, thesis-driven investigation, source ingestion, wiki compilation, truth-seeking audits, querying, and artifact generation. Ships as a Claude Code plugin, an OpenAI Codex plugin, an OpenCode instruction file, or a portable AGENTS.md for any other LLM agent. Obsidian-compatible.
 
 ---
@@ -511,6 +513,28 @@ Claude Code is the compiler. Obsidian is an optional viewer.
 | Standard | *(default)* | Reads relevant articles + full-text search. For most questions. |
 | Deep | `--deep` | Reads everything, searches raw sources, peeks sibling wikis. For complex questions. |
 | List | `--list` | Returns ranked article list instead of synthesized answer. Supports `--tag` and `--category` filters. |
+
+## Develop
+
+Contributions welcome. See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for the
+full workflow, the test layers, and the non-obvious rules (don't hand-edit
+the generated `plugins/` mirrors, re-run the sync scripts after editing
+`claude-plugin/skills/wiki-manager/`, etc.).
+
+Quick start:
+
+```bash
+./tests/test-plugin-validate.sh   # ~1s — manifest + frontmatter checks
+./tests/test-structure.sh         # ~1s — wiki fixture validation
+./tests/test-codex-sync.sh        # ~1s — Codex mirror drift
+./tests/test-opencode-sync.sh     # ~1s — OpenCode mirror drift
+```
+
+Behavioral evals (`npx promptfoo@latest eval -c tests/promptfooconfig.yaml`)
+require `ANTHROPIC_API_KEY` and cost ~$2-5 per run. CI runs them on every PR.
+
+For LLM agents working in this repo, [`CLAUDE.md`](CLAUDE.md) is the deeper
+dev guide.
 
 ## Credits
 


### PR DESCRIPTION
Onboarding bundle for outside contributors. Three changes that travel together — pure docs / dev experience, no plugin behavior change.

## What this PR does

- **Move `tests/ci/plugin-tests.yml` → `.github/workflows/plugin-tests.yml`** so GitHub Actions actually runs the workflow on every PR/push. Add the workflow file itself to the `paths:` filter so changes to it re-trigger CI. Drop the now-stale "copy to `.github/workflows/` to activate" line from `CLAUDE.md`. (Closes #32)
- **Add `.github/` scaffolding** for outside contributors:
  - `.github/CONTRIBUTING.md` — quickstart, the three test layers, the non-obvious rules ("never hand-edit `plugins/`", re-run sync scripts after editing the wiki-manager skill, etc.), PR checklist
  - `.github/ISSUE_TEMPLATE/bug_report.yml` — runtime / version / repro / logs / environment fields
  - `.github/ISSUE_TEMPLATE/feature_request.yml` — problem / proposal / scope / acceptance-criteria fields
  - `.github/PULL_REQUEST_TEMPLATE.md` — pre-flight checklist mirroring the rules in CONTRIBUTING (Closes #33)
- **README**: CI status badge near the top + a short **Develop** section above Credits pointing new contributors at CONTRIBUTING.md and the structural tests. Uses the actual script paths today; once #34 (Makefile) lands, a follow-up can swap them for `make` targets. (Closes #45)

## Verification

All four structural tests pass on the branch:

```
./tests/test-plugin-validate.sh   →  70 passed, 0 failed
./tests/test-structure.sh         →  92 passed, 0 failed
./tests/test-codex-sync.sh        →  Codex plugin mirror is in sync
./tests/test-opencode-sync.sh     →  OpenCode plugin mirror is in sync
```

All three new YAML files (`plugin-tests.yml`, `bug_report.yml`, `feature_request.yml`) parse cleanly via `ruby -ryaml -e 'YAML.load_file(...)'`.

The workflow rename preserves git history (96% similarity threshold).

## Pre-flight checklist

- [x] Structural tests pass locally
- [x] No edits under `claude-plugin/skills/wiki-manager/` (sync scripts not needed)
- [x] No command additions/removals (no README command-table or SKILL.md update needed)
- [x] No portable-protocol changes (`AGENTS.md` not touched)
- [x] No new lint rules
- [x] No hand-edits in `plugins/llm-wiki/` or `plugins/llm-wiki-opencode/`

## Notes for review

- The CI badge URL points at `actions/workflows/plugin-tests.yml/badge.svg` — that path will only resolve once the workflow is at the new location, so it'll go green only after this PR merges. Expected.
- I deliberately did not touch the workflow's `permissions:` block, the `gh pr comment` step, or the behavioral-eval secret wiring — those are out of scope for "make CI run" and would need a separate review.
- The PR template lives at `.github/PULL_REQUEST_TEMPLATE.md`. The template you're reading right now is the one this PR is adding — meta, but that's the test.