### PR TITLE
Add experimental model router packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@
 .codex/
 .tmp/
 
+# llm-wiki runtime-local sidecar state
+.runtime/
+
 # macOS
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ All content lives here. One topic per wiki. Isolated indexes, focused queries.
 ├── .obsidian/                     # Obsidian vault config (optional)
 ├── .librarian/                    # Optional: wiki-only maintenance reports
 ├── .audit/                        # Optional: umbrella audit reports
+├── .runtime/                      # Optional local sidecar config, ignored by indexes
 ├── _index.md                      # Master index: stats, navigation, recent changes
 ├── config.md                      # Title, scope, conventions
 ├── log.md                         # Activity log for this topic
@@ -99,6 +100,7 @@ Same structure as a topic wiki but at `<project>/.wiki/`. Add `.wiki/` to `.giti
 8. **Multi-wiki peek.** When querying, answer from the target wiki, then peek at sibling wiki `_index.md` files for overlap.
 9. **Confidence scoring.** Articles get `confidence: high|medium|low` in frontmatter based on source quality.
 10. **Activity log.** Append every operation to `log.md`. Format: `## [YYYY-MM-DD] operation | Description`. Never edit existing entries.
+11. **Experimental sidecars are opt-in.** If a model router or other local sidecar is configured under `.runtime/` or `~/.config/llm-wiki/`, use it only when explicitly requested. Sidecar workers return proposals; the agent remains the only filesystem writer.
 
 ## File Formats
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ claude-plugin/                  — source of truth, primary distribution target
   commands/*.md                 — 16 command files (15 user commands + wiki router)
   skills/wiki-manager/
     SKILL.md                    — skill manifest + fuzzy router
-    references/*.md             — 10 reference docs (hub-resolution, linting, audit, etc.)
+    references/*.md             — shared workflow references (hub-resolution, linting, audit, model-router, etc.)
   .claude-plugin/
     plugin.json                 — plugin manifest
 plugins/llm-wiki/               — generated Codex packaging mirror (do NOT hand-edit)
@@ -108,6 +108,8 @@ plugins/llm-wiki-opencode/      — generated OpenCode packaging mirror (do NOT 
 .agents/plugins/marketplace.json — repo-local Codex marketplace entry
 scripts/sync-codex-plugin.sh    — regenerates plugins/llm-wiki/ from claude-plugin/
 scripts/sync-opencode-plugin.sh — regenerates plugins/llm-wiki-opencode/ from claude-plugin/
+scripts/wiki-router             — optional experimental model-router sidecar client
+examples/model-router.yaml      — placeholder config for the dormant router
 AGENTS.md                       — portable single-file protocol for non-Claude agents
 tests/                          — test suite (see above)
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, th
 
 ---
 
-[Install](#install) · [Quick Start](#quick-start) · [Commands](#commands) · [How It Works](#how-it-works) · [Research Modes](#research-modes) · [Thesis Research](#thesis-driven-research) · [Query Depths](#query-depths) · [Linking](#linking-works-everywhere) · [Obsidian](#obsidian-integration) · [Architecture](#claude-first-multi-runtime) · [Nono Sandbox](#nono-sandbox-permissions) · [Upgrade](#upgrade) · [Changelog](#changelog) · [Credits](#credits)
+[Install](#install) · [Quick Start](#quick-start) · [Commands](#commands) · [How It Works](#how-it-works) · [Research Modes](#research-modes) · [Thesis Research](#thesis-driven-research) · [Query Depths](#query-depths) · [Linking](#linking-works-everywhere) · [Obsidian](#obsidian-integration) · [Architecture](#claude-first-multi-runtime) · [Model Router](#experimental-model-router) · [Nono Sandbox](#nono-sandbox-permissions) · [Upgrade](#upgrade) · [Changelog](#changelog) · [Credits](#credits)
 
 ---
 
@@ -165,6 +165,46 @@ Each sync script:
 Drift is caught by `./tests/test-codex-sync.sh` and `./tests/test-opencode-sync.sh`, which run the sync scripts and fail (with self-healing fix instructions) if the generated directories differ from `HEAD`.
 
 Practical rule: design workflows first for Claude commands and behavior, but keep the underlying knowledge model and references runtime-neutral. Runtime wrappers adapt invocation and metadata, not wiki logic.
+
+## Experimental Model Router
+
+llm-wiki ships a dormant multi-model router protocol for local/open model
+experiments. It is disabled by default and does not change normal wiki behavior.
+
+Package contents:
+
+- `claude-plugin/skills/wiki-manager/references/model-router.md` — shared opt-in protocol
+- `examples/model-router.yaml` — placeholder config with no secrets or real endpoints
+- `scripts/wiki-router` — tiny stdlib-only OpenAI-compatible helper for `chat`, `embed`, and `rerank`
+- `tests/test-model-router-disabled.sh` and `tests/test-model-router-config-parse.sh` — dependency-free packaging checks
+
+Enable explicitly:
+
+```bash
+export LLM_WIKI_MODEL_ROUTER=1
+export LLM_WIKI_MODEL_ROUTER_CONFIG=~/.config/llm-wiki/model-router.yaml
+```
+
+Dry-run without any live models:
+
+```bash
+./scripts/wiki-router --config examples/model-router.yaml status
+./scripts/wiki-router --config examples/model-router.yaml --dry-run chat \
+  --role synthesize \
+  --prompt "Summarize this wiki source."
+```
+
+Runtime config is local state, not wiki content. Put it in one of:
+
+```text
+~/.config/llm-wiki/model-router.yaml
+<hub>/.runtime/model-router.yaml
+<topic>/.runtime/model-router.yaml
+```
+
+The orchestrating agent remains the only filesystem writer. Local model workers
+return proposals for synthesis, compilation, retrieval, reranking, or critic
+passes; the orchestrator validates paths and citations before writing anything.
 
 ## Nono Sandbox Permissions
 

--- a/claude-plugin/skills/wiki-manager/SKILL.md
+++ b/claude-plugin/skills/wiki-manager/SKILL.md
@@ -151,6 +151,15 @@ notice it without treating it as factual evidence:
   records for durable follow-ups, stale items, source queues, or watch lists,
   but show a sample before creating a larger backlog.
 
+### Experimental Model Router
+See [references/model-router.md](references/model-router.md).
+This workflow is dormant by default. Only use it when the user explicitly asks
+for the model router/multi-model local stack, `LLM_WIKI_MODEL_ROUTER=1` is
+present, or an explicit experimental model-router flag is in scope. The
+orchestrating agent remains the only filesystem writer; local model workers
+return proposals for synthesis, compilation, retrieval, reranking, or critic
+passes.
+
 ### Output
 Flow: Gather relevant articles → generate artifact (summary/report/slides/etc) → save to `output/` → update indexes.
 

--- a/claude-plugin/skills/wiki-manager/references/model-router.md
+++ b/claude-plugin/skills/wiki-manager/references/model-router.md
@@ -1,0 +1,186 @@
+# Experimental Model Router
+
+The model router is an optional sidecar for calling local or OpenAI-compatible
+model endpoints from llm-wiki workflows. It is disabled by default. Normal wiki
+behavior must not change unless the user explicitly enables it.
+
+## Activation
+
+Only use this workflow when one of these is true:
+
+- The user explicitly asks to use the model router or multi-model local stack.
+- `LLM_WIKI_MODEL_ROUTER=1` is present in the environment.
+- A command or workflow explicitly includes `--experimental-model-router`.
+
+If none of those are true, ignore this reference and use the normal wiki
+workflow.
+
+## Configuration
+
+Runtime config is local machine state, not wiki content. Prefer this precedence:
+
+1. Command flag: `--model-router-config <path>`
+2. `LLM_WIKI_MODEL_ROUTER_CONFIG`
+3. Active topic: `<topic>/.runtime/model-router.yaml`
+4. Hub default: `<hub>/.runtime/model-router.yaml`
+5. User default: `~/.config/llm-wiki/model-router.yaml`
+
+Do not write endpoints, API keys, or LAN hostnames into `config.md`, `raw/`,
+compiled `wiki/` articles, or normal output artifacts. `.runtime/` directories
+are operational state and should be ignored by indexes, lint, and compilation.
+
+## Roles
+
+Use roles, not hardcoded model names, from wiki workflows:
+
+```yaml
+models:
+  synthesize:
+    model: qwen3.6-35b-a3b
+    endpoint: http://m5-max:11434/v1
+    use_for: [query, research_summary, source_synthesis, planning]
+
+  compiler:
+    model: qwen3-coder-next
+    endpoint: http://spark:8000/v1
+    use_for: [compile, article_update, frontmatter, crosslinks, indexes]
+
+  embed:
+    model: qwen3-embedding-8b
+    endpoint: http://spark:8081/v1
+    use_for: [search, dedup, source_recall, article_similarity]
+
+  rerank:
+    model: qwen3-reranker-8b
+    endpoint: http://spark:8082/v1
+    use_for: [claim_support, source_ordering, contamination_control]
+
+  critic:
+    model: qwen3.6-35b-a3b
+    endpoint: http://m5-max:11434/v1
+    use_for: [verify_article, find_unsupported_claims, staleness_check]
+```
+
+## Command Wiring
+
+### Query
+
+```text
+embed query
+-> retrieve raw/wiki candidates
+-> rerank
+-> synthesize answer with citations
+```
+
+Query is the first experiment because it can stay read-only.
+
+### Compile
+
+```text
+embed source/article candidates
+-> rerank support docs
+-> compiler drafts an article/update proposal
+-> critic checks source support
+-> orchestrator applies edits
+```
+
+The compiler model returns a proposal. The orchestrating agent owns every file
+write, index update, log append, and checkpoint update.
+
+### Research
+
+```text
+orchestrator collects sources
+-> synthesize summaries and gaps
+-> embed/rerank against existing wiki
+-> compiler proposes raw notes or outputs
+-> critic pass before durable writes
+```
+
+### Librarian / Audit
+
+```text
+extract claims
+-> retrieve supporting sources
+-> rerank
+-> critic labels supported / weak / contradicted / stale
+```
+
+## Write Barrier
+
+Model workers must not edit files directly. They return JSON or markdown
+proposals. The orchestrator validates paths, citations, and ownership before
+writing anything.
+
+Preferred proposal shape:
+
+```yaml
+role: compiler
+model: qwen3-coder-next
+target_files:
+  - wiki/topics/example.md
+proposal_type: patch
+citations:
+  - raw/articles/source.md
+unsupported_claims: []
+confidence: medium
+```
+
+Reject or revise a proposal when:
+
+- It targets files outside the active wiki.
+- It cites sources that do not exist.
+- It contains unsupported durable claims.
+- It would overwrite unrelated user edits.
+- It tries to edit generated indexes without also updating source files, unless
+  the workflow is explicitly rebuilding derived indexes.
+
+## Logging
+
+When the router is active, append model provenance to `.session-events.jsonl`:
+
+```json
+{"phase":"router","role":"synthesize","model":"qwen3.6-35b-a3b","endpoint":"http://m5-max:11434/v1","input_artifacts":["raw/articles/a.md"],"output_artifacts":["output/experiments/query.json"]}
+```
+
+Do not log prompts containing secrets or full private documents unless the user
+explicitly asked for that provenance detail. Prefer artifact ids and file paths.
+
+## Packaging
+
+The package may ship:
+
+- This reference document.
+- `examples/model-router.yaml` with placeholder endpoints only.
+- `scripts/wiki-router`, a small OpenAI-compatible helper.
+- Tests that validate disabled/default behavior and config parsing.
+
+The package must not ship real endpoints, API keys, personal LAN hostnames, or
+machine-specific runtime config.
+
+## First Safe Experiment
+
+Use read-only query shadow mode:
+
+```text
+normal wiki query
+parallel router query: embed -> rerank -> synthesize
+save comparison under output/experiments/
+do not modify raw/wiki/index/log files except the explicit experiment output
+```
+
+After that works, test compile proposal mode:
+
+```text
+compiler proposal -> critic review -> human/orchestrator applies patch
+```
+
+## Guardrails
+
+- Router is opt-in and disabled by default.
+- Worker models return proposals; orchestrator writes.
+- Retrieval/reranking should precede durable claims.
+- Use a critic pass before compilation writes.
+- Keep cloud fallback for high-stakes audits and disputed claims.
+- Do not let router config become wiki knowledge.
+

--- a/examples/model-router.yaml
+++ b/examples/model-router.yaml
@@ -1,0 +1,42 @@
+# Example llm-wiki model router config.
+#
+# Copy to one of:
+#   ~/.config/llm-wiki/model-router.yaml
+#   <hub>/.runtime/model-router.yaml
+#   <topic>/.runtime/model-router.yaml
+#
+# This file is intentionally inert: endpoints are placeholders and no API keys
+# are included. Enable with LLM_WIKI_MODEL_ROUTER=1 or an explicit experimental
+# model-router flag in the calling workflow.
+
+models:
+  synthesize:
+    model: qwen3.6-35b-a3b
+    endpoint: http://m5-max.local:11434/v1
+    use_for: [query, research_summary, source_synthesis, planning]
+    api_key_env: LLM_WIKI_ROUTER_API_KEY
+
+  compiler:
+    model: qwen3-coder-next
+    endpoint: http://spark.local:8000/v1
+    use_for: [compile, article_update, frontmatter, crosslinks, indexes]
+    api_key_env: LLM_WIKI_ROUTER_API_KEY
+
+  embed:
+    model: qwen3-embedding-8b
+    endpoint: http://spark.local:8081/v1
+    use_for: [search, dedup, source_recall, article_similarity]
+    api_key_env: LLM_WIKI_ROUTER_API_KEY
+
+  rerank:
+    model: qwen3-reranker-8b
+    endpoint: http://spark.local:8082/v1
+    use_for: [claim_support, source_ordering, contamination_control]
+    api_key_env: LLM_WIKI_ROUTER_API_KEY
+
+  critic:
+    model: qwen3.6-35b-a3b
+    endpoint: http://m5-max.local:11434/v1
+    use_for: [verify_article, find_unsupported_claims, staleness_check]
+    api_key_env: LLM_WIKI_ROUTER_API_KEY
+

--- a/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
+++ b/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
@@ -146,6 +146,15 @@ notice it without treating it as factual evidence:
   records for durable follow-ups, stale items, source queues, or watch lists,
   but show a sample before creating a larger backlog.
 
+### Experimental Model Router
+See [references/model-router.md](references/model-router.md).
+This workflow is dormant by default. Only use it when the user explicitly asks
+for the model router/multi-model local stack, `LLM_WIKI_MODEL_ROUTER=1` is
+present, or an explicit experimental model-router flag is in scope. The
+orchestrating agent remains the only filesystem writer; local model workers
+return proposals for synthesis, compilation, retrieval, reranking, or critic
+passes.
+
 ### Output
 Flow: Gather relevant articles → generate artifact (summary/report/slides/etc) → save to `output/` → update indexes.
 

--- a/plugins/llm-wiki/skills/wiki/SKILL.md
+++ b/plugins/llm-wiki/skills/wiki/SKILL.md
@@ -106,6 +106,8 @@ reference material you need for that workflow:
 - `research`, `plan`, `output`, `assess` → `references/research-infrastructure.md`
 - `project` → `references/projects.md`
 - `librarian` → `references/librarian.md`
+- experimental model router → `references/model-router.md` (opt-in only; the
+  orchestrating agent remains the only filesystem writer)
 - wiki structure, indexes, log format, file placement, init → `references/wiki-structure.md`
 - hub lookup and path handling → `references/hub-resolution.md`
 

--- a/plugins/llm-wiki/skills/wiki/references/model-router.md
+++ b/plugins/llm-wiki/skills/wiki/references/model-router.md
@@ -1,0 +1,186 @@
+# Experimental Model Router
+
+The model router is an optional sidecar for calling local or OpenAI-compatible
+model endpoints from llm-wiki workflows. It is disabled by default. Normal wiki
+behavior must not change unless the user explicitly enables it.
+
+## Activation
+
+Only use this workflow when one of these is true:
+
+- The user explicitly asks to use the model router or multi-model local stack.
+- `LLM_WIKI_MODEL_ROUTER=1` is present in the environment.
+- A command or workflow explicitly includes `--experimental-model-router`.
+
+If none of those are true, ignore this reference and use the normal wiki
+workflow.
+
+## Configuration
+
+Runtime config is local machine state, not wiki content. Prefer this precedence:
+
+1. Command flag: `--model-router-config <path>`
+2. `LLM_WIKI_MODEL_ROUTER_CONFIG`
+3. Active topic: `<topic>/.runtime/model-router.yaml`
+4. Hub default: `<hub>/.runtime/model-router.yaml`
+5. User default: `~/.config/llm-wiki/model-router.yaml`
+
+Do not write endpoints, API keys, or LAN hostnames into `config.md`, `raw/`,
+compiled `wiki/` articles, or normal output artifacts. `.runtime/` directories
+are operational state and should be ignored by indexes, lint, and compilation.
+
+## Roles
+
+Use roles, not hardcoded model names, from wiki workflows:
+
+```yaml
+models:
+  synthesize:
+    model: qwen3.6-35b-a3b
+    endpoint: http://m5-max:11434/v1
+    use_for: [query, research_summary, source_synthesis, planning]
+
+  compiler:
+    model: qwen3-coder-next
+    endpoint: http://spark:8000/v1
+    use_for: [compile, article_update, frontmatter, crosslinks, indexes]
+
+  embed:
+    model: qwen3-embedding-8b
+    endpoint: http://spark:8081/v1
+    use_for: [search, dedup, source_recall, article_similarity]
+
+  rerank:
+    model: qwen3-reranker-8b
+    endpoint: http://spark:8082/v1
+    use_for: [claim_support, source_ordering, contamination_control]
+
+  critic:
+    model: qwen3.6-35b-a3b
+    endpoint: http://m5-max:11434/v1
+    use_for: [verify_article, find_unsupported_claims, staleness_check]
+```
+
+## Command Wiring
+
+### Query
+
+```text
+embed query
+-> retrieve raw/wiki candidates
+-> rerank
+-> synthesize answer with citations
+```
+
+Query is the first experiment because it can stay read-only.
+
+### Compile
+
+```text
+embed source/article candidates
+-> rerank support docs
+-> compiler drafts an article/update proposal
+-> critic checks source support
+-> orchestrator applies edits
+```
+
+The compiler model returns a proposal. The orchestrating agent owns every file
+write, index update, log append, and checkpoint update.
+
+### Research
+
+```text
+orchestrator collects sources
+-> synthesize summaries and gaps
+-> embed/rerank against existing wiki
+-> compiler proposes raw notes or outputs
+-> critic pass before durable writes
+```
+
+### Librarian / Audit
+
+```text
+extract claims
+-> retrieve supporting sources
+-> rerank
+-> critic labels supported / weak / contradicted / stale
+```
+
+## Write Barrier
+
+Model workers must not edit files directly. They return JSON or markdown
+proposals. The orchestrator validates paths, citations, and ownership before
+writing anything.
+
+Preferred proposal shape:
+
+```yaml
+role: compiler
+model: qwen3-coder-next
+target_files:
+  - wiki/topics/example.md
+proposal_type: patch
+citations:
+  - raw/articles/source.md
+unsupported_claims: []
+confidence: medium
+```
+
+Reject or revise a proposal when:
+
+- It targets files outside the active wiki.
+- It cites sources that do not exist.
+- It contains unsupported durable claims.
+- It would overwrite unrelated user edits.
+- It tries to edit generated indexes without also updating source files, unless
+  the workflow is explicitly rebuilding derived indexes.
+
+## Logging
+
+When the router is active, append model provenance to `.session-events.jsonl`:
+
+```json
+{"phase":"router","role":"synthesize","model":"qwen3.6-35b-a3b","endpoint":"http://m5-max:11434/v1","input_artifacts":["raw/articles/a.md"],"output_artifacts":["output/experiments/query.json"]}
+```
+
+Do not log prompts containing secrets or full private documents unless the user
+explicitly asked for that provenance detail. Prefer artifact ids and file paths.
+
+## Packaging
+
+The package may ship:
+
+- This reference document.
+- `examples/model-router.yaml` with placeholder endpoints only.
+- `scripts/wiki-router`, a small OpenAI-compatible helper.
+- Tests that validate disabled/default behavior and config parsing.
+
+The package must not ship real endpoints, API keys, personal LAN hostnames, or
+machine-specific runtime config.
+
+## First Safe Experiment
+
+Use read-only query shadow mode:
+
+```text
+normal wiki query
+parallel router query: embed -> rerank -> synthesize
+save comparison under output/experiments/
+do not modify raw/wiki/index/log files except the explicit experiment output
+```
+
+After that works, test compile proposal mode:
+
+```text
+compiler proposal -> critic review -> human/orchestrator applies patch
+```
+
+## Guardrails
+
+- Router is opt-in and disabled by default.
+- Worker models return proposals; orchestrator writes.
+- Retrieval/reranking should precede durable claims.
+- Use a critic pass before compilation writes.
+- Keep cloud fallback for high-stakes audits and disputed claims.
+- Do not let router config become wiki knowledge.
+

--- a/scripts/sync-codex-plugin.sh
+++ b/scripts/sync-codex-plugin.sh
@@ -154,6 +154,8 @@ reference material you need for that workflow:
 - `research`, `plan`, `output`, `assess` → `references/research-infrastructure.md`
 - `project` → `references/projects.md`
 - `librarian` → `references/librarian.md`
+- experimental model router → `references/model-router.md` (opt-in only; the
+  orchestrating agent remains the only filesystem writer)
 - wiki structure, indexes, log format, file placement, init → `references/wiki-structure.md`
 - hub lookup and path handling → `references/hub-resolution.md`
 

--- a/scripts/wiki-router
+++ b/scripts/wiki-router
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Optional OpenAI-compatible sidecar client for llm-wiki model routing.
+
+This helper never writes wiki files. It reads local router config, prints status
+or dry-run payloads, and can call chat/embedding/rerank endpoints when the
+experimental router is explicitly enabled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+ENABLE_ENV = "LLM_WIKI_MODEL_ROUTER"
+CONFIG_ENV = "LLM_WIKI_MODEL_ROUTER_CONFIG"
+
+
+def parse_scalar(value: str) -> Any:
+    value = value.strip()
+    if not value:
+        return ""
+    if value in {"true", "True"}:
+        return True
+    if value in {"false", "False"}:
+        return False
+    if value in {"null", "None", "~"}:
+        return None
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        if not inner:
+            return []
+        return [parse_scalar(part.strip()) for part in inner.split(",")]
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def parse_simple_yaml(text: str) -> dict[str, Any]:
+    """Parse the limited YAML subset used by examples/model-router.yaml."""
+    root: dict[str, Any] = {}
+    stack: list[tuple[int, dict[str, Any]]] = [(-1, root)]
+
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        raw = raw.rstrip()
+        indent = len(raw) - len(raw.lstrip(" "))
+        line = raw.strip()
+        if ":" not in line:
+            raise ValueError(f"line {lineno}: expected key: value")
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise ValueError(f"line {lineno}: empty key")
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        if not stack:
+            raise ValueError(f"line {lineno}: invalid indentation")
+        parent = stack[-1][1]
+        if value == "":
+            child: dict[str, Any] = {}
+            parent[key] = child
+            stack.append((indent, child))
+        else:
+            parent[key] = parse_scalar(value)
+    return root
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"model router config not found: {path}")
+    text = path.read_text()
+    if path.suffix == ".json":
+        data = json.loads(text)
+    else:
+        data = parse_simple_yaml(text)
+    if not isinstance(data, dict) or not isinstance(data.get("models"), dict):
+        raise ValueError("config must contain a top-level 'models' mapping")
+    for role, spec in data["models"].items():
+        if not isinstance(spec, dict):
+            raise ValueError(f"role {role!r} must map to an object")
+        if "model" not in spec:
+            raise ValueError(f"role {role!r} is missing model")
+        if "endpoint" not in spec and "base_url" not in spec:
+            raise ValueError(f"role {role!r} is missing endpoint/base_url")
+    return data
+
+
+def default_config_candidates() -> list[Path]:
+    candidates: list[Path] = []
+    if os.environ.get(CONFIG_ENV):
+        candidates.append(Path(os.environ[CONFIG_ENV]).expanduser())
+    candidates.append(Path.cwd() / ".runtime" / "model-router.yaml")
+    candidates.append(Path.home() / ".config" / "llm-wiki" / "model-router.yaml")
+    return candidates
+
+
+def resolve_config(path_arg: str | None) -> Path | None:
+    if path_arg:
+        return Path(path_arg).expanduser()
+    for candidate in default_config_candidates():
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def router_enabled(args: argparse.Namespace) -> bool:
+    return bool(args.enable or os.environ.get(ENABLE_ENV) == "1")
+
+
+def role_spec(config: dict[str, Any], role: str) -> dict[str, Any]:
+    models = config.get("models", {})
+    if role not in models:
+        raise KeyError(f"role not found in model router config: {role}")
+    return models[role]
+
+
+def endpoint_for(spec: dict[str, Any], kind: str) -> str:
+    base = str(spec.get("endpoint") or spec.get("base_url")).rstrip("/")
+    if base.endswith(("/chat/completions", "/embeddings", "/rerank")):
+        return base
+    if kind == "chat":
+        return f"{base}/chat/completions"
+    if kind == "embed":
+        return f"{base}/embeddings"
+    if kind == "rerank":
+        return f"{base}/rerank"
+    raise ValueError(f"unknown endpoint kind: {kind}")
+
+
+def headers_for(spec: dict[str, Any]) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    api_key_env = spec.get("api_key_env")
+    if api_key_env and os.environ.get(str(api_key_env)):
+        headers["Authorization"] = f"Bearer {os.environ[str(api_key_env)]}"
+    return headers
+
+
+def post_json(url: str, payload: dict[str, Any], headers: dict[str, str]) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code} from {url}: {body}") from exc
+
+
+def read_text_input(args: argparse.Namespace) -> str:
+    if getattr(args, "prompt", None):
+        return args.prompt
+    if getattr(args, "input", None):
+        return Path(args.input).read_text()
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    raise SystemExit("provide --prompt, --input, or stdin")
+
+
+def print_json(data: Any) -> None:
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    config_path = resolve_config(args.config)
+    status: dict[str, Any] = {
+        "enabled": router_enabled(args),
+        "enable_env": ENABLE_ENV,
+        "config_env": CONFIG_ENV,
+        "config_path": str(config_path) if config_path else None,
+        "roles": [],
+    }
+    if config_path:
+        config = load_config(config_path)
+        status["roles"] = sorted(config.get("models", {}).keys())
+    print_json(status)
+    return 0
+
+
+def load_required_config(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
+    config_path = resolve_config(args.config)
+    if not config_path:
+        raise SystemExit(
+            "model router config not found; pass --config or set "
+            f"{CONFIG_ENV}. Router is disabled by default."
+        )
+    return config_path, load_config(config_path)
+
+
+def maybe_print_dry_run(
+    kind: str,
+    args: argparse.Namespace,
+    role: str,
+    spec: dict[str, Any],
+    payload: dict[str, Any],
+) -> bool:
+    if args.dry_run:
+        print_json(
+            {
+                "dry_run": True,
+                "kind": kind,
+                "role": role,
+                "model": spec["model"],
+                "endpoint": endpoint_for(spec, kind),
+                "payload": payload,
+            }
+        )
+        return True
+    return False
+
+
+def ensure_enabled(args: argparse.Namespace) -> None:
+    if not router_enabled(args):
+        raise SystemExit(
+            f"model router disabled; set {ENABLE_ENV}=1 or pass --enable. "
+            "Use --dry-run to inspect payloads without enabling."
+        )
+
+
+def cmd_chat(args: argparse.Namespace) -> int:
+    _, config = load_required_config(args)
+    spec = role_spec(config, args.role)
+    payload = {
+        "model": spec["model"],
+        "messages": [{"role": "user", "content": read_text_input(args)}],
+        "temperature": args.temperature,
+    }
+    if maybe_print_dry_run("chat", args, args.role, spec, payload):
+        return 0
+    ensure_enabled(args)
+    print_json(post_json(endpoint_for(spec, "chat"), payload, headers_for(spec)))
+    return 0
+
+
+def cmd_embed(args: argparse.Namespace) -> int:
+    _, config = load_required_config(args)
+    spec = role_spec(config, args.role)
+    payload = {"model": spec["model"], "input": read_text_input(args)}
+    if maybe_print_dry_run("embed", args, args.role, spec, payload):
+        return 0
+    ensure_enabled(args)
+    print_json(post_json(endpoint_for(spec, "embed"), payload, headers_for(spec)))
+    return 0
+
+
+def cmd_rerank(args: argparse.Namespace) -> int:
+    _, config = load_required_config(args)
+    spec = role_spec(config, args.role)
+    if args.documents_json:
+        documents = json.loads(args.documents_json)
+    elif args.documents_file:
+        documents = json.loads(Path(args.documents_file).read_text())
+    else:
+        raise SystemExit("rerank requires --documents-json or --documents-file")
+    payload = {"model": spec["model"], "query": args.query, "documents": documents}
+    if maybe_print_dry_run("rerank", args, args.role, spec, payload):
+        return 0
+    ensure_enabled(args)
+    print_json(post_json(endpoint_for(spec, "rerank"), payload, headers_for(spec)))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", help="Path to model-router.yaml/json")
+    parser.add_argument("--enable", action="store_true", help="Enable live endpoint calls")
+    parser.add_argument("--dry-run", action="store_true", help="Print payload instead of calling endpoint")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    status = sub.add_parser("status", help="Show router enabled/config status")
+    status.set_defaults(func=cmd_status)
+
+    chat = sub.add_parser("chat", help="Call a chat role")
+    chat.add_argument("--role", default="synthesize")
+    chat.add_argument("--prompt")
+    chat.add_argument("--input")
+    chat.add_argument("--temperature", type=float, default=0.2)
+    chat.set_defaults(func=cmd_chat)
+
+    embed = sub.add_parser("embed", help="Call an embedding role")
+    embed.add_argument("--role", default="embed")
+    embed.add_argument("--prompt")
+    embed.add_argument("--input")
+    embed.set_defaults(func=cmd_embed)
+
+    rerank = sub.add_parser("rerank", help="Call a reranking role")
+    rerank.add_argument("--role", default="rerank")
+    rerank.add_argument("--query", required=True)
+    rerank.add_argument("--documents-json")
+    rerank.add_argument("--documents-file")
+    rerank.set_defaults(func=cmd_rerank)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return args.func(args)
+    except Exception as exc:
+        print(f"wiki-router: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,10 @@ No LLM calls. Validates wiki file structure, frontmatter schema, index integrity
 
 # Validate plugin manifest
 ./tests/test-plugin-validate.sh
+
+# Validate experimental model-router packaging stays dormant and parseable
+./tests/test-model-router-disabled.sh
+./tests/test-model-router-config-parse.sh
 ```
 
 ### What it checks
@@ -28,6 +32,8 @@ No LLM calls. Validates wiki file structure, frontmatter schema, index integrity
 - C6: No orphan sources (via defect fixture)
 - C11: File placement matches frontmatter type/category
 - C12: No unknown file types in raw/wiki directories
+- Packaging: the experimental model router is disabled by default and its
+  example config generates valid dry-run payloads without live model endpoints
 
 ### Defect fixtures
 

--- a/tests/ci/plugin-tests.yml
+++ b/tests/ci/plugin-tests.yml
@@ -30,6 +30,15 @@ jobs:
       - name: Verify Codex plugin sync
         run: chmod +x tests/test-codex-sync.sh && ./tests/test-codex-sync.sh
 
+      - name: Verify OpenCode plugin sync
+        run: chmod +x tests/test-opencode-sync.sh && ./tests/test-opencode-sync.sh
+
+      - name: Verify model router packaging
+        run: |
+          chmod +x tests/test-model-router-disabled.sh tests/test-model-router-config-parse.sh
+          ./tests/test-model-router-disabled.sh
+          ./tests/test-model-router-config-parse.sh
+
   behavioral:
     name: "Layer 2: Behavioral Evals"
     runs-on: ubuntu-latest

--- a/tests/test-model-router-config-parse.sh
+++ b/tests/test-model-router-config-parse.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Validate the packaged example config and dry-run payload generation.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CONFIG="examples/model-router.yaml"
+
+STATUS="$(LLM_WIKI_MODEL_ROUTER=1 ./scripts/wiki-router --config "$CONFIG" status)"
+echo "$STATUS" | python3 -c '
+import json,sys
+data=json.load(sys.stdin)
+assert data["enabled"] is True
+assert "synthesize" in data["roles"]
+assert "compiler" in data["roles"]
+assert "embed" in data["roles"]
+assert "rerank" in data["roles"]
+'
+
+CHAT="$(./scripts/wiki-router --config "$CONFIG" --dry-run chat --role synthesize --prompt "Summarize this wiki source.")"
+echo "$CHAT" | python3 -c '
+import json,sys
+data=json.load(sys.stdin)
+assert data["dry_run"] is True
+assert data["kind"] == "chat"
+assert data["model"] == "qwen3.6-35b-a3b"
+assert data["endpoint"].endswith("/chat/completions")
+'
+
+EMBED="$(./scripts/wiki-router --config "$CONFIG" --dry-run embed --prompt "raw source text")"
+echo "$EMBED" | python3 -c '
+import json,sys
+data=json.load(sys.stdin)
+assert data["kind"] == "embed"
+assert data["model"] == "qwen3-embedding-8b"
+assert data["endpoint"].endswith("/embeddings")
+'
+
+RERANK="$(./scripts/wiki-router --config "$CONFIG" --dry-run rerank --query "claim" --documents-json '["source a", "source b"]')"
+echo "$RERANK" | python3 -c '
+import json,sys
+data=json.load(sys.stdin)
+assert data["kind"] == "rerank"
+assert data["model"] == "qwen3-reranker-8b"
+assert data["payload"]["documents"] == ["source a", "source b"]
+'
+
+echo "OK: model router example config parses and dry-run payloads are valid."
+

--- a/tests/test-model-router-disabled.sh
+++ b/tests/test-model-router-disabled.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Prove the experimental model router is dormant by default.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+unset LLM_WIKI_MODEL_ROUTER
+unset LLM_WIKI_MODEL_ROUTER_CONFIG
+
+STATUS="$(./scripts/wiki-router status)"
+echo "$STATUS" | python3 -c 'import json,sys; data=json.load(sys.stdin); assert data["enabled"] is False'
+
+if ./scripts/wiki-router chat --role synthesize --prompt "hello" >/tmp/llm-wiki-router-disabled.out 2>/tmp/llm-wiki-router-disabled.err; then
+  echo "FAIL: live chat call unexpectedly succeeded with router disabled" >&2
+  exit 1
+fi
+
+if ! grep -Eq "Router is disabled by default|model router config not found|model router disabled" /tmp/llm-wiki-router-disabled.err; then
+  echo "FAIL: disabled router error did not explain opt-in behavior" >&2
+  cat /tmp/llm-wiki-router-disabled.err >&2
+  exit 1
+fi
+
+grep -q "Only use this workflow when" claude-plugin/skills/wiki-manager/references/model-router.md
+grep -q "Router is opt-in and disabled by default" claude-plugin/skills/wiki-manager/references/model-router.md
+
+echo "OK: model router is dormant by default."
+

--- a/tests/test-plugin-validate.sh
+++ b/tests/test-plugin-validate.sh
@@ -9,7 +9,7 @@ PLUGIN_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
 PASS=0
 FAIL=0
 TOTAL=0
-REFERENCE_NAMES="audit command-prelude compilation datasets hub-resolution indexing ingestion inventory librarian linting projects research-infrastructure wiki-structure"
+REFERENCE_NAMES="audit command-prelude compilation datasets hub-resolution indexing ingestion inventory librarian linting model-router projects research-infrastructure wiki-structure"
 
 log_pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); printf "  \033[32mPASS\033[0m: %s\n" "$1"; }
 log_fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); printf "  \033[31mFAIL\033[0m: %s — %s\n" "$1" "$2"; }


### PR DESCRIPTION
## Summary
- Add a dormant shared model-router reference and placeholder example config.
- Add stdlib-only `scripts/wiki-router` helper for status, chat, embed, rerank dry-runs, and optional live OpenAI-compatible calls.
- Package the reference through Codex/OpenCode mirrors and add dependency-free validation tests.

## Tests
- `./tests/test-model-router-disabled.sh`
- `./tests/test-model-router-config-parse.sh`
- `./tests/test-plugin-validate.sh`
- `python3 -m py_compile scripts/wiki-router`
- `git diff --check`
- `./tests/test-structure.sh`
- `./tests/test-codex-sync.sh`
- `./tests/test-opencode-sync.sh`
