### PR TITLE
Add automated session capture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ The hub is lightweight — NO content, just a registry.
 ├── wikis.json          # Registry of all topic wikis
 ├── _index.md           # Lists topic wikis with stats
 ├── log.md              # Global activity log
+├── .sessions/          # Optional automated agent-session capture (hidden operational layer)
 └── topics/
     ├── nutrition/      # Each topic is a full, isolated wiki
     ├── robotics/
@@ -116,6 +117,7 @@ Same structure as a topic wiki but at `<project>/.wiki/`. Add `.wiki/` to `.giti
 normal query/compile/research/collect/output context unless explicitly included. Deep
 queries may surface archived index matches separately.
 11. **Activity log.** Append every operation to `log.md`. Format: `## [YYYY-MM-DD] operation | Description`. Never edit existing entries.
+12. **Session capture is operational memory.** Automated harness-session capture lives under `HUB/.sessions/` or `.wiki/.sessions/`. It can preserve redacted checkpoints automatically, but topic wiki promotion is explicit and user-directed.
 
 ## File Formats
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ git -C ~/.claude/plugins/marketplaces/llm-wiki remote set-url origin https://git
 ./tests/test-plugin-validate.sh   # plugin manifest + command frontmatter
 ./tests/test-structure.sh          # wiki fixture validation (84 assertions)
 ./tests/test-local-cli-lint.sh     # local scripts/llm-wiki lint helper
+./tests/test-session-capture.sh    # deterministic session capture helper
 ./tests/test-codex-sync.sh         # Codex plugin mirror matches Claude source
 ./tests/test-opencode-sync.sh     # OpenCode plugin mirror matches Claude source
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, co
 
 ## Changelog
 
-**Unreleased** — **Automated session capture.** Added an opt-in `session` workflow and deterministic `llm-wiki-session` helper that writes redacted hook events, state JSON, and markdown digests under `HUB/.sessions/`; Codex plugin packaging now bundles disabled-by-default lifecycle hooks that activate after `session enable`.
+**Unreleased** — **Automated session capture.** Added a default-on `session` workflow and deterministic `llm-wiki-session` helper that writes redacted hook events, state JSON, and markdown digests under `HUB/.sessions/`; users can opt out with `session disable`, and promotion into topic wikis remains explicit.
 
 **v0.10.2** — **Collector production hardening.** Collection-family topic slugs now prefer kind-first names such as `memes-bitcoin`, the scale boundary treats 500 rows as large and 501+ as huge, and media downloads call out timeouts, file-size caps, content-type checks, and IPv4 retry for hosts that hang.
 
@@ -68,7 +68,8 @@ Canonical explicit invocation:
 @wiki collect "bitcoin memes" --wiki memes-bitcoin
 @wiki ingest https://example.com/article
 @wiki audit --project coldcard-threat-model
-@wiki session enable --mode balanced
+@wiki session status
+@wiki session disable   # optional opt-out
 @wiki ll "codex plugin install gotchas"
 ```
 
@@ -367,7 +368,9 @@ checks without an agent:
 ./scripts/llm-wiki archive --hub /path/to/hub topic old-interest --reason "No longer active"
 ./scripts/llm-wiki archive --hub /path/to/hub list --archived
 ./scripts/llm-wiki archive --hub /path/to/hub restore old-interest
-./scripts/llm-wiki-session --hub /path/to/hub enable --mode balanced
+./scripts/llm-wiki-session --hub /path/to/hub status
+./scripts/llm-wiki-session --hub /path/to/hub disable   # optional opt-out
+./scripts/llm-wiki-session --hub /path/to/hub enable --mode balanced --tool-events 50
 ./scripts/llm-wiki-session --hub /path/to/hub rehydrate --cwd "$PWD"
 ```
 
@@ -409,7 +412,9 @@ folder move plus `wikis.json`, hub index, and log updates.
 | `/wiki:archive topic <slug> --reason "why"` | Move a topic wiki to `topics/.archive/<slug>` and hide it from default context |
 | `/wiki:archive restore <slug>` | Restore an archived topic wiki to active status |
 | `/wiki:archive peek <query>` | Search archived topic indexes without reading archived articles |
-| `/wiki:session enable --mode balanced` | Opt in to automated redacted session capture and soft rehydration |
+| `/wiki:session status` | Show automated session-capture mode, root, and indexed session count |
+| `/wiki:session disable` | Opt out of automated redacted session capture |
+| `/wiki:session enable --mode balanced` | Re-enable or tune automated capture and soft rehydration |
 | `/wiki:session capture` | Force a manual session digest checkpoint |
 | `/wiki:session rehydrate` | Print compact context from matching session digests |
 | `/wiki:session promote <id> --topic <slug>` | Promote a distilled digest into a topic raw note |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [github.com/nvk/llm-wiki](https://github.com/nvk/llm-wiki)
 
-LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, collector catalogs, thesis-driven investigation, source ingestion, wiki compilation, truth-seeking audits, querying, and artifact generation. Ships as a Claude Code plugin, an OpenAI Codex plugin, an OpenCode instruction file, or a portable AGENTS.md for any other LLM agent. Obsidian-compatible.
+LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, collector catalogs, automated session capture, thesis-driven investigation, source ingestion, wiki compilation, truth-seeking audits, querying, and artifact generation. Ships as a Claude Code plugin, an OpenAI Codex plugin, an OpenCode instruction file, or a portable AGENTS.md for any other LLM agent. Obsidian-compatible.
 
 ---
 
@@ -18,6 +18,8 @@ LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, co
 ---
 
 ## Changelog
+
+**Unreleased** — **Automated session capture.** Added an opt-in `session` workflow and deterministic `llm-wiki-session` helper that writes redacted hook events, state JSON, and markdown digests under `HUB/.sessions/`; Codex plugin packaging now bundles disabled-by-default lifecycle hooks that activate after `session enable`.
 
 **v0.10.2** — **Collector production hardening.** Collection-family topic slugs now prefer kind-first names such as `memes-bitcoin`, the scale boundary treats 500 rows as large and 501+ as huge, and media downloads call out timeouts, file-size caps, content-type checks, and IPv4 retry for hosts that hang.
 
@@ -66,6 +68,7 @@ Canonical explicit invocation:
 @wiki collect "bitcoin memes" --wiki memes-bitcoin
 @wiki ingest https://example.com/article
 @wiki audit --project coldcard-threat-model
+@wiki session enable --mode balanced
 @wiki ll "codex plugin install gotchas"
 ```
 
@@ -364,6 +367,8 @@ checks without an agent:
 ./scripts/llm-wiki archive --hub /path/to/hub topic old-interest --reason "No longer active"
 ./scripts/llm-wiki archive --hub /path/to/hub list --archived
 ./scripts/llm-wiki archive --hub /path/to/hub restore old-interest
+./scripts/llm-wiki-session --hub /path/to/hub enable --mode balanced
+./scripts/llm-wiki-session --hub /path/to/hub rehydrate --cwd "$PWD"
 ```
 
 This local helper covers structural checks that do not require an LLM. The
@@ -404,6 +409,10 @@ folder move plus `wikis.json`, hub index, and log updates.
 | `/wiki:archive topic <slug> --reason "why"` | Move a topic wiki to `topics/.archive/<slug>` and hide it from default context |
 | `/wiki:archive restore <slug>` | Restore an archived topic wiki to active status |
 | `/wiki:archive peek <query>` | Search archived topic indexes without reading archived articles |
+| `/wiki:session enable --mode balanced` | Opt in to automated redacted session capture and soft rehydration |
+| `/wiki:session capture` | Force a manual session digest checkpoint |
+| `/wiki:session rehydrate` | Print compact context from matching session digests |
+| `/wiki:session promote <id> --topic <slug>` | Promote a distilled digest into a topic raw note |
 | `/wiki:compile` | Compile new sources into wiki articles |
 | `/wiki:compile --full` | Recompile everything from scratch |
 | `/wiki:query <question>` | Q&A against the wiki (standard depth) |
@@ -454,6 +463,7 @@ All commands accept `--wiki <name>` to target a specific topic wiki and `--local
 ├── wikis.json                          # Registry of all topic wikis
 ├── _index.md                           # Lists topic wikis with stats
 ├── log.md                              # Global activity log
+├── .sessions/                          # Optional automated session capture
 └── topics/                             # Each topic is an isolated wiki
     ├── nutrition/                      # Example topic wiki
     │   ├── .obsidian/                  # Optional Obsidian vault config
@@ -486,10 +496,11 @@ The hub is just a registry — no content directories, no `.obsidian/`. All cont
 6. **Archive** whole topic wikis that should stay preserved but quiet
 7. **Compile** raw sources into synthesized wiki articles with cross-references and confidence scores
 8. **Query** the wiki — quick (indexes), standard (articles), or deep (everything active, archived indexes separated)
-9. **Lessons learned** — extract knowledge from the current session (errors, fixes, gotchas) into the wiki
-10. **Assess** a repo against the wiki — gap analysis: what aligns, what's missing, what the market offers
-11. **Lint** for consistency — broken links, missing indexes, orphan articles, archive registry drift
-12. **Output** artifacts — summaries, reports, slides — filed back into the wiki
+9. **Session capture** — automatically preserve redacted Codex/Claude/OpenCode/Gemini checkpoints under `.sessions/` and rehydrate future turns
+10. **Lessons learned** — extract knowledge from the current session (errors, fixes, gotchas) into the wiki
+11. **Assess** a repo against the wiki — gap analysis: what aligns, what's missing, what the market offers
+12. **Lint** for consistency — broken links, missing indexes, orphan articles, archive registry drift
+13. **Output** artifacts — summaries, reports, slides — filed back into the wiki
 
 ### Key Design
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, co
 
 ## Changelog
 
-**Unreleased** — **Automated session capture.** Added a default-on `session` workflow and deterministic `llm-wiki-session` helper that writes redacted hook events, state JSON, and markdown digests under `HUB/.sessions/`; users can opt out with `session disable`, and promotion into topic wikis remains explicit.
+**v0.11.0** — **Automated session capture.** Added a default-on `session` workflow and deterministic `llm-wiki-session` helper that writes redacted hook events, state JSON, and markdown digests under `HUB/.sessions/`; users can opt out with `session disable`, and promotion into topic wikis remains explicit.
 
 **v0.10.2** — **Collector production hardening.** Collection-family topic slugs now prefer kind-first names such as `memes-bitcoin`, the scale boundary treats 500 rows as large and 501+ as huge, and media downloads call out timeouts, file-size caps, content-type checks, and IPv4 retry for hosts that hang.
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wiki",
   "description": "LLM-compiled knowledge base. Natural language routing, collector catalogs, topic archive lifecycle, inventory tracking, dataset manifests, collection ingestion for external wikis/spec repos, truth-seeking audits, session resume, automated session capture, context rehydration, concurrent-safe derived indexes, topic-isolated wikis, parallel multi-agent research, thesis-driven investigation, repo assessment, Obsidian dual-linking, retardmax mode, and --min-time sustained research.",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "author": {
     "name": "nvk"
   },

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki",
-  "description": "LLM-compiled knowledge base. Natural language routing, collector catalogs, topic archive lifecycle, inventory tracking, dataset manifests, collection ingestion for external wikis/spec repos, truth-seeking audits, session resume, concurrent-safe derived indexes, topic-isolated wikis, parallel multi-agent research, thesis-driven investigation, repo assessment, Obsidian dual-linking, retardmax mode, and --min-time sustained research.",
+  "description": "LLM-compiled knowledge base. Natural language routing, collector catalogs, topic archive lifecycle, inventory tracking, dataset manifests, collection ingestion for external wikis/spec repos, truth-seeking audits, session resume, automated session capture, context rehydration, concurrent-safe derived indexes, topic-isolated wikis, parallel multi-agent research, thesis-driven investigation, repo assessment, Obsidian dual-linking, retardmax mode, and --min-time sustained research.",
   "version": "0.10.2",
   "author": {
     "name": "nvk"
@@ -20,6 +20,9 @@
     "collect",
     "inventory",
     "datasets",
-    "archive"
+    "archive",
+    "sessions",
+    "hooks",
+    "context"
   ]
 }

--- a/claude-plugin/commands/session.md
+++ b/claude-plugin/commands/session.md
@@ -23,10 +23,10 @@ in `references/sessions.md`.
 
 ### Parse $ARGUMENTS
 
-- `enable [--mode capture-only|balanced|aggressive] [--tool-events N]`: enable
-automated capture by writing `HUB/.sessions/config.json`. Default mode is
-`balanced`; default threshold is 50 observed tool events.
-- `disable`: set `enabled: false` in `HUB/.sessions/config.json`.
+- `enable [--mode capture-only|balanced|aggressive] [--tool-events N]`: re-enable
+or reconfigure automated capture by writing `HUB/.sessions/config.json`. Default
+mode is `balanced`; default threshold is 50 observed tool events.
+- `disable`: opt out by setting `enabled: false` in `HUB/.sessions/config.json`.
 - `status`: report whether capture is enabled, where `.sessions/` lives, and how
 many sessions are indexed.
 - `capture`: force a manual digest checkpoint for the current or specified
@@ -42,8 +42,9 @@ note from the distilled digest. Do not copy raw transcripts.
 
 ### Policy
 
-1. Automated capture is opt-in. Enabling writes config; hooks must still be
-installed/trusted in the target harness.
+1. Automated capture is default-on when trusted hooks are installed. Users can
+opt out with `session disable`, which writes `enabled: false` and causes hooks
+using `--if-enabled` to no-op.
 2. Hooks should be fast and deterministic: append redacted JSONL event metadata,
 update state, and write markdown digests at checkpoints. Do not call an LLM from
 every tool hook.
@@ -57,7 +58,10 @@ strict forced continuation remains opt-in and must have loop guards.
 ### Examples
 
 ```bash
-# Opt in to automated capture and soft rehydration.
+# Opt out of automated capture.
+scripts/llm-wiki-session --hub "$HUB" disable
+
+# Re-enable or tune automated capture and soft rehydration.
 scripts/llm-wiki-session --hub "$HUB" enable --mode balanced --tool-events 50
 
 # Capture now with a short human summary.

--- a/claude-plugin/commands/session.md
+++ b/claude-plugin/commands/session.md
@@ -1,0 +1,74 @@
+---
+description: "Capture, list, rehydrate, and promote llm-wiki session context. Supports automated hook capture into HUB/.sessions plus explicit promotion into topic raw notes."
+argument-hint: "enable|disable|status|capture|list|show|rehydrate|promote [options]"
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(ls:*), Bash(mkdir:*), Bash(python3:*), Bash(scripts/llm-wiki-session:*)
+---
+
+## Your task
+
+Manage llm-wiki session context. Session context is operational memory for agent
+sessions, not canonical topic knowledge. Use `HUB/.sessions/` as the canonical
+store and promote only explicit distilled learnings into topic `raw/notes/`.
+
+First read `references/sessions.md`, then resolve HUB by the standard hub
+resolution protocol from `references/hub-resolution.md`. If a deterministic
+helper is available, prefer it:
+
+```bash
+scripts/llm-wiki-session --hub "$HUB" <subcommand>
+```
+
+If the helper is not available, perform the equivalent file operations described
+in `references/sessions.md`.
+
+### Parse $ARGUMENTS
+
+- `enable [--mode capture-only|balanced|aggressive] [--tool-events N]`: enable
+automated capture by writing `HUB/.sessions/config.json`. Default mode is
+`balanced`; default threshold is 50 observed tool events.
+- `disable`: set `enabled: false` in `HUB/.sessions/config.json`.
+- `status`: report whether capture is enabled, where `.sessions/` lives, and how
+many sessions are indexed.
+- `capture`: force a manual digest checkpoint for the current or specified
+session. Accept optional `--harness`, `--session-id`, `--cwd`, `--topic`, and
+`--summary` hints.
+- `list`: list sessions by recency, optionally filtered by `--harness`, `--cwd`,
+or `--topic`.
+- `show <session-id>`: show the latest digest for a session.
+- `rehydrate [--session-id <id>|--cwd <path>|--topic <slug>]`: print a compact
+context block that the harness should read before continuing.
+- `promote <session-id> --topic <slug>`: create a topic `raw/notes/` promotion
+note from the distilled digest. Do not copy raw transcripts.
+
+### Policy
+
+1. Automated capture is opt-in. Enabling writes config; hooks must still be
+installed/trusted in the target harness.
+2. Hooks should be fast and deterministic: append redacted JSONL event metadata,
+update state, and write markdown digests at checkpoints. Do not call an LLM from
+every tool hook.
+3. Raw transcript archiving is off by default. Store transcript pointers/hashes,
+not transcript bodies.
+4. Auto-promotion is forbidden. Sessions can be untagged or topic-tagged, but
+canonical wiki knowledge requires explicit promotion.
+5. Rehydration may inject a short context block in balanced/aggressive modes;
+strict forced continuation remains opt-in and must have loop guards.
+
+### Examples
+
+```bash
+# Opt in to automated capture and soft rehydration.
+scripts/llm-wiki-session --hub "$HUB" enable --mode balanced --tool-events 50
+
+# Capture now with a short human summary.
+scripts/llm-wiki-session --hub "$HUB" capture --harness manual --summary "Design decision: sessions live under HUB/.sessions and promote into topic raw notes only by command."
+
+# Continue a previous task.
+scripts/llm-wiki-session --hub "$HUB" rehydrate --cwd "$PWD"
+
+# Promote a distilled digest into a topic wiki.
+scripts/llm-wiki-session --hub "$HUB" promote codex:abc123 --topic meta-llm-wiki
+```
+
+Report absolute paths for every created digest, config file, or promotion note.
+Append topic `log.md` when promoting into a topic wiki.

--- a/claude-plugin/skills/wiki-manager/SKILL.md
+++ b/claude-plugin/skills/wiki-manager/SKILL.md
@@ -7,13 +7,14 @@ description: >
   collect/catalog discoverable artifacts and examples, track inventory,
   manage source queues, candidates, corpora, entities, watch lists,
   dataset manifests, large datasets, or data that is too big for the wiki,
-  archive old topic wikis, or uses /wiki commands. Also activates when user says "wiki", "knowledge base",
+  archive old topic wikis, capture or rehydrate agent session context, or uses /wiki commands. Also activates when user says "wiki", "knowledge base",
   "ingest", "import wiki", "ingest collection", "collect", "catalog",
   "curate", "find all", "compile wiki", "add to wiki", "search wiki", "audit", "librarian",
   "scan quality", "article quality", "content review", "output drift", "inventory",
   "ingest queue", "source queue", "candidate list", "watch list", "backlog",
   "dataset", "large data", "data registry", "dataset manifest",
-  "archive wiki", "archive topic", "restore wiki",
+  "archive wiki", "archive topic", "restore wiki", "session capture",
+  "capture context", "rehydrate", "resume from session",
   "provenance", "trust this", or asks a factual question in a directory
   containing .wiki/ or when ~/wiki/ exists or the configured hub path exists
   (check ~/.config/llm-wiki/config.json for hub_path).
@@ -91,6 +92,11 @@ See [references/wiki-structure.md](references/wiki-structure.md) for the complet
 They remain structurally maintainable through explicit archive/lint operations.
 Deep queries may surface archived index matches separately, but archived content
 must not influence new synthesis unless the user explicitly includes it.
+
+11. **Session capture is operational memory.** Harness session digests live in
+`HUB/.sessions/` or `.wiki/.sessions/`, not in topic `raw/` by default.
+Automated hooks may capture redacted checkpoints, but promotion into topic wikis
+is explicit and user-directed.
 
 ## Ambient Behavior
 
@@ -193,6 +199,15 @@ notice it without treating it as factual evidence:
   records for durable follow-ups, stale items, source queues, or watch lists,
   but show a sample before creating a larger backlog.
 
+### Sessions
+See [references/sessions.md](references/sessions.md).
+Flow: Opt in with `session enable` → harness hooks append redacted events under
+`HUB/.sessions/queue/` → session state and markdown digests update at tool-count,
+compaction, stop/session-end, or manual checkpoints → `session rehydrate` returns
+a compact context block → `session promote` explicitly copies the distilled
+digest into a topic `raw/notes/` note. Automated capture is allowed; automated
+promotion is not.
+
 ### Output
 Flow: Gather relevant articles → generate artifact (summary/report/slides/etc) → save to `output/` → update indexes.
 
@@ -245,7 +260,7 @@ Automatically run a quick structural check when any of these triggers occur:
 
 ### Quick Structure Check (lightweight, runs inline — not a full lint)
 
-1. **Hub integrity**: The hub (HUB) should ONLY contain `wikis.json`, `_index.md`, `log.md`, and `topics/`. If `raw/`, `wiki/`, `inventory/`, `datasets/`, `output/`, `inbox/`, or `config.md` exist at the hub level → **warn, do not delete**. These may hold user data from an older wiki layout. Suggest `/wiki:lint --fix`, which will move contents to the appropriate topic wiki, repair archive registry drift, or quarantine to `inbox/.unknown/` per C11/C12/C16/C17/C19 in `references/linting.md`.
+1. **Hub integrity**: The hub (HUB) should ONLY contain `wikis.json`, `_index.md`, `log.md`, `topics/`, and optional `.sessions/`. If `raw/`, `wiki/`, `inventory/`, `datasets/`, `output/`, `inbox/`, or `config.md` exist at the hub level → **warn, do not delete**. These may hold user data from an older wiki layout. Suggest `/wiki:lint --fix`, which will move contents to the appropriate topic wiki, repair archive registry drift, or quarantine to `inbox/.unknown/` per C11/C12/C16/C17/C19 in `references/linting.md`.
 
 2. **Index freshness**: For the active topic wiki, compare actual file counts in `raw/`, `wiki/`, `inventory/`, and `datasets/` subdirectories against the rows in their `_index.md`. Ignore maintenance/report areas such as `.librarian/` and `.audit/`. If mismatched → auto-fix by regenerating the affected directory index from frontmatter and removing dead entries.
 
@@ -297,3 +312,13 @@ checkpoint are the durable provenance trail.
 - Session files are ephemeral — never included in structural health checks or index counts
 - Session files should NOT be committed to git
 - `.session-events.jsonl` and `.session-checkpoint.json` should normally be preserved after completion so `/wiki:audit` can classify provenance as `replayable` instead of `partial`
+
+### Harness Session Capture
+
+Automated Codex/Claude/OpenCode/Gemini session capture uses `HUB/.sessions/`
+(or `.wiki/.sessions/` for local wikis). This is a hidden operational layer for
+redacted hook events, state JSON, derived indexes, and markdown session digests.
+It is not topic evidence until explicitly promoted.
+
+See `references/sessions.md` for the storage layout, config modes, hook adapter
+contract, rehydration behavior, and promotion rules.

--- a/claude-plugin/skills/wiki-manager/references/sessions.md
+++ b/claude-plugin/skills/wiki-manager/references/sessions.md
@@ -36,7 +36,7 @@ HUB/.sessions/
 
 Use the same layout under `.wiki/.sessions/` for local project wikis.
 
-- `config.json` controls opt-in automation and rehydration.
+- `config.json` controls automation and rehydration. If it is absent, capture defaults to `balanced`; `enabled: false` is the opt-out switch.
 - `registry.jsonl` is append-only lifecycle metadata such as `session_seen` and
   `digest_written`.
 - `queue/*.jsonl` stores small redacted hook events. Do not store full prompts,
@@ -53,7 +53,7 @@ private. It should not be compiled as ordinary topic content. A future generated
 
 ## Config Modes
 
-Default mode after opt-in should be `balanced`:
+Default mode is `balanced`, even before a config file exists:
 
 ```json
 {
@@ -81,7 +81,7 @@ Modes:
 
 | Mode | Capture | Rehydrate | Use when |
 |---|---|---|---|
-| `off` | none | none | Disabled |
+| `off` | none | none | Disabled / user opt-out |
 | `capture-only` | automatic checkpoints | no injected context | Maximum privacy/least surprise |
 | `balanced` | automatic checkpoints | SessionStart/UserPromptSubmit soft context | Recommended default |
 | `aggressive` | more frequent checkpoints | soft context | Long, high-context work |
@@ -144,7 +144,7 @@ The command reads the harness hook JSON object from stdin and should:
 1. resolve HUB from `~/.config/llm-wiki/config.json` unless `--hub` or `--local`
    is supplied;
 2. exit 0 without writing if `--if-enabled` is set and `.sessions/config.json`
-   is missing or disabled;
+   has `enabled: false`; missing config means default-on balanced capture;
 3. append a redacted event to `queue/YYYY-MM-DD.jsonl`;
 4. update `state/<harness>/<session_id>.json`;
 5. write a digest if a capture trigger fired;
@@ -158,8 +158,8 @@ background worker instead of doing it inline inside every tool hook.
 
 Codex plugins can bundle hooks in `hooks/hooks.json`. Plugin-bundled hooks still
 require the user to review/trust them. The bundled llm-wiki Codex hook should
-call the copied helper in the plugin root and use `--if-enabled`, so installing
-the plugin does not capture anything until the user enables sessions.
+call the copied helper in the plugin root and use `--if-enabled`, so users can
+turn capture off with `session disable` without editing hook manifests.
 
 Useful Codex events:
 
@@ -227,3 +227,4 @@ not the raw transcript. Append the topic `log.md` entry. Compilation into
 - Do not auto-promote session material into topic wikis.
 - Do not let hook failures block normal agent work; fail closed to no capture,
   not to broken tool execution.
+- To opt out, run `llm-wiki-session disable` or ask `@wiki session disable`; this writes `enabled: false`.

--- a/claude-plugin/skills/wiki-manager/references/sessions.md
+++ b/claude-plugin/skills/wiki-manager/references/sessions.md
@@ -1,0 +1,229 @@
+# Session Context Capture
+
+Use this reference for `session`, `session capture`, `rehydrate`, "look at the
+last session", automated hook capture, and promotion of session learnings into a
+topic wiki.
+
+## Purpose
+
+Session capture preserves agent-session context without polluting curated topic
+wikis. The session layer records redacted harness metadata and markdown digests
+under the hub-level operational directory `HUB/.sessions/`. Topic wikis receive
+session knowledge only through explicit promotion into `raw/notes/`.
+
+This layer is separate from existing research-session files:
+
+| Layer | Path | Meaning |
+|---|---|---|
+| Research crash state | `.research-session.json`, `.thesis-session.json` | In-progress wiki research/thesis runs |
+| Durable research provenance | `.session-events.jsonl`, `.session-checkpoint.json` | Replayable provenance for wiki workflows |
+| Harness sessions | `HUB/.sessions/` or `.wiki/.sessions/` | Cross-runtime Codex/Claude/OpenCode/Gemini session context |
+
+## Storage Layout
+
+```text
+HUB/.sessions/
+├── config.json
+├── registry.jsonl
+├── state/<harness>/<session_id>.json
+├── queue/YYYY-MM-DD.jsonl
+├── digests/YYYY/MM/<harness>-<session_id>.md
+└── indexes/
+    ├── by-cwd.json
+    ├── by-topic.json
+    └── sessions.json
+```
+
+Use the same layout under `.wiki/.sessions/` for local project wikis.
+
+- `config.json` controls opt-in automation and rehydration.
+- `registry.jsonl` is append-only lifecycle metadata such as `session_seen` and
+  `digest_written`.
+- `queue/*.jsonl` stores small redacted hook events. Do not store full prompts,
+  tool outputs, or transcript bodies by default.
+- `state/` is the latest per-session machine state.
+- `digests/` contains human/LLM-readable markdown checkpoints with YAML
+  frontmatter.
+- `indexes/` are derived caches rebuilt from `state/`.
+
+`.sessions/` is hidden because it is operational, cross-topic, and potentially
+private. It should not be compiled as ordinary topic content. A future generated
+`HUB/_sessions.md` can expose a human-friendly index, but the canonical store is
+`.sessions/`.
+
+## Config Modes
+
+Default mode after opt-in should be `balanced`:
+
+```json
+{
+  "schema_version": 1,
+  "enabled": true,
+  "mode": "balanced",
+  "auto_capture": {
+    "tool_events": 50,
+    "pre_compact": true,
+    "post_compact": true,
+    "session_end": true,
+    "stop": true
+  },
+  "rehydrate": {
+    "session_start": true,
+    "user_prompt": true,
+    "strict": false
+  },
+  "raw_transcripts": false,
+  "privacy": "redacted"
+}
+```
+
+Modes:
+
+| Mode | Capture | Rehydrate | Use when |
+|---|---|---|---|
+| `off` | none | none | Disabled |
+| `capture-only` | automatic checkpoints | no injected context | Maximum privacy/least surprise |
+| `balanced` | automatic checkpoints | SessionStart/UserPromptSubmit soft context | Recommended default |
+| `aggressive` | more frequent checkpoints | soft context | Long, high-context work |
+
+## Capture Triggers
+
+Hooks should write deterministic checkpoints for:
+
+1. every configured number of observed tool events, default 50;
+2. pre-compaction and post-compaction;
+3. stop/session-end events;
+4. manual `session capture` requests.
+
+"Observed tool events" means events the current harness adapter exposes. Codex,
+Claude, OpenCode, and Gemini have different hook coverage, so do not promise an
+exact total count across all tool classes.
+
+## Digest Schema
+
+Session digest files are markdown with YAML frontmatter:
+
+```yaml
+title: "Session Digest: codex:abc123"
+type: session-digest
+schema_version: 1
+harness: "codex"
+native_session_id: "abc123"
+llm_wiki_session_id: "codex:abc123"
+cwd: "/path/to/project"
+git_remote: "https://github.com/org/repo.git"
+git_branch: "feature/example"
+transcript_path: "/path/to/transcript.jsonl"
+started_at: "2026-06-13T17:00:00Z"
+last_seen_at: "2026-06-13T18:10:00Z"
+tool_event_count: 50
+event_count: 61
+capture_trigger: "tool-count-50"
+topics: []
+topic_candidates: []
+privacy: "redacted"
+raw_transcripts: false
+promoted_to: []
+summary: "Automated checkpoint for codex:abc123."
+```
+
+The body should include session identity, summary, manual notes if any, recent
+observed events, distillation notes, and open loops. It should not include full
+transcript text by default.
+
+## Hook Adapter Contract
+
+Each runtime adapter should call the same deterministic helper shape:
+
+```bash
+llm-wiki-session hook --harness <codex|claude|opencode|gemini> --if-enabled
+```
+
+The command reads the harness hook JSON object from stdin and should:
+
+1. resolve HUB from `~/.config/llm-wiki/config.json` unless `--hub` or `--local`
+   is supplied;
+2. exit 0 without writing if `--if-enabled` is set and `.sessions/config.json`
+   is missing or disabled;
+3. append a redacted event to `queue/YYYY-MM-DD.jsonl`;
+4. update `state/<harness>/<session_id>.json`;
+5. write a digest if a capture trigger fired;
+6. optionally emit a short `additionalContext` block only for rehydration hooks
+   when config enables it.
+
+Hooks must be fast. If future versions do LLM distillation, enqueue work for a
+background worker instead of doing it inline inside every tool hook.
+
+## Codex Hook Packaging
+
+Codex plugins can bundle hooks in `hooks/hooks.json`. Plugin-bundled hooks still
+require the user to review/trust them. The bundled llm-wiki Codex hook should
+call the copied helper in the plugin root and use `--if-enabled`, so installing
+the plugin does not capture anything until the user enables sessions.
+
+Useful Codex events:
+
+- `SessionStart` and `UserPromptSubmit` for soft rehydration;
+- `PostToolUse` for observed tool counters;
+- `PreCompact` and `PostCompact` for compaction checkpoints;
+- `Stop` for final checkpoints.
+
+## Claude/OpenCode/Gemini Adapters
+
+For Claude Code, use command hooks on `SessionStart`, `UserPromptSubmit`,
+`PostToolUse`, `PostToolBatch`, `PreCompact`, `PostCompact`, `Stop`, and
+`SessionEnd` where available. Keep `SessionEnd` especially short or detached.
+
+For OpenCode, use plugin events such as session/message/tool execution and the
+compaction hook surface. For Gemini CLI, use `AfterTool`, `PreCompress`,
+`AfterAgent`, `SessionStart`, and related hook events. All adapters normalize to
+the same `.sessions/` files.
+
+## Rehydration
+
+Rehydration is a compact context block, not a bulk transcript paste:
+
+```text
+llm-wiki session context: review these distilled session digests before continuing.
+- codex:abc123 — Automated checkpoint summary. Digest: /abs/path/HUB/.sessions/digests/2026/06/codex-abc123.md
+Do not treat session digests as canonical topic knowledge until promoted into a topic wiki.
+```
+
+Soft rehydration can be injected on `SessionStart` or `UserPromptSubmit` in
+balanced/aggressive modes. Manual rehydration should be available with:
+
+```bash
+llm-wiki-session rehydrate --cwd "$PWD"
+llm-wiki-session rehydrate --session-id codex:abc123
+llm-wiki-session rehydrate --topic meta-llm-wiki
+```
+
+Strict forced continuation is not the default. If implemented later, it must be
+opt-in and guard against loops with per-turn counters and stop-hook-active flags.
+
+## Promotion
+
+Promotion is explicit:
+
+```bash
+llm-wiki-session promote codex:abc123 --topic meta-llm-wiki
+```
+
+Promotion writes a topic raw note:
+
+```text
+HUB/topics/<topic>/raw/notes/YYYY-MM-DD-session-<harness>-<session>.md
+```
+
+The raw note links back to the digest and copies only the distilled digest body,
+not the raw transcript. Append the topic `log.md` entry. Compilation into
+`wiki/` articles remains a separate, explicit wiki compile/update step.
+
+## Privacy Defaults
+
+- Redact obvious token/password/authorization fields in event previews.
+- Store transcript pointers and hashes, not transcript bodies.
+- Keep raw transcript archiving disabled unless the user explicitly opts in.
+- Do not auto-promote session material into topic wikis.
+- Do not let hook failures block normal agent work; fail closed to no capture,
+  not to broken tool execution.

--- a/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
+++ b/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
@@ -2,14 +2,15 @@
 name: wiki-manager
 description: >
   LLM-compiled knowledge base manager for OpenCode. Use it to initialize, ingest,
-  import source collections, collect catalogs, track inventory, index datasets, archive old topics, compile, query, lint, audit, research, plan, and generate outputs from topic-scoped wikis.
+  import source collections, collect catalogs, track inventory, index datasets, archive old topics, compile, query, lint, audit, research, plan, capture or rehydrate agent session context, and generate outputs from topic-scoped wikis.
   Activates when the user mentions wiki workflows, knowledge-base management,
   ingestion, collection ingestion, import wiki, collect, catalog, curate,
   find all, inventory, source queue,
   candidate list, watch list, backlog, dataset, large data, data registry,
   dataset manifest, compilation, querying, linting, audit, research, librarian,
   scan quality, article quality, content review, output drift, provenance,
-  archive wiki, archive topic, restore wiki, lessons learned, implementation
+  archive wiki, archive topic, restore wiki, session capture, capture
+  context, rehydrate, resume from session, lessons learned, implementation
   plan, or uses wiki-related shorthand in a repo with .wiki/, ~/wiki/, or a
   configured hub path.
 ---
@@ -85,6 +86,11 @@ See [references/wiki-structure.md](references/wiki-structure.md) for the complet
 They remain structurally maintainable through explicit archive/lint operations.
 Deep queries may surface archived index matches separately, but archived content
 must not influence new synthesis unless the user explicitly includes it.
+
+11. **Session capture is operational memory.** Harness session digests live in
+`HUB/.sessions/` or `.wiki/.sessions/`, not in topic `raw/` by default.
+Automated hooks may capture redacted checkpoints, but promotion into topic wikis
+is explicit and user-directed.
 
 ## Ambient Behavior
 
@@ -187,6 +193,15 @@ notice it without treating it as factual evidence:
   records for durable follow-ups, stale items, source queues, or watch lists,
   but show a sample before creating a larger backlog.
 
+### Sessions
+See [references/sessions.md](references/sessions.md).
+Flow: Opt in with `session enable` → harness hooks append redacted events under
+`HUB/.sessions/queue/` → session state and markdown digests update at tool-count,
+compaction, stop/session-end, or manual checkpoints → `session rehydrate` returns
+a compact context block → `session promote` explicitly copies the distilled
+digest into a topic `raw/notes/` note. Automated capture is allowed; automated
+promotion is not.
+
 ### Output
 Flow: Gather relevant articles → generate artifact (summary/report/slides/etc) → save to `output/` → update indexes.
 
@@ -239,7 +254,7 @@ Automatically run a quick structural check when any of these triggers occur:
 
 ### Quick Structure Check (lightweight, runs inline — not a full lint)
 
-1. **Hub integrity**: The hub (HUB) should ONLY contain `wikis.json`, `_index.md`, `log.md`, and `topics/`. If `raw/`, `wiki/`, `inventory/`, `datasets/`, `output/`, `inbox/`, or `config.md` exist at the hub level → **warn, do not delete**. These may hold user data from an older wiki layout. Suggest running the lint --fix workflow, which will move contents to the appropriate topic wiki, repair archive registry drift, or quarantine to `inbox/.unknown/` per C11/C12/C16/C17/C19 in `references/linting.md`.
+1. **Hub integrity**: The hub (HUB) should ONLY contain `wikis.json`, `_index.md`, `log.md`, `topics/`, and optional `.sessions/`. If `raw/`, `wiki/`, `inventory/`, `datasets/`, `output/`, `inbox/`, or `config.md` exist at the hub level → **warn, do not delete**. These may hold user data from an older wiki layout. Suggest running the lint --fix workflow, which will move contents to the appropriate topic wiki, repair archive registry drift, or quarantine to `inbox/.unknown/` per C11/C12/C16/C17/C19 in `references/linting.md`.
 
 2. **Index freshness**: For the active topic wiki, compare actual file counts in `raw/`, `wiki/`, `inventory/`, and `datasets/` subdirectories against the rows in their `_index.md`. Ignore maintenance/report areas such as `.librarian/` and `.audit/`. If mismatched → auto-fix by regenerating the affected directory index from frontmatter and removing dead entries.
 
@@ -291,3 +306,13 @@ checkpoint are the durable provenance trail.
 - Session files are ephemeral — never included in structural health checks or index counts
 - Session files should NOT be committed to git
 - `.session-events.jsonl` and `.session-checkpoint.json` should normally be preserved after completion so `/wiki:audit` can classify provenance as `replayable` instead of `partial`
+
+### Harness Session Capture
+
+Automated Codex/Claude/OpenCode/Gemini session capture uses `HUB/.sessions/`
+(or `.wiki/.sessions/` for local wikis). This is a hidden operational layer for
+redacted hook events, state JSON, derived indexes, and markdown session digests.
+It is not topic evidence until explicitly promoted.
+
+See `references/sessions.md` for the storage layout, config modes, hook adapter
+contract, rehydration behavior, and promotion rules.

--- a/plugins/llm-wiki/.codex-plugin/plugin.json
+++ b/plugins/llm-wiki/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wiki",
   "version": "0.10.2",
-  "description": "LLM-compiled knowledge bases for Codex. Build topic-scoped wikis, collect provenance-rich catalogs, archive old topics, track inventory, index datasets, ingest sources and external collections, compile articles, run truth-seeking audits, query, lint, research, and generate outputs.",
+  "description": "LLM-compiled knowledge bases for Codex. Build topic-scoped wikis, collect provenance-rich catalogs, archive old topics, track inventory, index datasets, capture and rehydrate session context, ingest sources, compile articles, audit, query, lint, research, and generate outputs.",
   "author": {
     "name": "nvk",
     "url": "https://github.com/nvk"
@@ -21,13 +21,16 @@
     "collect",
     "inventory",
     "datasets",
-    "archive"
+    "archive",
+    "sessions",
+    "hooks",
+    "context"
   ],
   "skills": "./skills/",
   "interface": {
     "displayName": "LLM Wiki",
-    "shortDescription": "Build, collect, archive, inventory, index data, audit, and maintain research wikis",
-    "longDescription": "Bundle the llm-wiki workflow for Codex: initialize a wiki, collect provenance-rich catalogs of discoverable artifacts, media, examples, tools, and source candidates, archive old topics so they stay preserved but quiet, track inventory, index large datasets without copying them into the wiki, ingest sources and external collections, compile articles, audit outputs and provenance, query knowledge, lint structure, run research, and generate outputs.",
+    "shortDescription": "Build, collect, archive, inventory, index data, capture sessions, audit, and maintain research wikis",
+    "longDescription": "Bundle the llm-wiki workflow for Codex: initialize a wiki, collect provenance-rich catalogs, archive old topics, track inventory, index datasets, capture and rehydrate session context, ingest sources and external collections, compile articles, audit outputs and provenance, query knowledge, lint structure, run research, and generate outputs.",
     "developerName": "nvk",
     "category": "Productivity",
     "capabilities": [
@@ -43,7 +46,8 @@
       "Index this large dataset with a manifest, schema notes, samples, and query recipes.",
       "Ingest these notes or an external source collection into my wiki and update the indexes.",
       "Audit this wiki output and tell me if I can trust it.",
-      "Lint this wiki and fix structural issues."
+      "Lint this wiki and fix structural issues.",
+      "Enable automated session capture and rehydrate context for this project."
     ],
     "brandColor": "#2F855A"
   }

--- a/plugins/llm-wiki/.codex-plugin/plugin.json
+++ b/plugins/llm-wiki/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "LLM-compiled knowledge bases for Codex. Build topic-scoped wikis, collect provenance-rich catalogs, archive old topics, track inventory, index datasets, capture and rehydrate session context, ingest sources, compile articles, audit, query, lint, research, and generate outputs.",
   "author": {
     "name": "nvk",

--- a/plugins/llm-wiki/hooks/hooks.json
+++ b/plugins/llm-wiki/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
             "timeout": 5,
             "statusMessage": "Loading llm-wiki session context"
           }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
             "timeout": 5,
             "statusMessage": "Checking llm-wiki session context"
           }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
             "timeout": 5,
             "statusMessage": "Recording llm-wiki session event"
           }
@@ -43,7 +43,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
             "timeout": 5,
             "statusMessage": "Capturing llm-wiki pre-compact session context"
           }
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
             "timeout": 5,
             "statusMessage": "Capturing llm-wiki post-compact session context"
           }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
             "timeout": 5,
             "statusMessage": "Saving llm-wiki session checkpoint"
           }

--- a/plugins/llm-wiki/hooks/hooks.json
+++ b/plugins/llm-wiki/hooks/hooks.json
@@ -1,0 +1,79 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "timeout": 5,
+            "statusMessage": "Loading llm-wiki session context"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "timeout": 5,
+            "statusMessage": "Checking llm-wiki session context"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "timeout": 5,
+            "statusMessage": "Recording llm-wiki session event"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "timeout": 5,
+            "statusMessage": "Capturing llm-wiki pre-compact session context"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "timeout": 5,
+            "statusMessage": "Capturing llm-wiki post-compact session context"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "timeout": 5,
+            "statusMessage": "Saving llm-wiki session checkpoint"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/llm-wiki/hooks/llm_wiki_session.py
+++ b/plugins/llm-wiki/hooks/llm_wiki_session.py
@@ -41,8 +41,8 @@ CONTENT_KEY_RE = re.compile(
 
 DEFAULT_CONFIG: dict[str, Any] = {
     "schema_version": SCHEMA_VERSION,
-    "enabled": False,
-    "mode": "capture-only",
+    "enabled": True,
+    "mode": "balanced",
     "auto_capture": {
         "tool_events": DEFAULT_TOOL_THRESHOLD,
         "pre_compact": True,
@@ -51,8 +51,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "stop": True,
     },
     "rehydrate": {
-        "session_start": False,
-        "user_prompt": False,
+        "session_start": True,
+        "user_prompt": True,
         "strict": False,
     },
     "raw_transcripts": False,
@@ -117,7 +117,12 @@ AGGRESSIVE_CONFIG = {
 }
 
 MODE_CONFIGS = {
-    "off": {**DEFAULT_CONFIG, "mode": "off"},
+    "off": {
+        **DEFAULT_CONFIG,
+        "enabled": False,
+        "mode": "off",
+        "rehydrate": {"session_start": False, "user_prompt": False, "strict": False},
+    },
     "capture-only": {**DEFAULT_CONFIG, **CAPTURE_ONLY_CONFIG},
     "balanced": {**DEFAULT_CONFIG, **BALANCED_CONFIG},
     "aggressive": {**DEFAULT_CONFIG, **AGGRESSIVE_CONFIG},
@@ -1042,7 +1047,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--local", action="store_true", help="Use .wiki/.sessions in the current directory.")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    enable = sub.add_parser("enable", help="Enable automated session capture in HUB/.sessions/config.json.")
+    enable = sub.add_parser("enable", help="Enable or reconfigure automated session capture in HUB/.sessions/config.json.")
     enable.add_argument("--mode", choices=sorted(MODE_CONFIGS), default="balanced")
     enable.add_argument("--tool-events", type=int, help="Override automated tool-event checkpoint threshold.")
     enable.add_argument("--force", action="store_true", help="Replace existing config instead of merging.")
@@ -1059,7 +1064,7 @@ def build_parser() -> argparse.ArgumentParser:
     hook.add_argument("--topic", help="Attach a topic tag to this event/state.")
     hook.add_argument("--summary", help="Manual summary to append to state.")
     hook.add_argument("--trigger", help="Override capture trigger name.")
-    hook.add_argument("--if-enabled", action="store_true", help="No-op unless .sessions/config.json has enabled=true.")
+    hook.add_argument("--if-enabled", action="store_true", help="Honor .sessions/config.json enabled=false; default is enabled when no config exists.")
     hook.add_argument("--max-event-bytes", type=int, default=MAX_EVENT_PREVIEW_CHARS)
     hook.set_defaults(func=run_hook)
 

--- a/plugins/llm-wiki/hooks/llm_wiki_session.py
+++ b/plugins/llm-wiki/hooks/llm_wiki_session.py
@@ -1,0 +1,1121 @@
+#!/usr/bin/env python3
+"""Automated session capture helpers for llm-wiki.
+
+This helper is intentionally deterministic and local-only. Harness hooks call the
+`hook` subcommand with one JSON object on stdin. The hook path records a small,
+redacted event, updates per-session state under HUB/.sessions, and writes a
+markdown digest at configured checkpoints. It never calls an LLM or copies raw
+transcripts by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+DEFAULT_TOOL_THRESHOLD = 50
+MAX_LAST_EVENTS = 20
+MAX_EVENT_PREVIEW_CHARS = 1200
+SESSION_ID_SAFE = re.compile(r"[^A-Za-z0-9_.@:+-]+")
+SECRET_KEY_RE = re.compile(
+    r"(?i)(api[_-]?key|authorization|bearer|token|secret|password|passwd|private[_-]?key|access[_-]?key|session[_-]?cookie|cookie)"
+)
+SECRET_VALUE_RE = re.compile(
+    r"(?i)(bearer\s+)[A-Za-z0-9._~+\-/=]{12,}|"
+    r"(sk-[A-Za-z0-9]{12,})|"
+    r"([A-Za-z0-9_\-]{24,}\.[A-Za-z0-9_\-]{12,}\.[A-Za-z0-9_\-]{12,})"
+)
+CONTENT_KEY_RE = re.compile(
+    r"(?i)^(prompt|user_prompt|message|messages|content|transcript|tool_response|tool_output|response|result|stdout|stderr)$"
+)
+
+DEFAULT_CONFIG: dict[str, Any] = {
+    "schema_version": SCHEMA_VERSION,
+    "enabled": False,
+    "mode": "capture-only",
+    "auto_capture": {
+        "tool_events": DEFAULT_TOOL_THRESHOLD,
+        "pre_compact": True,
+        "post_compact": True,
+        "session_end": True,
+        "stop": True,
+    },
+    "rehydrate": {
+        "session_start": False,
+        "user_prompt": False,
+        "strict": False,
+    },
+    "raw_transcripts": False,
+    "privacy": "redacted",
+}
+
+BALANCED_CONFIG = {
+    "enabled": True,
+    "mode": "balanced",
+    "auto_capture": {
+        "tool_events": DEFAULT_TOOL_THRESHOLD,
+        "pre_compact": True,
+        "post_compact": True,
+        "session_end": True,
+        "stop": True,
+    },
+    "rehydrate": {
+        "session_start": True,
+        "user_prompt": True,
+        "strict": False,
+    },
+    "raw_transcripts": False,
+    "privacy": "redacted",
+}
+
+CAPTURE_ONLY_CONFIG = {
+    "enabled": True,
+    "mode": "capture-only",
+    "auto_capture": {
+        "tool_events": DEFAULT_TOOL_THRESHOLD,
+        "pre_compact": True,
+        "post_compact": True,
+        "session_end": True,
+        "stop": True,
+    },
+    "rehydrate": {
+        "session_start": False,
+        "user_prompt": False,
+        "strict": False,
+    },
+    "raw_transcripts": False,
+    "privacy": "redacted",
+}
+
+AGGRESSIVE_CONFIG = {
+    "enabled": True,
+    "mode": "aggressive",
+    "auto_capture": {
+        "tool_events": 25,
+        "pre_compact": True,
+        "post_compact": True,
+        "session_end": True,
+        "stop": True,
+    },
+    "rehydrate": {
+        "session_start": True,
+        "user_prompt": True,
+        "strict": False,
+    },
+    "raw_transcripts": False,
+    "privacy": "redacted",
+}
+
+MODE_CONFIGS = {
+    "off": {**DEFAULT_CONFIG, "mode": "off"},
+    "capture-only": {**DEFAULT_CONFIG, **CAPTURE_ONLY_CONFIG},
+    "balanced": {**DEFAULT_CONFIG, **BALANCED_CONFIG},
+    "aggressive": {**DEFAULT_CONFIG, **AGGRESSIVE_CONFIG},
+}
+
+
+class HookSkip(Exception):
+    """Raised when a hook should silently do nothing."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def today() -> str:
+    return dt.date.today().isoformat()
+
+
+def expand_leading_tilde(value: str) -> Path:
+    if value == "~":
+        return Path.home()
+    if value.startswith("~/"):
+        return Path.home() / value[2:]
+    return Path(value)
+
+
+def resolve_hub(args: argparse.Namespace) -> Path:
+    if getattr(args, "local", False):
+        return Path.cwd() / ".wiki"
+    if getattr(args, "hub", None):
+        return expand_leading_tilde(str(args.hub))
+    config = Path.home() / ".config" / "llm-wiki" / "config.json"
+    if config.exists():
+        try:
+            data = json.loads(config.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"invalid llm-wiki config {config}: {exc}") from exc
+        hub_path = data.get("hub_path") or data.get("resolved_path")
+        if hub_path:
+            return expand_leading_tilde(str(hub_path))
+    return Path.home() / "wiki"
+
+
+def sessions_dir(hub: Path) -> Path:
+    return hub / ".sessions"
+
+
+def safe_id(value: str) -> str:
+    cleaned = SESSION_ID_SAFE.sub("-", value).strip(".-")
+    if not cleaned:
+        cleaned = hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+    return cleaned[:120]
+
+
+def state_path(root: Path, harness: str, native_session_id: str) -> Path:
+    return root / "state" / safe_id(harness) / f"{safe_id(native_session_id)}.json"
+
+
+def digest_path(root: Path, harness: str, native_session_id: str, now: str | None = None) -> Path:
+    when = parse_timestamp(now or utc_now())
+    return (
+        root
+        / "digests"
+        / f"{when.year:04d}"
+        / f"{when.month:02d}"
+        / f"{safe_id(harness)}-{safe_id(native_session_id)}.md"
+    )
+
+
+def parse_timestamp(value: str) -> dt.datetime:
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = dt.datetime.fromisoformat(normalized)
+    except ValueError:
+        return dt.datetime.now(dt.UTC)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
+
+
+def read_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, data: Any) -> None:
+    atomic_write(path, json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+def append_jsonl(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(data, sort_keys=True, ensure_ascii=False) + "\n")
+
+
+def merge_dict(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    result = json.loads(json.dumps(base))
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = merge_dict(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def load_config(root: Path) -> dict[str, Any]:
+    data = merge_dict(DEFAULT_CONFIG, {})
+    path = root / "config.json"
+    if path.exists():
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict):
+            data = merge_dict(data, loaded)
+    return data
+
+
+def mode_config(mode: str) -> dict[str, Any]:
+    if mode not in MODE_CONFIGS:
+        raise SystemExit(f"unknown session mode: {mode}")
+    return merge_dict(DEFAULT_CONFIG, MODE_CONFIGS[mode])
+
+
+def ensure_layout(root: Path) -> None:
+    for rel in ["state", "queue", "digests", "indexes"]:
+        (root / rel).mkdir(parents=True, exist_ok=True)
+
+
+def omitted_value(value: Any) -> str:
+    try:
+        text = json.dumps(value, sort_keys=True, ensure_ascii=False)
+    except TypeError:
+        text = str(value)
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+    return f"[OMITTED len={len(text)} sha256={digest}]"
+
+
+def redact_scalar(value: Any, key_hint: str = "") -> Any:
+    if value is None or isinstance(value, bool) or isinstance(value, (int, float)):
+        return value
+    if SECRET_KEY_RE.search(key_hint):
+        return "[REDACTED]"
+    text = str(value)
+    text = SECRET_VALUE_RE.sub(lambda m: (m.group(1) or "") + "[REDACTED]", text)
+    if len(text) > MAX_EVENT_PREVIEW_CHARS:
+        text = text[:MAX_EVENT_PREVIEW_CHARS] + "…"
+    return text
+
+
+def redact(value: Any, key_hint: str = "") -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, nested in value.items():
+            key_text = str(key)
+            if SECRET_KEY_RE.search(key_text):
+                redacted[key_text] = "[REDACTED]"
+            elif CONTENT_KEY_RE.search(key_text):
+                redacted[key_text] = omitted_value(nested)
+            else:
+                redacted[key_text] = redact(nested, key_text)
+        return redacted
+    if isinstance(value, list):
+        return [redact(item, key_hint) for item in value[:20]]
+    return redact_scalar(value, key_hint)
+
+
+def compact_json(value: Any, max_chars: int = MAX_EVENT_PREVIEW_CHARS) -> str:
+    text = json.dumps(redact(value), sort_keys=True, ensure_ascii=False)
+    if len(text) > max_chars:
+        return text[:max_chars] + "…"
+    return text
+
+
+def detect_harness(args: argparse.Namespace, payload: dict[str, Any]) -> str:
+    if getattr(args, "harness", None):
+        return str(args.harness)
+    env_harness = os.environ.get("LLM_WIKI_HARNESS")
+    if env_harness:
+        return env_harness
+    if os.environ.get("PLUGIN_ROOT") or "model" in payload:
+        return "codex"
+    if "permission_mode" in payload or "agent_id" in payload:
+        return "claude"
+    return "unknown"
+
+
+def fallback_session_id(payload: dict[str, Any]) -> str:
+    parts = [
+        str(payload.get("transcript_path") or ""),
+        str(payload.get("cwd") or ""),
+        str(payload.get("model") or ""),
+    ]
+    basis = "|".join(parts).strip("|") or utc_now()
+    return "derived-" + hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
+
+
+def git_value(cwd: str | None, args: list[str]) -> str | None:
+    if not cwd:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=1.5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def normalize_event(args: argparse.Namespace, payload: dict[str, Any], root: Path) -> dict[str, Any]:
+    now = utc_now()
+    harness = safe_id(detect_harness(args, payload))
+    native_session_id = str(
+        getattr(args, "session_id", None)
+        or payload.get("session_id")
+        or payload.get("sessionId")
+        or fallback_session_id(payload)
+    )
+    event_name = str(
+        getattr(args, "event_name", None)
+        or payload.get("hook_event_name")
+        or payload.get("hookEventName")
+        or payload.get("event")
+        or "manual"
+    )
+    cwd = str(getattr(args, "cwd", None) or payload.get("cwd") or os.getcwd())
+    transcript_path = payload.get("transcript_path") or payload.get("transcriptPath")
+    tool_name = payload.get("tool_name") or payload.get("toolName") or payload.get("tool")
+    trigger = str(getattr(args, "trigger", None) or event_name)
+    event = {
+        "schema_version": SCHEMA_VERSION,
+        "ts": now,
+        "event": "session_event",
+        "harness": harness,
+        "hook_event_name": event_name,
+        "native_session_id": native_session_id,
+        "llm_wiki_session_id": f"{harness}:{native_session_id}",
+        "cwd": cwd,
+        "transcript_path": str(transcript_path) if transcript_path else None,
+        "model": payload.get("model"),
+        "turn_id": payload.get("turn_id") or payload.get("turnId"),
+        "tool_name": str(tool_name) if tool_name else None,
+        "tool_use_id": payload.get("tool_use_id") or payload.get("toolUseId"),
+        "trigger": trigger,
+        "payload_preview": compact_json(payload, max_chars=int(getattr(args, "max_event_bytes", MAX_EVENT_PREVIEW_CHARS))),
+    }
+    if getattr(args, "topic", None):
+        event["topics"] = [args.topic]
+    if getattr(args, "summary", None):
+        event["manual_summary"] = str(args.summary)
+    if transcript_path:
+        event["transcript_path_hash"] = hashlib.sha256(str(transcript_path).encode("utf-8")).hexdigest()
+    return event
+
+
+def event_queue_path(root: Path, event: dict[str, Any]) -> Path:
+    return root / "queue" / f"{event['ts'][:10]}.jsonl"
+
+
+def load_state(root: Path, event: dict[str, Any]) -> tuple[dict[str, Any], bool, Path]:
+    path = state_path(root, event["harness"], event["native_session_id"])
+    is_new = not path.exists()
+    state = read_json(path, {})
+    if not isinstance(state, dict):
+        state = {}
+        is_new = True
+    return state, is_new, path
+
+
+def update_state(root: Path, event: dict[str, Any], config: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    state, is_new, path = load_state(root, event)
+    now = str(event["ts"])
+    state.setdefault("schema_version", SCHEMA_VERSION)
+    state.setdefault("harness", event["harness"])
+    state.setdefault("native_session_id", event["native_session_id"])
+    state.setdefault("llm_wiki_session_id", event["llm_wiki_session_id"])
+    state.setdefault("started_at", now)
+    state["last_seen_at"] = now
+    state["cwd"] = event.get("cwd")
+    state["transcript_path"] = event.get("transcript_path")
+    state["model"] = event.get("model") or state.get("model")
+    state["privacy"] = config.get("privacy", "redacted")
+    state["raw_transcripts"] = bool(config.get("raw_transcripts", False))
+    state["git_remote"] = git_value(event.get("cwd"), ["config", "--get", "remote.origin.url"])
+    state["git_branch"] = git_value(event.get("cwd"), ["branch", "--show-current"])
+    state["event_count"] = int(state.get("event_count") or 0) + 1
+    if is_tool_event(event):
+        state["tool_event_count"] = int(state.get("tool_event_count") or 0) + 1
+    else:
+        state.setdefault("tool_event_count", int(state.get("tool_event_count") or 0))
+    topics = set(as_list(state.get("topics")))
+    topics.update(str(item) for item in as_list(event.get("topics")))
+    if topics:
+        state["topics"] = sorted(topics)
+    summaries = as_list(state.get("manual_summaries"))
+    if event.get("manual_summary"):
+        summaries.append(str(event["manual_summary"]))
+        state["manual_summaries"] = summaries[-10:]
+    if event.get("hook_event_name") == "PostCompact":
+        state["last_compact_event"] = event.get("payload_preview")
+    last_events = as_list(state.get("last_events"))
+    last_events.append(
+        {
+            "ts": event.get("ts"),
+            "hook_event_name": event.get("hook_event_name"),
+            "tool_name": event.get("tool_name"),
+            "turn_id": event.get("turn_id"),
+            "trigger": event.get("trigger"),
+        }
+    )
+    state["last_events"] = last_events[-MAX_LAST_EVENTS:]
+    write_json(path, state)
+    return state, is_new
+
+
+def as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def is_tool_event(event: dict[str, Any]) -> bool:
+    name = str(event.get("hook_event_name") or "")
+    return bool(event.get("tool_name")) or name in {"PreToolUse", "PostToolUse", "PermissionRequest", "BeforeTool", "AfterTool"}
+
+
+def should_write_digest(state: dict[str, Any], event: dict[str, Any], config: dict[str, Any], force: bool = False) -> tuple[bool, str]:
+    if force:
+        return True, str(event.get("trigger") or "manual")
+    auto = config.get("auto_capture") if isinstance(config.get("auto_capture"), dict) else {}
+    event_name = str(event.get("hook_event_name") or "")
+    lower = event_name.lower().replace("_", "")
+    if lower in {"precompact", "precompress"} and auto.get("pre_compact", True):
+        return True, "pre-compact"
+    if lower in {"postcompact", "postcompress"} and auto.get("post_compact", True):
+        return True, "post-compact"
+    if lower in {"sessionend", "afteragent"} and auto.get("session_end", True):
+        return True, "session-end"
+    if lower in {"stop", "stopfailure"} and auto.get("stop", True):
+        return True, "stop"
+    threshold = int(auto.get("tool_events") or 0)
+    tool_count = int(state.get("tool_event_count") or 0)
+    if threshold > 0 and is_tool_event(event) and tool_count > 0 and tool_count % threshold == 0:
+        return True, f"tool-count-{threshold}"
+    return False, ""
+
+
+def yaml_string(value: Any) -> str:
+    text = "" if value is None else str(value)
+    if text == "":
+        return '""'
+    if re.fullmatch(r"[A-Za-z0-9_.:/@+ -]+", text):
+        return json.dumps(text)
+    return json.dumps(text)
+
+
+def yaml_list(values: list[Any]) -> str:
+    return "[" + ", ".join(yaml_string(item) for item in values) + "]"
+
+
+def digest_summary(state: dict[str, Any], trigger: str) -> str:
+    manual = as_list(state.get("manual_summaries"))
+    if manual:
+        return str(manual[-1])[:240]
+    cwd = state.get("cwd") or "unknown cwd"
+    return f"Automated {trigger} checkpoint for {state.get('llm_wiki_session_id')} in {cwd}."
+
+
+def frontmatter_block(state: dict[str, Any], trigger: str, digest_file: Path) -> str:
+    summary = digest_summary(state, trigger)
+    topics = as_list(state.get("topics"))
+    lines = [
+        "---",
+        f"title: {yaml_string('Session Digest: ' + str(state.get('llm_wiki_session_id')))}",
+        "type: session-digest",
+        f"schema_version: {SCHEMA_VERSION}",
+        f"harness: {yaml_string(state.get('harness'))}",
+        f"native_session_id: {yaml_string(state.get('native_session_id'))}",
+        f"llm_wiki_session_id: {yaml_string(state.get('llm_wiki_session_id'))}",
+        f"cwd: {yaml_string(state.get('cwd'))}",
+        f"git_remote: {yaml_string(state.get('git_remote'))}",
+        f"git_branch: {yaml_string(state.get('git_branch'))}",
+        f"transcript_path: {yaml_string(state.get('transcript_path'))}",
+        f"started_at: {yaml_string(state.get('started_at'))}",
+        f"last_seen_at: {yaml_string(state.get('last_seen_at'))}",
+        f"tool_event_count: {int(state.get('tool_event_count') or 0)}",
+        f"event_count: {int(state.get('event_count') or 0)}",
+        f"capture_trigger: {yaml_string(trigger)}",
+        f"topics: {yaml_list(topics)}",
+        "topic_candidates: []",
+        f"privacy: {yaml_string(state.get('privacy') or 'redacted')}",
+        f"raw_transcripts: {str(bool(state.get('raw_transcripts'))).lower()}",
+        "promoted_to: []",
+        f"summary: {yaml_string(summary)}",
+        "---",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def markdown_table(rows: list[tuple[str, str]]) -> str:
+    out = ["| Field | Value |", "|---|---|"]
+    for key, value in rows:
+        safe = str(value or "").replace("|", "\\|").replace("\n", " ")
+        out.append(f"| {key} | {safe} |")
+    return "\n".join(out)
+
+
+def render_digest(state: dict[str, Any], trigger: str, digest_file: Path) -> str:
+    summary = digest_summary(state, trigger)
+    last_events = as_list(state.get("last_events"))[-12:]
+    event_lines = []
+    for event in last_events:
+        event_lines.append(
+            f"- `{event.get('ts')}` — {event.get('hook_event_name')}"
+            + (f" / {event.get('tool_name')}" if event.get("tool_name") else "")
+        )
+    if not event_lines:
+        event_lines.append("- No hook events recorded yet.")
+
+    manual = as_list(state.get("manual_summaries"))
+    manual_lines = [f"- {item}" for item in manual[-5:]] or ["- None recorded."]
+
+    body = f"""
+# Session Digest: {state.get('llm_wiki_session_id')}
+
+## Summary
+
+{summary}
+
+## Session Identity
+
+{markdown_table([
+        ('Harness', state.get('harness')),
+        ('Native session ID', state.get('native_session_id')),
+        ('llm-wiki session ID', state.get('llm_wiki_session_id')),
+        ('CWD', state.get('cwd')),
+        ('Git remote', state.get('git_remote')),
+        ('Git branch', state.get('git_branch')),
+        ('Transcript pointer', state.get('transcript_path')),
+        ('Started at', state.get('started_at')),
+        ('Last seen at', state.get('last_seen_at')),
+        ('Capture trigger', trigger),
+        ('Observed tool events', state.get('tool_event_count')),
+        ('Observed total events', state.get('event_count')),
+    ])}
+
+## Manual Summaries
+
+{chr(10).join(manual_lines)}
+
+## Recent Observed Events
+
+{chr(10).join(event_lines)}
+
+## Distillation Notes
+
+- This digest is an automated checkpoint generated from redacted hook metadata.
+- Raw transcript text is not copied by default; use the transcript pointer only if the harness still owns a readable transcript and the user approves.
+- Promote useful distilled learnings into a topic wiki with `llm-wiki-session promote`; do not treat this operational digest as canonical topic knowledge until promoted.
+
+## Open Loops
+
+- Review whether this session should be topic-tagged or promoted.
+- If the session ended mid-task, use `llm-wiki-session rehydrate --session-id {state.get('llm_wiki_session_id')}` before continuing.
+""".strip()
+    return frontmatter_block(state, trigger, digest_file) + "\n" + body + "\n"
+
+
+def write_digest(root: Path, state: dict[str, Any], trigger: str) -> Path:
+    path = digest_path(root, str(state["harness"]), str(state["native_session_id"]), str(state.get("last_seen_at") or utc_now()))
+    text = render_digest(state, trigger, path)
+    atomic_write(path, text)
+    state["last_digest_path"] = str(path)
+    state["last_digest_at"] = utc_now()
+    state["digest_count"] = int(state.get("digest_count") or 0) + 1
+    write_json(state_path(root, str(state["harness"]), str(state["native_session_id"])), state)
+    append_jsonl(
+        root / "registry.jsonl",
+        {
+            "schema_version": SCHEMA_VERSION,
+            "ts": utc_now(),
+            "event": "digest_written",
+            "llm_wiki_session_id": state.get("llm_wiki_session_id"),
+            "harness": state.get("harness"),
+            "native_session_id": state.get("native_session_id"),
+            "digest_path": str(path),
+            "capture_trigger": trigger,
+            "cwd": state.get("cwd"),
+            "topics": as_list(state.get("topics")),
+        },
+    )
+    rebuild_indexes(root)
+    return path
+
+
+def rebuild_indexes(root: Path) -> None:
+    by_cwd: dict[str, list[dict[str, Any]]] = {}
+    by_topic: dict[str, list[dict[str, Any]]] = {}
+    states: list[dict[str, Any]] = []
+    for path in sorted((root / "state").glob("*/*.json")):
+        try:
+            state = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(state, dict):
+            continue
+        states.append(state)
+        record = {
+            "llm_wiki_session_id": state.get("llm_wiki_session_id"),
+            "harness": state.get("harness"),
+            "native_session_id": state.get("native_session_id"),
+            "last_seen_at": state.get("last_seen_at"),
+            "last_digest_path": state.get("last_digest_path"),
+        }
+        cwd = str(state.get("cwd") or "")
+        if cwd:
+            by_cwd.setdefault(cwd, []).append(record)
+        for topic in as_list(state.get("topics")):
+            by_topic.setdefault(str(topic), []).append(record)
+    write_json(root / "indexes" / "by-cwd.json", by_cwd)
+    write_json(root / "indexes" / "by-topic.json", by_topic)
+    write_json(root / "indexes" / "sessions.json", {"sessions": states})
+
+
+def hook_output(event_name: str, context: str) -> None:
+    if not context.strip():
+        return
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": event_name,
+                    "additionalContext": context,
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def run_hook(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    config = load_config(root)
+    if args.if_enabled and not config.get("enabled"):
+        raise HookSkip()
+    ensure_layout(root)
+    raw = sys.stdin.read()
+    payload: dict[str, Any]
+    if raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"invalid hook JSON input: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise SystemExit("hook JSON input must be an object")
+        payload = parsed
+    else:
+        payload = {}
+    event = normalize_event(args, payload, root)
+    append_jsonl(event_queue_path(root, event), event)
+    state, is_new = update_state(root, event, config)
+    if is_new:
+        append_jsonl(
+            root / "registry.jsonl",
+            {
+                "schema_version": SCHEMA_VERSION,
+                "ts": event["ts"],
+                "event": "session_seen",
+                "llm_wiki_session_id": event["llm_wiki_session_id"],
+                "harness": event["harness"],
+                "native_session_id": event["native_session_id"],
+                "cwd": event.get("cwd"),
+                "transcript_path": event.get("transcript_path"),
+            },
+        )
+    write, trigger = should_write_digest(state, event, config, force=False)
+    if write:
+        write_digest(root, state, trigger)
+    else:
+        rebuild_indexes(root)
+
+    event_name = str(event.get("hook_event_name") or "")
+    rehydrate_cfg = config.get("rehydrate") if isinstance(config.get("rehydrate"), dict) else {}
+    if event_name == "SessionStart" and rehydrate_cfg.get("session_start"):
+        hook_output(event_name, build_rehydrate_context(root, cwd=event.get("cwd"), limit=3))
+    elif event_name == "UserPromptSubmit" and rehydrate_cfg.get("user_prompt"):
+        hook_output(event_name, build_rehydrate_context(root, cwd=event.get("cwd"), limit=3))
+    return 0
+
+
+def run_enable(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    ensure_layout(root)
+    config = mode_config(args.mode)
+    existing = load_config(root)
+    if (root / "config.json").exists() and not args.force:
+        config = merge_dict(existing, config)
+    if args.tool_events is not None:
+        config.setdefault("auto_capture", {})["tool_events"] = int(args.tool_events)
+    config["enabled"] = args.mode != "off"
+    write_json(root / "config.json", config)
+    print(f"llm-wiki sessions {config['mode']}: {root}")
+    print(f"enabled: {config['enabled']}")
+    print("raw_transcripts: false")
+    return 0
+
+
+def run_disable(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    ensure_layout(root)
+    config = load_config(root)
+    config["enabled"] = False
+    config["mode"] = "off"
+    write_json(root / "config.json", config)
+    print(f"llm-wiki sessions disabled: {root}")
+    return 0
+
+
+def manual_payload(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "session_id": args.session_id or f"manual-{dt.datetime.now().strftime('%Y%m%d-%H%M%S')}",
+        "hook_event_name": "ManualCapture",
+        "cwd": args.cwd or os.getcwd(),
+        "transcript_path": args.transcript_path,
+        "model": args.model,
+        "manual_summary": args.summary,
+    }
+
+
+def run_capture(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    ensure_layout(root)
+    config = load_config(root)
+    payload = manual_payload(args)
+    event = normalize_event(args, payload, root)
+    append_jsonl(event_queue_path(root, event), event)
+    state, is_new = update_state(root, event, config)
+    if is_new:
+        append_jsonl(
+            root / "registry.jsonl",
+            {
+                "schema_version": SCHEMA_VERSION,
+                "ts": event["ts"],
+                "event": "session_seen",
+                "llm_wiki_session_id": event["llm_wiki_session_id"],
+                "harness": event["harness"],
+                "native_session_id": event["native_session_id"],
+                "cwd": event.get("cwd"),
+                "transcript_path": event.get("transcript_path"),
+            },
+        )
+    path = write_digest(root, state, "manual")
+    print(str(path))
+    return 0
+
+
+def iter_states(root: Path) -> list[dict[str, Any]]:
+    states = []
+    for path in sorted((root / "state").glob("*/*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict):
+            states.append(data)
+    return sorted(states, key=lambda item: str(item.get("last_seen_at") or ""), reverse=True)
+
+
+def session_matches(state: dict[str, Any], args: argparse.Namespace) -> bool:
+    if getattr(args, "harness", None) and state.get("harness") != args.harness:
+        return False
+    if getattr(args, "cwd", None) and state.get("cwd") != args.cwd:
+        return False
+    if getattr(args, "topic", None) and args.topic not in as_list(state.get("topics")):
+        return False
+    return True
+
+
+def run_list(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    states = [state for state in iter_states(root) if session_matches(state, args)]
+    if args.json:
+        print(json.dumps({"sessions_root": str(root), "sessions": states}, indent=2, sort_keys=True))
+        return 0
+    print(f"llm-wiki sessions: {root}")
+    print("| Session | Last seen | Tools | CWD | Digest |")
+    print("|---|---:|---:|---|---|")
+    for state in states[: args.limit]:
+        print(
+            "| {sid} | {last} | {tools} | {cwd} | {digest} |".format(
+                sid=str(state.get("llm_wiki_session_id") or "").replace("|", "\\|"),
+                last=str(state.get("last_seen_at") or ""),
+                tools=int(state.get("tool_event_count") or 0),
+                cwd=str(state.get("cwd") or "").replace("|", "\\|"),
+                digest=str(state.get("last_digest_path") or ""),
+            )
+        )
+    return 0
+
+
+def find_session(root: Path, session_id: str) -> dict[str, Any] | None:
+    for state in iter_states(root):
+        if session_id in {state.get("llm_wiki_session_id"), state.get("native_session_id")}:
+            return state
+    return None
+
+
+def split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    raw = text[4:end]
+    body = text[end + 5 :]
+    data: dict[str, Any] = {}
+    for line in raw.splitlines():
+        if not line.strip() or ":" not in line or line.startswith(" "):
+            continue
+        key, value = line.split(":", 1)
+        value = value.strip()
+        if value.startswith("[") and value.endswith("]"):
+            try:
+                data[key.strip()] = json.loads(value)
+            except json.JSONDecodeError:
+                data[key.strip()] = []
+        else:
+            data[key.strip()] = value.strip('"')
+    return data, body
+
+
+def run_show(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    state = find_session(root, args.session_id)
+    if not state:
+        raise SystemExit(f"session not found: {args.session_id}")
+    digest = state.get("last_digest_path")
+    if not digest:
+        raise SystemExit(f"session has no digest yet: {args.session_id}")
+    path = Path(str(digest))
+    if args.path_only:
+        print(str(path))
+    else:
+        print(path.read_text(encoding="utf-8"))
+    return 0
+
+
+def build_rehydrate_context(root: Path, cwd: str | None = None, session_id: str | None = None, topic: str | None = None, limit: int = 3) -> str:
+    candidates = iter_states(root)
+    selected: list[dict[str, Any]] = []
+    for state in candidates:
+        if session_id and session_id not in {state.get("llm_wiki_session_id"), state.get("native_session_id")}:
+            continue
+        if topic and topic not in as_list(state.get("topics")):
+            continue
+        if cwd and not session_id and not topic and state.get("cwd") != cwd:
+            continue
+        if state.get("last_digest_path"):
+            selected.append(state)
+        if len(selected) >= limit:
+            break
+    if not selected:
+        return ""
+    lines = [
+        "llm-wiki session context: review these distilled session digests before continuing.",
+    ]
+    for state in selected:
+        lines.append(
+            f"- {state.get('llm_wiki_session_id')} — {digest_summary(state, 'rehydrate')} "
+            f"Digest: {state.get('last_digest_path')}"
+        )
+    lines.append("Do not treat session digests as canonical topic knowledge until promoted into a topic wiki.")
+    return "\n".join(lines)
+
+
+def run_rehydrate(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    context = build_rehydrate_context(root, cwd=args.cwd, session_id=args.session_id, topic=args.topic, limit=args.limit)
+    if not context:
+        print("No matching session digests found.")
+        return 1
+    print(context)
+    return 0
+
+
+def read_registry(hub: Path) -> dict[str, Any]:
+    path = hub / "wikis.json"
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_registry_path(raw_path: str, hub: Path) -> Path:
+    if raw_path in {".", "<HUB>", "HUB"}:
+        return hub
+    if raw_path.startswith("<HUB>/"):
+        return hub / raw_path[len("<HUB>/") :]
+    if raw_path.startswith("HUB/"):
+        return hub / raw_path[len("HUB/") :]
+    path = expand_leading_tilde(raw_path)
+    if path.is_absolute():
+        return path
+    return hub / path
+
+
+def topic_path(hub: Path, slug: str) -> Path:
+    registry = read_registry(hub)
+    entry = registry.get("wikis", {}).get(slug) if isinstance(registry.get("wikis"), dict) else None
+    if isinstance(entry, dict) and entry.get("path"):
+        return resolve_registry_path(str(entry["path"]), hub)
+    return hub / "topics" / slug
+
+
+def slugify(value: str) -> str:
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    return value.strip("-")[:80] or "session"
+
+
+def append_topic_log(topic_root: Path, message: str) -> None:
+    log = topic_root / "log.md"
+    if log.exists():
+        with log.open("a", encoding="utf-8") as handle:
+            handle.write(f"\n## [{today()}] session | {message}\n")
+
+
+def run_promote(args: argparse.Namespace) -> int:
+    hub = resolve_hub(args)
+    root = sessions_dir(hub)
+    state = find_session(root, args.session_id)
+    if not state:
+        raise SystemExit(f"session not found: {args.session_id}")
+    digest = state.get("last_digest_path")
+    if not digest:
+        raise SystemExit(f"session has no digest yet: {args.session_id}")
+    digest_file = Path(str(digest))
+    digest_text = digest_file.read_text(encoding="utf-8")
+    fm, body = split_frontmatter(digest_text)
+    topic_root = topic_path(hub, args.topic)
+    notes = topic_root / "raw" / "notes"
+    if not notes.exists():
+        raise SystemExit(f"topic raw notes directory not found: {notes}")
+    filename = f"{today()}-session-{slugify(str(state.get('harness')))}-{slugify(str(state.get('native_session_id')))}.md"
+    dest = notes / filename
+    if dest.exists() and not args.force:
+        raise SystemExit(f"promotion note already exists: {dest}")
+    summary = fm.get("summary") or digest_summary(state, "promote")
+    promoted = textwrap.dedent(
+        f"""
+        ---
+        title: {yaml_string('Session Digest Promotion: ' + str(state.get('llm_wiki_session_id')))}
+        source: {yaml_string(str(digest_file))}
+        type: notes
+        ingested: {today()}
+        tags: [session-digest, session-promotion, {yaml_string(args.topic)}]
+        summary: {yaml_string(summary)}
+        ---
+
+        # Session Digest Promotion: {state.get('llm_wiki_session_id')}
+
+        Source digest: [{digest_file.name}]({digest_file})
+
+        This note promotes a distilled session checkpoint into the `{args.topic}` topic raw layer. It intentionally promotes the digest, not the raw transcript.
+
+        {body.strip()}
+        """
+    ).strip() + "\n"
+    atomic_write(dest, promoted)
+    topics = set(as_list(state.get("topics")))
+    topics.add(args.topic)
+    state["topics"] = sorted(topics)
+    promoted_to = as_list(state.get("promoted_to"))
+    promoted_to.append(str(dest))
+    state["promoted_to"] = sorted(set(str(item) for item in promoted_to))
+    write_json(state_path(root, str(state["harness"]), str(state["native_session_id"])), state)
+    rebuild_indexes(root)
+    append_topic_log(topic_root, f"promoted session digest {state.get('llm_wiki_session_id')} → raw/notes/{filename}")
+    print(str(dest))
+    return 0
+
+
+def run_status(args: argparse.Namespace) -> int:
+    hub = resolve_hub(args)
+    root = sessions_dir(hub)
+    config = load_config(root)
+    states = iter_states(root) if root.exists() else []
+    report = {
+        "hub": str(hub),
+        "sessions_root": str(root),
+        "enabled": bool(config.get("enabled")),
+        "mode": config.get("mode"),
+        "session_count": len(states),
+        "config": config,
+    }
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"llm-wiki sessions: {root}")
+        print(f"enabled: {report['enabled']}")
+        print(f"mode: {report['mode']}")
+        print(f"sessions: {report['session_count']}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="llm-wiki-session", description="Capture and rehydrate llm-wiki session context.")
+    parser.add_argument("--hub", help="Override wiki hub path.")
+    parser.add_argument("--local", action="store_true", help="Use .wiki/.sessions in the current directory.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    enable = sub.add_parser("enable", help="Enable automated session capture in HUB/.sessions/config.json.")
+    enable.add_argument("--mode", choices=sorted(MODE_CONFIGS), default="balanced")
+    enable.add_argument("--tool-events", type=int, help="Override automated tool-event checkpoint threshold.")
+    enable.add_argument("--force", action="store_true", help="Replace existing config instead of merging.")
+    enable.set_defaults(func=run_enable)
+
+    disable = sub.add_parser("disable", help="Disable automated session capture.")
+    disable.set_defaults(func=run_disable)
+
+    hook = sub.add_parser("hook", help="Record a harness hook event from JSON on stdin.")
+    hook.add_argument("--harness", help="Harness name, e.g. codex, claude, opencode, gemini.")
+    hook.add_argument("--event-name", help="Override hook event name.")
+    hook.add_argument("--session-id", help="Override native session id.")
+    hook.add_argument("--cwd", help="Override session cwd.")
+    hook.add_argument("--topic", help="Attach a topic tag to this event/state.")
+    hook.add_argument("--summary", help="Manual summary to append to state.")
+    hook.add_argument("--trigger", help="Override capture trigger name.")
+    hook.add_argument("--if-enabled", action="store_true", help="No-op unless .sessions/config.json has enabled=true.")
+    hook.add_argument("--max-event-bytes", type=int, default=MAX_EVENT_PREVIEW_CHARS)
+    hook.set_defaults(func=run_hook)
+
+    capture = sub.add_parser("capture", help="Force a manual session digest checkpoint.")
+    capture.add_argument("--harness", default="manual")
+    capture.add_argument("--session-id", help="Native session id; defaults to manual timestamp.")
+    capture.add_argument("--cwd", help="Session working directory; defaults to current directory.")
+    capture.add_argument("--transcript-path", help="Transcript pointer to record without copying contents.")
+    capture.add_argument("--model", help="Model/profile label to record.")
+    capture.add_argument("--topic", help="Topic tag to attach to this digest.")
+    capture.add_argument("--summary", help="Short manual summary for the digest.")
+    capture.set_defaults(func=run_capture)
+
+    list_cmd = sub.add_parser("list", help="List captured sessions.")
+    list_cmd.add_argument("--harness", help="Filter by harness.")
+    list_cmd.add_argument("--cwd", help="Filter by cwd.")
+    list_cmd.add_argument("--topic", help="Filter by topic tag.")
+    list_cmd.add_argument("--limit", type=int, default=20)
+    list_cmd.add_argument("--json", action="store_true")
+    list_cmd.set_defaults(func=run_list)
+
+    show = sub.add_parser("show", help="Show a session digest.")
+    show.add_argument("session_id", help="llm-wiki session id or native session id.")
+    show.add_argument("--path-only", action="store_true")
+    show.set_defaults(func=run_show)
+
+    rehydrate = sub.add_parser("rehydrate", help="Print a compact context block from matching session digests.")
+    rehydrate.add_argument("--session-id", help="llm-wiki session id or native session id.")
+    rehydrate.add_argument("--cwd", help="Match sessions by cwd; defaults to current cwd.")
+    rehydrate.add_argument("--topic", help="Match sessions by topic tag.")
+    rehydrate.add_argument("--limit", type=int, default=3)
+    rehydrate.set_defaults(func=run_rehydrate)
+
+    promote = sub.add_parser("promote", help="Promote a session digest into a topic raw note.")
+    promote.add_argument("session_id", help="llm-wiki session id or native session id.")
+    promote.add_argument("--topic", required=True, help="Target topic slug.")
+    promote.add_argument("--force", action="store_true")
+    promote.set_defaults(func=run_promote)
+
+    status = sub.add_parser("status", help="Show session capture status.")
+    status.add_argument("--json", action="store_true")
+    status.set_defaults(func=run_status)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except HookSkip:
+        return 0
+    except BrokenPipeError:
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/llm-wiki/skills/wiki/SKILL.md
+++ b/plugins/llm-wiki/skills/wiki/SKILL.md
@@ -2,14 +2,14 @@
 name: wiki
 description: >
   LLM-compiled knowledge base manager for Codex. Use it to initialize, ingest,
-  import source collections, collect catalogs, track inventory, index datasets, archive old topics, compile, query, lint, audit, research, plan, and generate outputs from topic-scoped wikis.
+  import source collections, collect catalogs, track inventory, index datasets, archive old topics, compile, query, lint, audit, research, plan, capture or rehydrate agent session context, and generate outputs from topic-scoped wikis.
   Activates when the user mentions wiki workflows, knowledge-base management,
   ingestion, collection ingestion, import wiki, collect, catalog, curate,
   find all, inventory, source queue,
   candidate list, watch list, backlog, dataset, large data, data registry,
   dataset manifest, compilation, querying, linting, audit, research, librarian,
   scan quality, article quality, content review, output drift, provenance,
-  archive wiki, archive topic, restore wiki, implementation plan, or uses
+  archive wiki, archive topic, restore wiki, session capture, capture context, rehydrate, resume from session, implementation plan, or uses
   /wiki-style shorthand in a repo with .wiki/, ~/wiki/, or a configured hub path.
 ---
 
@@ -81,6 +81,11 @@ They remain structurally maintainable through explicit archive/lint operations.
 Deep queries may surface archived index matches separately, but archived content
 must not influence new synthesis unless the user explicitly includes it.
 
+11. **Session capture is operational memory.** Harness session digests live in
+`HUB/.sessions/` or `.wiki/.sessions/`, not in topic `raw/` by default.
+Automated hooks may capture redacted checkpoints, but promotion into topic wikis
+is explicit and user-directed.
+
 ## Ambient Behavior
 
 When this skill activates outside of an explicit `@wiki` invocation or `/wiki`-style shorthand:
@@ -121,6 +126,7 @@ reference material you need for that workflow:
 - `librarian` → `references/librarian.md`
 - wiki structure, indexes, log format, file placement, init → `references/wiki-structure.md`
 - hub lookup and path handling → `references/hub-resolution.md`
+- session capture, automated hooks, rehydration, promotion → `references/sessions.md`
 
 Collect requests create bounded catalogs of discoverable things: artifacts,
 examples, resources, entities, tools, media, memes, or source candidates. Infer

--- a/plugins/llm-wiki/skills/wiki/agents/openai.yaml
+++ b/plugins/llm-wiki/skills/wiki/agents/openai.yaml
@@ -1,8 +1,8 @@
 interface:
   display_name: "Wiki Manager"
-  short_description: "Initialize, ingest collections, collect catalogs, track inventory, index datasets, compile, audit, query, research, and lint llm-wiki knowledge bases."
+  short_description: "Initialize, ingest collections, capture sessions, track inventory, index datasets, compile, audit, query, research, and lint llm-wiki knowledge bases."
   brand_color: "#2F855A"
-  default_prompt: "Research a topic and compile it into a structured wiki."
+  default_prompt: "Research a topic, capture a session, or compile knowledge into a structured wiki."
 
 policy:
   allow_implicit_invocation: true

--- a/plugins/llm-wiki/skills/wiki/references/sessions.md
+++ b/plugins/llm-wiki/skills/wiki/references/sessions.md
@@ -36,7 +36,7 @@ HUB/.sessions/
 
 Use the same layout under `.wiki/.sessions/` for local project wikis.
 
-- `config.json` controls opt-in automation and rehydration.
+- `config.json` controls automation and rehydration. If it is absent, capture defaults to `balanced`; `enabled: false` is the opt-out switch.
 - `registry.jsonl` is append-only lifecycle metadata such as `session_seen` and
   `digest_written`.
 - `queue/*.jsonl` stores small redacted hook events. Do not store full prompts,
@@ -53,7 +53,7 @@ private. It should not be compiled as ordinary topic content. A future generated
 
 ## Config Modes
 
-Default mode after opt-in should be `balanced`:
+Default mode is `balanced`, even before a config file exists:
 
 ```json
 {
@@ -81,7 +81,7 @@ Modes:
 
 | Mode | Capture | Rehydrate | Use when |
 |---|---|---|---|
-| `off` | none | none | Disabled |
+| `off` | none | none | Disabled / user opt-out |
 | `capture-only` | automatic checkpoints | no injected context | Maximum privacy/least surprise |
 | `balanced` | automatic checkpoints | SessionStart/UserPromptSubmit soft context | Recommended default |
 | `aggressive` | more frequent checkpoints | soft context | Long, high-context work |
@@ -144,7 +144,7 @@ The command reads the harness hook JSON object from stdin and should:
 1. resolve HUB from `~/.config/llm-wiki/config.json` unless `--hub` or `--local`
    is supplied;
 2. exit 0 without writing if `--if-enabled` is set and `.sessions/config.json`
-   is missing or disabled;
+   has `enabled: false`; missing config means default-on balanced capture;
 3. append a redacted event to `queue/YYYY-MM-DD.jsonl`;
 4. update `state/<harness>/<session_id>.json`;
 5. write a digest if a capture trigger fired;
@@ -158,8 +158,8 @@ background worker instead of doing it inline inside every tool hook.
 
 Codex plugins can bundle hooks in `hooks/hooks.json`. Plugin-bundled hooks still
 require the user to review/trust them. The bundled llm-wiki Codex hook should
-call the copied helper in the plugin root and use `--if-enabled`, so installing
-the plugin does not capture anything until the user enables sessions.
+call the copied helper in the plugin root and use `--if-enabled`, so users can
+turn capture off with `session disable` without editing hook manifests.
 
 Useful Codex events:
 
@@ -227,3 +227,4 @@ not the raw transcript. Append the topic `log.md` entry. Compilation into
 - Do not auto-promote session material into topic wikis.
 - Do not let hook failures block normal agent work; fail closed to no capture,
   not to broken tool execution.
+- To opt out, run `llm-wiki-session disable` or ask `@wiki session disable`; this writes `enabled: false`.

--- a/plugins/llm-wiki/skills/wiki/references/sessions.md
+++ b/plugins/llm-wiki/skills/wiki/references/sessions.md
@@ -1,0 +1,229 @@
+# Session Context Capture
+
+Use this reference for `session`, `session capture`, `rehydrate`, "look at the
+last session", automated hook capture, and promotion of session learnings into a
+topic wiki.
+
+## Purpose
+
+Session capture preserves agent-session context without polluting curated topic
+wikis. The session layer records redacted harness metadata and markdown digests
+under the hub-level operational directory `HUB/.sessions/`. Topic wikis receive
+session knowledge only through explicit promotion into `raw/notes/`.
+
+This layer is separate from existing research-session files:
+
+| Layer | Path | Meaning |
+|---|---|---|
+| Research crash state | `.research-session.json`, `.thesis-session.json` | In-progress wiki research/thesis runs |
+| Durable research provenance | `.session-events.jsonl`, `.session-checkpoint.json` | Replayable provenance for wiki workflows |
+| Harness sessions | `HUB/.sessions/` or `.wiki/.sessions/` | Cross-runtime Codex/Claude/OpenCode/Gemini session context |
+
+## Storage Layout
+
+```text
+HUB/.sessions/
+├── config.json
+├── registry.jsonl
+├── state/<harness>/<session_id>.json
+├── queue/YYYY-MM-DD.jsonl
+├── digests/YYYY/MM/<harness>-<session_id>.md
+└── indexes/
+    ├── by-cwd.json
+    ├── by-topic.json
+    └── sessions.json
+```
+
+Use the same layout under `.wiki/.sessions/` for local project wikis.
+
+- `config.json` controls opt-in automation and rehydration.
+- `registry.jsonl` is append-only lifecycle metadata such as `session_seen` and
+  `digest_written`.
+- `queue/*.jsonl` stores small redacted hook events. Do not store full prompts,
+  tool outputs, or transcript bodies by default.
+- `state/` is the latest per-session machine state.
+- `digests/` contains human/LLM-readable markdown checkpoints with YAML
+  frontmatter.
+- `indexes/` are derived caches rebuilt from `state/`.
+
+`.sessions/` is hidden because it is operational, cross-topic, and potentially
+private. It should not be compiled as ordinary topic content. A future generated
+`HUB/_sessions.md` can expose a human-friendly index, but the canonical store is
+`.sessions/`.
+
+## Config Modes
+
+Default mode after opt-in should be `balanced`:
+
+```json
+{
+  "schema_version": 1,
+  "enabled": true,
+  "mode": "balanced",
+  "auto_capture": {
+    "tool_events": 50,
+    "pre_compact": true,
+    "post_compact": true,
+    "session_end": true,
+    "stop": true
+  },
+  "rehydrate": {
+    "session_start": true,
+    "user_prompt": true,
+    "strict": false
+  },
+  "raw_transcripts": false,
+  "privacy": "redacted"
+}
+```
+
+Modes:
+
+| Mode | Capture | Rehydrate | Use when |
+|---|---|---|---|
+| `off` | none | none | Disabled |
+| `capture-only` | automatic checkpoints | no injected context | Maximum privacy/least surprise |
+| `balanced` | automatic checkpoints | SessionStart/UserPromptSubmit soft context | Recommended default |
+| `aggressive` | more frequent checkpoints | soft context | Long, high-context work |
+
+## Capture Triggers
+
+Hooks should write deterministic checkpoints for:
+
+1. every configured number of observed tool events, default 50;
+2. pre-compaction and post-compaction;
+3. stop/session-end events;
+4. manual `session capture` requests.
+
+"Observed tool events" means events the current harness adapter exposes. Codex,
+Claude, OpenCode, and Gemini have different hook coverage, so do not promise an
+exact total count across all tool classes.
+
+## Digest Schema
+
+Session digest files are markdown with YAML frontmatter:
+
+```yaml
+title: "Session Digest: codex:abc123"
+type: session-digest
+schema_version: 1
+harness: "codex"
+native_session_id: "abc123"
+llm_wiki_session_id: "codex:abc123"
+cwd: "/path/to/project"
+git_remote: "https://github.com/org/repo.git"
+git_branch: "feature/example"
+transcript_path: "/path/to/transcript.jsonl"
+started_at: "2026-06-13T17:00:00Z"
+last_seen_at: "2026-06-13T18:10:00Z"
+tool_event_count: 50
+event_count: 61
+capture_trigger: "tool-count-50"
+topics: []
+topic_candidates: []
+privacy: "redacted"
+raw_transcripts: false
+promoted_to: []
+summary: "Automated checkpoint for codex:abc123."
+```
+
+The body should include session identity, summary, manual notes if any, recent
+observed events, distillation notes, and open loops. It should not include full
+transcript text by default.
+
+## Hook Adapter Contract
+
+Each runtime adapter should call the same deterministic helper shape:
+
+```bash
+llm-wiki-session hook --harness <codex|claude|opencode|gemini> --if-enabled
+```
+
+The command reads the harness hook JSON object from stdin and should:
+
+1. resolve HUB from `~/.config/llm-wiki/config.json` unless `--hub` or `--local`
+   is supplied;
+2. exit 0 without writing if `--if-enabled` is set and `.sessions/config.json`
+   is missing or disabled;
+3. append a redacted event to `queue/YYYY-MM-DD.jsonl`;
+4. update `state/<harness>/<session_id>.json`;
+5. write a digest if a capture trigger fired;
+6. optionally emit a short `additionalContext` block only for rehydration hooks
+   when config enables it.
+
+Hooks must be fast. If future versions do LLM distillation, enqueue work for a
+background worker instead of doing it inline inside every tool hook.
+
+## Codex Hook Packaging
+
+Codex plugins can bundle hooks in `hooks/hooks.json`. Plugin-bundled hooks still
+require the user to review/trust them. The bundled llm-wiki Codex hook should
+call the copied helper in the plugin root and use `--if-enabled`, so installing
+the plugin does not capture anything until the user enables sessions.
+
+Useful Codex events:
+
+- `SessionStart` and `UserPromptSubmit` for soft rehydration;
+- `PostToolUse` for observed tool counters;
+- `PreCompact` and `PostCompact` for compaction checkpoints;
+- `Stop` for final checkpoints.
+
+## Claude/OpenCode/Gemini Adapters
+
+For Claude Code, use command hooks on `SessionStart`, `UserPromptSubmit`,
+`PostToolUse`, `PostToolBatch`, `PreCompact`, `PostCompact`, `Stop`, and
+`SessionEnd` where available. Keep `SessionEnd` especially short or detached.
+
+For OpenCode, use plugin events such as session/message/tool execution and the
+compaction hook surface. For Gemini CLI, use `AfterTool`, `PreCompress`,
+`AfterAgent`, `SessionStart`, and related hook events. All adapters normalize to
+the same `.sessions/` files.
+
+## Rehydration
+
+Rehydration is a compact context block, not a bulk transcript paste:
+
+```text
+llm-wiki session context: review these distilled session digests before continuing.
+- codex:abc123 — Automated checkpoint summary. Digest: /abs/path/HUB/.sessions/digests/2026/06/codex-abc123.md
+Do not treat session digests as canonical topic knowledge until promoted into a topic wiki.
+```
+
+Soft rehydration can be injected on `SessionStart` or `UserPromptSubmit` in
+balanced/aggressive modes. Manual rehydration should be available with:
+
+```bash
+llm-wiki-session rehydrate --cwd "$PWD"
+llm-wiki-session rehydrate --session-id codex:abc123
+llm-wiki-session rehydrate --topic meta-llm-wiki
+```
+
+Strict forced continuation is not the default. If implemented later, it must be
+opt-in and guard against loops with per-turn counters and stop-hook-active flags.
+
+## Promotion
+
+Promotion is explicit:
+
+```bash
+llm-wiki-session promote codex:abc123 --topic meta-llm-wiki
+```
+
+Promotion writes a topic raw note:
+
+```text
+HUB/topics/<topic>/raw/notes/YYYY-MM-DD-session-<harness>-<session>.md
+```
+
+The raw note links back to the digest and copies only the distilled digest body,
+not the raw transcript. Append the topic `log.md` entry. Compilation into
+`wiki/` articles remains a separate, explicit wiki compile/update step.
+
+## Privacy Defaults
+
+- Redact obvious token/password/authorization fields in event previews.
+- Store transcript pointers and hashes, not transcript bodies.
+- Keep raw transcript archiving disabled unless the user explicitly opts in.
+- Do not auto-promote session material into topic wikis.
+- Do not let hook failures block normal agent work; fail closed to no capture,
+  not to broken tool execution.

--- a/scripts/llm-wiki
+++ b/scripts/llm-wiki
@@ -69,8 +69,9 @@ ROOT_ALLOWED = {
     ".thesis-session.json",
     ".session-events.jsonl",
     ".session-checkpoint.json",
+    ".sessions",
 }
-HUB_ALLOWED = {"wikis.json", "_index.md", "log.md", "topics"}
+HUB_ALLOWED = {"wikis.json", "_index.md", "log.md", "topics", ".sessions"}
 RAW_ALLOWED = {"_index.md", "articles", "papers", "repos", "notes", "data"}
 WIKI_ALLOWED = {"_index.md", "concepts", "topics", "references", "theses"}
 INVENTORY_ALLOWED = {

--- a/scripts/llm-wiki-session
+++ b/scripts/llm-wiki-session
@@ -41,8 +41,8 @@ CONTENT_KEY_RE = re.compile(
 
 DEFAULT_CONFIG: dict[str, Any] = {
     "schema_version": SCHEMA_VERSION,
-    "enabled": False,
-    "mode": "capture-only",
+    "enabled": True,
+    "mode": "balanced",
     "auto_capture": {
         "tool_events": DEFAULT_TOOL_THRESHOLD,
         "pre_compact": True,
@@ -51,8 +51,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "stop": True,
     },
     "rehydrate": {
-        "session_start": False,
-        "user_prompt": False,
+        "session_start": True,
+        "user_prompt": True,
         "strict": False,
     },
     "raw_transcripts": False,
@@ -117,7 +117,12 @@ AGGRESSIVE_CONFIG = {
 }
 
 MODE_CONFIGS = {
-    "off": {**DEFAULT_CONFIG, "mode": "off"},
+    "off": {
+        **DEFAULT_CONFIG,
+        "enabled": False,
+        "mode": "off",
+        "rehydrate": {"session_start": False, "user_prompt": False, "strict": False},
+    },
     "capture-only": {**DEFAULT_CONFIG, **CAPTURE_ONLY_CONFIG},
     "balanced": {**DEFAULT_CONFIG, **BALANCED_CONFIG},
     "aggressive": {**DEFAULT_CONFIG, **AGGRESSIVE_CONFIG},
@@ -1042,7 +1047,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--local", action="store_true", help="Use .wiki/.sessions in the current directory.")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    enable = sub.add_parser("enable", help="Enable automated session capture in HUB/.sessions/config.json.")
+    enable = sub.add_parser("enable", help="Enable or reconfigure automated session capture in HUB/.sessions/config.json.")
     enable.add_argument("--mode", choices=sorted(MODE_CONFIGS), default="balanced")
     enable.add_argument("--tool-events", type=int, help="Override automated tool-event checkpoint threshold.")
     enable.add_argument("--force", action="store_true", help="Replace existing config instead of merging.")
@@ -1059,7 +1064,7 @@ def build_parser() -> argparse.ArgumentParser:
     hook.add_argument("--topic", help="Attach a topic tag to this event/state.")
     hook.add_argument("--summary", help="Manual summary to append to state.")
     hook.add_argument("--trigger", help="Override capture trigger name.")
-    hook.add_argument("--if-enabled", action="store_true", help="No-op unless .sessions/config.json has enabled=true.")
+    hook.add_argument("--if-enabled", action="store_true", help="Honor .sessions/config.json enabled=false; default is enabled when no config exists.")
     hook.add_argument("--max-event-bytes", type=int, default=MAX_EVENT_PREVIEW_CHARS)
     hook.set_defaults(func=run_hook)
 

--- a/scripts/llm-wiki-session
+++ b/scripts/llm-wiki-session
@@ -1,0 +1,1121 @@
+#!/usr/bin/env python3
+"""Automated session capture helpers for llm-wiki.
+
+This helper is intentionally deterministic and local-only. Harness hooks call the
+`hook` subcommand with one JSON object on stdin. The hook path records a small,
+redacted event, updates per-session state under HUB/.sessions, and writes a
+markdown digest at configured checkpoints. It never calls an LLM or copies raw
+transcripts by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+DEFAULT_TOOL_THRESHOLD = 50
+MAX_LAST_EVENTS = 20
+MAX_EVENT_PREVIEW_CHARS = 1200
+SESSION_ID_SAFE = re.compile(r"[^A-Za-z0-9_.@:+-]+")
+SECRET_KEY_RE = re.compile(
+    r"(?i)(api[_-]?key|authorization|bearer|token|secret|password|passwd|private[_-]?key|access[_-]?key|session[_-]?cookie|cookie)"
+)
+SECRET_VALUE_RE = re.compile(
+    r"(?i)(bearer\s+)[A-Za-z0-9._~+\-/=]{12,}|"
+    r"(sk-[A-Za-z0-9]{12,})|"
+    r"([A-Za-z0-9_\-]{24,}\.[A-Za-z0-9_\-]{12,}\.[A-Za-z0-9_\-]{12,})"
+)
+CONTENT_KEY_RE = re.compile(
+    r"(?i)^(prompt|user_prompt|message|messages|content|transcript|tool_response|tool_output|response|result|stdout|stderr)$"
+)
+
+DEFAULT_CONFIG: dict[str, Any] = {
+    "schema_version": SCHEMA_VERSION,
+    "enabled": False,
+    "mode": "capture-only",
+    "auto_capture": {
+        "tool_events": DEFAULT_TOOL_THRESHOLD,
+        "pre_compact": True,
+        "post_compact": True,
+        "session_end": True,
+        "stop": True,
+    },
+    "rehydrate": {
+        "session_start": False,
+        "user_prompt": False,
+        "strict": False,
+    },
+    "raw_transcripts": False,
+    "privacy": "redacted",
+}
+
+BALANCED_CONFIG = {
+    "enabled": True,
+    "mode": "balanced",
+    "auto_capture": {
+        "tool_events": DEFAULT_TOOL_THRESHOLD,
+        "pre_compact": True,
+        "post_compact": True,
+        "session_end": True,
+        "stop": True,
+    },
+    "rehydrate": {
+        "session_start": True,
+        "user_prompt": True,
+        "strict": False,
+    },
+    "raw_transcripts": False,
+    "privacy": "redacted",
+}
+
+CAPTURE_ONLY_CONFIG = {
+    "enabled": True,
+    "mode": "capture-only",
+    "auto_capture": {
+        "tool_events": DEFAULT_TOOL_THRESHOLD,
+        "pre_compact": True,
+        "post_compact": True,
+        "session_end": True,
+        "stop": True,
+    },
+    "rehydrate": {
+        "session_start": False,
+        "user_prompt": False,
+        "strict": False,
+    },
+    "raw_transcripts": False,
+    "privacy": "redacted",
+}
+
+AGGRESSIVE_CONFIG = {
+    "enabled": True,
+    "mode": "aggressive",
+    "auto_capture": {
+        "tool_events": 25,
+        "pre_compact": True,
+        "post_compact": True,
+        "session_end": True,
+        "stop": True,
+    },
+    "rehydrate": {
+        "session_start": True,
+        "user_prompt": True,
+        "strict": False,
+    },
+    "raw_transcripts": False,
+    "privacy": "redacted",
+}
+
+MODE_CONFIGS = {
+    "off": {**DEFAULT_CONFIG, "mode": "off"},
+    "capture-only": {**DEFAULT_CONFIG, **CAPTURE_ONLY_CONFIG},
+    "balanced": {**DEFAULT_CONFIG, **BALANCED_CONFIG},
+    "aggressive": {**DEFAULT_CONFIG, **AGGRESSIVE_CONFIG},
+}
+
+
+class HookSkip(Exception):
+    """Raised when a hook should silently do nothing."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def today() -> str:
+    return dt.date.today().isoformat()
+
+
+def expand_leading_tilde(value: str) -> Path:
+    if value == "~":
+        return Path.home()
+    if value.startswith("~/"):
+        return Path.home() / value[2:]
+    return Path(value)
+
+
+def resolve_hub(args: argparse.Namespace) -> Path:
+    if getattr(args, "local", False):
+        return Path.cwd() / ".wiki"
+    if getattr(args, "hub", None):
+        return expand_leading_tilde(str(args.hub))
+    config = Path.home() / ".config" / "llm-wiki" / "config.json"
+    if config.exists():
+        try:
+            data = json.loads(config.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"invalid llm-wiki config {config}: {exc}") from exc
+        hub_path = data.get("hub_path") or data.get("resolved_path")
+        if hub_path:
+            return expand_leading_tilde(str(hub_path))
+    return Path.home() / "wiki"
+
+
+def sessions_dir(hub: Path) -> Path:
+    return hub / ".sessions"
+
+
+def safe_id(value: str) -> str:
+    cleaned = SESSION_ID_SAFE.sub("-", value).strip(".-")
+    if not cleaned:
+        cleaned = hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+    return cleaned[:120]
+
+
+def state_path(root: Path, harness: str, native_session_id: str) -> Path:
+    return root / "state" / safe_id(harness) / f"{safe_id(native_session_id)}.json"
+
+
+def digest_path(root: Path, harness: str, native_session_id: str, now: str | None = None) -> Path:
+    when = parse_timestamp(now or utc_now())
+    return (
+        root
+        / "digests"
+        / f"{when.year:04d}"
+        / f"{when.month:02d}"
+        / f"{safe_id(harness)}-{safe_id(native_session_id)}.md"
+    )
+
+
+def parse_timestamp(value: str) -> dt.datetime:
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = dt.datetime.fromisoformat(normalized)
+    except ValueError:
+        return dt.datetime.now(dt.UTC)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
+
+
+def read_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, data: Any) -> None:
+    atomic_write(path, json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+def append_jsonl(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(data, sort_keys=True, ensure_ascii=False) + "\n")
+
+
+def merge_dict(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    result = json.loads(json.dumps(base))
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = merge_dict(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def load_config(root: Path) -> dict[str, Any]:
+    data = merge_dict(DEFAULT_CONFIG, {})
+    path = root / "config.json"
+    if path.exists():
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict):
+            data = merge_dict(data, loaded)
+    return data
+
+
+def mode_config(mode: str) -> dict[str, Any]:
+    if mode not in MODE_CONFIGS:
+        raise SystemExit(f"unknown session mode: {mode}")
+    return merge_dict(DEFAULT_CONFIG, MODE_CONFIGS[mode])
+
+
+def ensure_layout(root: Path) -> None:
+    for rel in ["state", "queue", "digests", "indexes"]:
+        (root / rel).mkdir(parents=True, exist_ok=True)
+
+
+def omitted_value(value: Any) -> str:
+    try:
+        text = json.dumps(value, sort_keys=True, ensure_ascii=False)
+    except TypeError:
+        text = str(value)
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+    return f"[OMITTED len={len(text)} sha256={digest}]"
+
+
+def redact_scalar(value: Any, key_hint: str = "") -> Any:
+    if value is None or isinstance(value, bool) or isinstance(value, (int, float)):
+        return value
+    if SECRET_KEY_RE.search(key_hint):
+        return "[REDACTED]"
+    text = str(value)
+    text = SECRET_VALUE_RE.sub(lambda m: (m.group(1) or "") + "[REDACTED]", text)
+    if len(text) > MAX_EVENT_PREVIEW_CHARS:
+        text = text[:MAX_EVENT_PREVIEW_CHARS] + "…"
+    return text
+
+
+def redact(value: Any, key_hint: str = "") -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, nested in value.items():
+            key_text = str(key)
+            if SECRET_KEY_RE.search(key_text):
+                redacted[key_text] = "[REDACTED]"
+            elif CONTENT_KEY_RE.search(key_text):
+                redacted[key_text] = omitted_value(nested)
+            else:
+                redacted[key_text] = redact(nested, key_text)
+        return redacted
+    if isinstance(value, list):
+        return [redact(item, key_hint) for item in value[:20]]
+    return redact_scalar(value, key_hint)
+
+
+def compact_json(value: Any, max_chars: int = MAX_EVENT_PREVIEW_CHARS) -> str:
+    text = json.dumps(redact(value), sort_keys=True, ensure_ascii=False)
+    if len(text) > max_chars:
+        return text[:max_chars] + "…"
+    return text
+
+
+def detect_harness(args: argparse.Namespace, payload: dict[str, Any]) -> str:
+    if getattr(args, "harness", None):
+        return str(args.harness)
+    env_harness = os.environ.get("LLM_WIKI_HARNESS")
+    if env_harness:
+        return env_harness
+    if os.environ.get("PLUGIN_ROOT") or "model" in payload:
+        return "codex"
+    if "permission_mode" in payload or "agent_id" in payload:
+        return "claude"
+    return "unknown"
+
+
+def fallback_session_id(payload: dict[str, Any]) -> str:
+    parts = [
+        str(payload.get("transcript_path") or ""),
+        str(payload.get("cwd") or ""),
+        str(payload.get("model") or ""),
+    ]
+    basis = "|".join(parts).strip("|") or utc_now()
+    return "derived-" + hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
+
+
+def git_value(cwd: str | None, args: list[str]) -> str | None:
+    if not cwd:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=1.5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def normalize_event(args: argparse.Namespace, payload: dict[str, Any], root: Path) -> dict[str, Any]:
+    now = utc_now()
+    harness = safe_id(detect_harness(args, payload))
+    native_session_id = str(
+        getattr(args, "session_id", None)
+        or payload.get("session_id")
+        or payload.get("sessionId")
+        or fallback_session_id(payload)
+    )
+    event_name = str(
+        getattr(args, "event_name", None)
+        or payload.get("hook_event_name")
+        or payload.get("hookEventName")
+        or payload.get("event")
+        or "manual"
+    )
+    cwd = str(getattr(args, "cwd", None) or payload.get("cwd") or os.getcwd())
+    transcript_path = payload.get("transcript_path") or payload.get("transcriptPath")
+    tool_name = payload.get("tool_name") or payload.get("toolName") or payload.get("tool")
+    trigger = str(getattr(args, "trigger", None) or event_name)
+    event = {
+        "schema_version": SCHEMA_VERSION,
+        "ts": now,
+        "event": "session_event",
+        "harness": harness,
+        "hook_event_name": event_name,
+        "native_session_id": native_session_id,
+        "llm_wiki_session_id": f"{harness}:{native_session_id}",
+        "cwd": cwd,
+        "transcript_path": str(transcript_path) if transcript_path else None,
+        "model": payload.get("model"),
+        "turn_id": payload.get("turn_id") or payload.get("turnId"),
+        "tool_name": str(tool_name) if tool_name else None,
+        "tool_use_id": payload.get("tool_use_id") or payload.get("toolUseId"),
+        "trigger": trigger,
+        "payload_preview": compact_json(payload, max_chars=int(getattr(args, "max_event_bytes", MAX_EVENT_PREVIEW_CHARS))),
+    }
+    if getattr(args, "topic", None):
+        event["topics"] = [args.topic]
+    if getattr(args, "summary", None):
+        event["manual_summary"] = str(args.summary)
+    if transcript_path:
+        event["transcript_path_hash"] = hashlib.sha256(str(transcript_path).encode("utf-8")).hexdigest()
+    return event
+
+
+def event_queue_path(root: Path, event: dict[str, Any]) -> Path:
+    return root / "queue" / f"{event['ts'][:10]}.jsonl"
+
+
+def load_state(root: Path, event: dict[str, Any]) -> tuple[dict[str, Any], bool, Path]:
+    path = state_path(root, event["harness"], event["native_session_id"])
+    is_new = not path.exists()
+    state = read_json(path, {})
+    if not isinstance(state, dict):
+        state = {}
+        is_new = True
+    return state, is_new, path
+
+
+def update_state(root: Path, event: dict[str, Any], config: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    state, is_new, path = load_state(root, event)
+    now = str(event["ts"])
+    state.setdefault("schema_version", SCHEMA_VERSION)
+    state.setdefault("harness", event["harness"])
+    state.setdefault("native_session_id", event["native_session_id"])
+    state.setdefault("llm_wiki_session_id", event["llm_wiki_session_id"])
+    state.setdefault("started_at", now)
+    state["last_seen_at"] = now
+    state["cwd"] = event.get("cwd")
+    state["transcript_path"] = event.get("transcript_path")
+    state["model"] = event.get("model") or state.get("model")
+    state["privacy"] = config.get("privacy", "redacted")
+    state["raw_transcripts"] = bool(config.get("raw_transcripts", False))
+    state["git_remote"] = git_value(event.get("cwd"), ["config", "--get", "remote.origin.url"])
+    state["git_branch"] = git_value(event.get("cwd"), ["branch", "--show-current"])
+    state["event_count"] = int(state.get("event_count") or 0) + 1
+    if is_tool_event(event):
+        state["tool_event_count"] = int(state.get("tool_event_count") or 0) + 1
+    else:
+        state.setdefault("tool_event_count", int(state.get("tool_event_count") or 0))
+    topics = set(as_list(state.get("topics")))
+    topics.update(str(item) for item in as_list(event.get("topics")))
+    if topics:
+        state["topics"] = sorted(topics)
+    summaries = as_list(state.get("manual_summaries"))
+    if event.get("manual_summary"):
+        summaries.append(str(event["manual_summary"]))
+        state["manual_summaries"] = summaries[-10:]
+    if event.get("hook_event_name") == "PostCompact":
+        state["last_compact_event"] = event.get("payload_preview")
+    last_events = as_list(state.get("last_events"))
+    last_events.append(
+        {
+            "ts": event.get("ts"),
+            "hook_event_name": event.get("hook_event_name"),
+            "tool_name": event.get("tool_name"),
+            "turn_id": event.get("turn_id"),
+            "trigger": event.get("trigger"),
+        }
+    )
+    state["last_events"] = last_events[-MAX_LAST_EVENTS:]
+    write_json(path, state)
+    return state, is_new
+
+
+def as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def is_tool_event(event: dict[str, Any]) -> bool:
+    name = str(event.get("hook_event_name") or "")
+    return bool(event.get("tool_name")) or name in {"PreToolUse", "PostToolUse", "PermissionRequest", "BeforeTool", "AfterTool"}
+
+
+def should_write_digest(state: dict[str, Any], event: dict[str, Any], config: dict[str, Any], force: bool = False) -> tuple[bool, str]:
+    if force:
+        return True, str(event.get("trigger") or "manual")
+    auto = config.get("auto_capture") if isinstance(config.get("auto_capture"), dict) else {}
+    event_name = str(event.get("hook_event_name") or "")
+    lower = event_name.lower().replace("_", "")
+    if lower in {"precompact", "precompress"} and auto.get("pre_compact", True):
+        return True, "pre-compact"
+    if lower in {"postcompact", "postcompress"} and auto.get("post_compact", True):
+        return True, "post-compact"
+    if lower in {"sessionend", "afteragent"} and auto.get("session_end", True):
+        return True, "session-end"
+    if lower in {"stop", "stopfailure"} and auto.get("stop", True):
+        return True, "stop"
+    threshold = int(auto.get("tool_events") or 0)
+    tool_count = int(state.get("tool_event_count") or 0)
+    if threshold > 0 and is_tool_event(event) and tool_count > 0 and tool_count % threshold == 0:
+        return True, f"tool-count-{threshold}"
+    return False, ""
+
+
+def yaml_string(value: Any) -> str:
+    text = "" if value is None else str(value)
+    if text == "":
+        return '""'
+    if re.fullmatch(r"[A-Za-z0-9_.:/@+ -]+", text):
+        return json.dumps(text)
+    return json.dumps(text)
+
+
+def yaml_list(values: list[Any]) -> str:
+    return "[" + ", ".join(yaml_string(item) for item in values) + "]"
+
+
+def digest_summary(state: dict[str, Any], trigger: str) -> str:
+    manual = as_list(state.get("manual_summaries"))
+    if manual:
+        return str(manual[-1])[:240]
+    cwd = state.get("cwd") or "unknown cwd"
+    return f"Automated {trigger} checkpoint for {state.get('llm_wiki_session_id')} in {cwd}."
+
+
+def frontmatter_block(state: dict[str, Any], trigger: str, digest_file: Path) -> str:
+    summary = digest_summary(state, trigger)
+    topics = as_list(state.get("topics"))
+    lines = [
+        "---",
+        f"title: {yaml_string('Session Digest: ' + str(state.get('llm_wiki_session_id')))}",
+        "type: session-digest",
+        f"schema_version: {SCHEMA_VERSION}",
+        f"harness: {yaml_string(state.get('harness'))}",
+        f"native_session_id: {yaml_string(state.get('native_session_id'))}",
+        f"llm_wiki_session_id: {yaml_string(state.get('llm_wiki_session_id'))}",
+        f"cwd: {yaml_string(state.get('cwd'))}",
+        f"git_remote: {yaml_string(state.get('git_remote'))}",
+        f"git_branch: {yaml_string(state.get('git_branch'))}",
+        f"transcript_path: {yaml_string(state.get('transcript_path'))}",
+        f"started_at: {yaml_string(state.get('started_at'))}",
+        f"last_seen_at: {yaml_string(state.get('last_seen_at'))}",
+        f"tool_event_count: {int(state.get('tool_event_count') or 0)}",
+        f"event_count: {int(state.get('event_count') or 0)}",
+        f"capture_trigger: {yaml_string(trigger)}",
+        f"topics: {yaml_list(topics)}",
+        "topic_candidates: []",
+        f"privacy: {yaml_string(state.get('privacy') or 'redacted')}",
+        f"raw_transcripts: {str(bool(state.get('raw_transcripts'))).lower()}",
+        "promoted_to: []",
+        f"summary: {yaml_string(summary)}",
+        "---",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def markdown_table(rows: list[tuple[str, str]]) -> str:
+    out = ["| Field | Value |", "|---|---|"]
+    for key, value in rows:
+        safe = str(value or "").replace("|", "\\|").replace("\n", " ")
+        out.append(f"| {key} | {safe} |")
+    return "\n".join(out)
+
+
+def render_digest(state: dict[str, Any], trigger: str, digest_file: Path) -> str:
+    summary = digest_summary(state, trigger)
+    last_events = as_list(state.get("last_events"))[-12:]
+    event_lines = []
+    for event in last_events:
+        event_lines.append(
+            f"- `{event.get('ts')}` — {event.get('hook_event_name')}"
+            + (f" / {event.get('tool_name')}" if event.get("tool_name") else "")
+        )
+    if not event_lines:
+        event_lines.append("- No hook events recorded yet.")
+
+    manual = as_list(state.get("manual_summaries"))
+    manual_lines = [f"- {item}" for item in manual[-5:]] or ["- None recorded."]
+
+    body = f"""
+# Session Digest: {state.get('llm_wiki_session_id')}
+
+## Summary
+
+{summary}
+
+## Session Identity
+
+{markdown_table([
+        ('Harness', state.get('harness')),
+        ('Native session ID', state.get('native_session_id')),
+        ('llm-wiki session ID', state.get('llm_wiki_session_id')),
+        ('CWD', state.get('cwd')),
+        ('Git remote', state.get('git_remote')),
+        ('Git branch', state.get('git_branch')),
+        ('Transcript pointer', state.get('transcript_path')),
+        ('Started at', state.get('started_at')),
+        ('Last seen at', state.get('last_seen_at')),
+        ('Capture trigger', trigger),
+        ('Observed tool events', state.get('tool_event_count')),
+        ('Observed total events', state.get('event_count')),
+    ])}
+
+## Manual Summaries
+
+{chr(10).join(manual_lines)}
+
+## Recent Observed Events
+
+{chr(10).join(event_lines)}
+
+## Distillation Notes
+
+- This digest is an automated checkpoint generated from redacted hook metadata.
+- Raw transcript text is not copied by default; use the transcript pointer only if the harness still owns a readable transcript and the user approves.
+- Promote useful distilled learnings into a topic wiki with `llm-wiki-session promote`; do not treat this operational digest as canonical topic knowledge until promoted.
+
+## Open Loops
+
+- Review whether this session should be topic-tagged or promoted.
+- If the session ended mid-task, use `llm-wiki-session rehydrate --session-id {state.get('llm_wiki_session_id')}` before continuing.
+""".strip()
+    return frontmatter_block(state, trigger, digest_file) + "\n" + body + "\n"
+
+
+def write_digest(root: Path, state: dict[str, Any], trigger: str) -> Path:
+    path = digest_path(root, str(state["harness"]), str(state["native_session_id"]), str(state.get("last_seen_at") or utc_now()))
+    text = render_digest(state, trigger, path)
+    atomic_write(path, text)
+    state["last_digest_path"] = str(path)
+    state["last_digest_at"] = utc_now()
+    state["digest_count"] = int(state.get("digest_count") or 0) + 1
+    write_json(state_path(root, str(state["harness"]), str(state["native_session_id"])), state)
+    append_jsonl(
+        root / "registry.jsonl",
+        {
+            "schema_version": SCHEMA_VERSION,
+            "ts": utc_now(),
+            "event": "digest_written",
+            "llm_wiki_session_id": state.get("llm_wiki_session_id"),
+            "harness": state.get("harness"),
+            "native_session_id": state.get("native_session_id"),
+            "digest_path": str(path),
+            "capture_trigger": trigger,
+            "cwd": state.get("cwd"),
+            "topics": as_list(state.get("topics")),
+        },
+    )
+    rebuild_indexes(root)
+    return path
+
+
+def rebuild_indexes(root: Path) -> None:
+    by_cwd: dict[str, list[dict[str, Any]]] = {}
+    by_topic: dict[str, list[dict[str, Any]]] = {}
+    states: list[dict[str, Any]] = []
+    for path in sorted((root / "state").glob("*/*.json")):
+        try:
+            state = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(state, dict):
+            continue
+        states.append(state)
+        record = {
+            "llm_wiki_session_id": state.get("llm_wiki_session_id"),
+            "harness": state.get("harness"),
+            "native_session_id": state.get("native_session_id"),
+            "last_seen_at": state.get("last_seen_at"),
+            "last_digest_path": state.get("last_digest_path"),
+        }
+        cwd = str(state.get("cwd") or "")
+        if cwd:
+            by_cwd.setdefault(cwd, []).append(record)
+        for topic in as_list(state.get("topics")):
+            by_topic.setdefault(str(topic), []).append(record)
+    write_json(root / "indexes" / "by-cwd.json", by_cwd)
+    write_json(root / "indexes" / "by-topic.json", by_topic)
+    write_json(root / "indexes" / "sessions.json", {"sessions": states})
+
+
+def hook_output(event_name: str, context: str) -> None:
+    if not context.strip():
+        return
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": event_name,
+                    "additionalContext": context,
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def run_hook(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    config = load_config(root)
+    if args.if_enabled and not config.get("enabled"):
+        raise HookSkip()
+    ensure_layout(root)
+    raw = sys.stdin.read()
+    payload: dict[str, Any]
+    if raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"invalid hook JSON input: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise SystemExit("hook JSON input must be an object")
+        payload = parsed
+    else:
+        payload = {}
+    event = normalize_event(args, payload, root)
+    append_jsonl(event_queue_path(root, event), event)
+    state, is_new = update_state(root, event, config)
+    if is_new:
+        append_jsonl(
+            root / "registry.jsonl",
+            {
+                "schema_version": SCHEMA_VERSION,
+                "ts": event["ts"],
+                "event": "session_seen",
+                "llm_wiki_session_id": event["llm_wiki_session_id"],
+                "harness": event["harness"],
+                "native_session_id": event["native_session_id"],
+                "cwd": event.get("cwd"),
+                "transcript_path": event.get("transcript_path"),
+            },
+        )
+    write, trigger = should_write_digest(state, event, config, force=False)
+    if write:
+        write_digest(root, state, trigger)
+    else:
+        rebuild_indexes(root)
+
+    event_name = str(event.get("hook_event_name") or "")
+    rehydrate_cfg = config.get("rehydrate") if isinstance(config.get("rehydrate"), dict) else {}
+    if event_name == "SessionStart" and rehydrate_cfg.get("session_start"):
+        hook_output(event_name, build_rehydrate_context(root, cwd=event.get("cwd"), limit=3))
+    elif event_name == "UserPromptSubmit" and rehydrate_cfg.get("user_prompt"):
+        hook_output(event_name, build_rehydrate_context(root, cwd=event.get("cwd"), limit=3))
+    return 0
+
+
+def run_enable(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    ensure_layout(root)
+    config = mode_config(args.mode)
+    existing = load_config(root)
+    if (root / "config.json").exists() and not args.force:
+        config = merge_dict(existing, config)
+    if args.tool_events is not None:
+        config.setdefault("auto_capture", {})["tool_events"] = int(args.tool_events)
+    config["enabled"] = args.mode != "off"
+    write_json(root / "config.json", config)
+    print(f"llm-wiki sessions {config['mode']}: {root}")
+    print(f"enabled: {config['enabled']}")
+    print("raw_transcripts: false")
+    return 0
+
+
+def run_disable(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    ensure_layout(root)
+    config = load_config(root)
+    config["enabled"] = False
+    config["mode"] = "off"
+    write_json(root / "config.json", config)
+    print(f"llm-wiki sessions disabled: {root}")
+    return 0
+
+
+def manual_payload(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "session_id": args.session_id or f"manual-{dt.datetime.now().strftime('%Y%m%d-%H%M%S')}",
+        "hook_event_name": "ManualCapture",
+        "cwd": args.cwd or os.getcwd(),
+        "transcript_path": args.transcript_path,
+        "model": args.model,
+        "manual_summary": args.summary,
+    }
+
+
+def run_capture(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    ensure_layout(root)
+    config = load_config(root)
+    payload = manual_payload(args)
+    event = normalize_event(args, payload, root)
+    append_jsonl(event_queue_path(root, event), event)
+    state, is_new = update_state(root, event, config)
+    if is_new:
+        append_jsonl(
+            root / "registry.jsonl",
+            {
+                "schema_version": SCHEMA_VERSION,
+                "ts": event["ts"],
+                "event": "session_seen",
+                "llm_wiki_session_id": event["llm_wiki_session_id"],
+                "harness": event["harness"],
+                "native_session_id": event["native_session_id"],
+                "cwd": event.get("cwd"),
+                "transcript_path": event.get("transcript_path"),
+            },
+        )
+    path = write_digest(root, state, "manual")
+    print(str(path))
+    return 0
+
+
+def iter_states(root: Path) -> list[dict[str, Any]]:
+    states = []
+    for path in sorted((root / "state").glob("*/*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict):
+            states.append(data)
+    return sorted(states, key=lambda item: str(item.get("last_seen_at") or ""), reverse=True)
+
+
+def session_matches(state: dict[str, Any], args: argparse.Namespace) -> bool:
+    if getattr(args, "harness", None) and state.get("harness") != args.harness:
+        return False
+    if getattr(args, "cwd", None) and state.get("cwd") != args.cwd:
+        return False
+    if getattr(args, "topic", None) and args.topic not in as_list(state.get("topics")):
+        return False
+    return True
+
+
+def run_list(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    states = [state for state in iter_states(root) if session_matches(state, args)]
+    if args.json:
+        print(json.dumps({"sessions_root": str(root), "sessions": states}, indent=2, sort_keys=True))
+        return 0
+    print(f"llm-wiki sessions: {root}")
+    print("| Session | Last seen | Tools | CWD | Digest |")
+    print("|---|---:|---:|---|---|")
+    for state in states[: args.limit]:
+        print(
+            "| {sid} | {last} | {tools} | {cwd} | {digest} |".format(
+                sid=str(state.get("llm_wiki_session_id") or "").replace("|", "\\|"),
+                last=str(state.get("last_seen_at") or ""),
+                tools=int(state.get("tool_event_count") or 0),
+                cwd=str(state.get("cwd") or "").replace("|", "\\|"),
+                digest=str(state.get("last_digest_path") or ""),
+            )
+        )
+    return 0
+
+
+def find_session(root: Path, session_id: str) -> dict[str, Any] | None:
+    for state in iter_states(root):
+        if session_id in {state.get("llm_wiki_session_id"), state.get("native_session_id")}:
+            return state
+    return None
+
+
+def split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    raw = text[4:end]
+    body = text[end + 5 :]
+    data: dict[str, Any] = {}
+    for line in raw.splitlines():
+        if not line.strip() or ":" not in line or line.startswith(" "):
+            continue
+        key, value = line.split(":", 1)
+        value = value.strip()
+        if value.startswith("[") and value.endswith("]"):
+            try:
+                data[key.strip()] = json.loads(value)
+            except json.JSONDecodeError:
+                data[key.strip()] = []
+        else:
+            data[key.strip()] = value.strip('"')
+    return data, body
+
+
+def run_show(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    state = find_session(root, args.session_id)
+    if not state:
+        raise SystemExit(f"session not found: {args.session_id}")
+    digest = state.get("last_digest_path")
+    if not digest:
+        raise SystemExit(f"session has no digest yet: {args.session_id}")
+    path = Path(str(digest))
+    if args.path_only:
+        print(str(path))
+    else:
+        print(path.read_text(encoding="utf-8"))
+    return 0
+
+
+def build_rehydrate_context(root: Path, cwd: str | None = None, session_id: str | None = None, topic: str | None = None, limit: int = 3) -> str:
+    candidates = iter_states(root)
+    selected: list[dict[str, Any]] = []
+    for state in candidates:
+        if session_id and session_id not in {state.get("llm_wiki_session_id"), state.get("native_session_id")}:
+            continue
+        if topic and topic not in as_list(state.get("topics")):
+            continue
+        if cwd and not session_id and not topic and state.get("cwd") != cwd:
+            continue
+        if state.get("last_digest_path"):
+            selected.append(state)
+        if len(selected) >= limit:
+            break
+    if not selected:
+        return ""
+    lines = [
+        "llm-wiki session context: review these distilled session digests before continuing.",
+    ]
+    for state in selected:
+        lines.append(
+            f"- {state.get('llm_wiki_session_id')} — {digest_summary(state, 'rehydrate')} "
+            f"Digest: {state.get('last_digest_path')}"
+        )
+    lines.append("Do not treat session digests as canonical topic knowledge until promoted into a topic wiki.")
+    return "\n".join(lines)
+
+
+def run_rehydrate(args: argparse.Namespace) -> int:
+    root = sessions_dir(resolve_hub(args))
+    context = build_rehydrate_context(root, cwd=args.cwd, session_id=args.session_id, topic=args.topic, limit=args.limit)
+    if not context:
+        print("No matching session digests found.")
+        return 1
+    print(context)
+    return 0
+
+
+def read_registry(hub: Path) -> dict[str, Any]:
+    path = hub / "wikis.json"
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_registry_path(raw_path: str, hub: Path) -> Path:
+    if raw_path in {".", "<HUB>", "HUB"}:
+        return hub
+    if raw_path.startswith("<HUB>/"):
+        return hub / raw_path[len("<HUB>/") :]
+    if raw_path.startswith("HUB/"):
+        return hub / raw_path[len("HUB/") :]
+    path = expand_leading_tilde(raw_path)
+    if path.is_absolute():
+        return path
+    return hub / path
+
+
+def topic_path(hub: Path, slug: str) -> Path:
+    registry = read_registry(hub)
+    entry = registry.get("wikis", {}).get(slug) if isinstance(registry.get("wikis"), dict) else None
+    if isinstance(entry, dict) and entry.get("path"):
+        return resolve_registry_path(str(entry["path"]), hub)
+    return hub / "topics" / slug
+
+
+def slugify(value: str) -> str:
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    return value.strip("-")[:80] or "session"
+
+
+def append_topic_log(topic_root: Path, message: str) -> None:
+    log = topic_root / "log.md"
+    if log.exists():
+        with log.open("a", encoding="utf-8") as handle:
+            handle.write(f"\n## [{today()}] session | {message}\n")
+
+
+def run_promote(args: argparse.Namespace) -> int:
+    hub = resolve_hub(args)
+    root = sessions_dir(hub)
+    state = find_session(root, args.session_id)
+    if not state:
+        raise SystemExit(f"session not found: {args.session_id}")
+    digest = state.get("last_digest_path")
+    if not digest:
+        raise SystemExit(f"session has no digest yet: {args.session_id}")
+    digest_file = Path(str(digest))
+    digest_text = digest_file.read_text(encoding="utf-8")
+    fm, body = split_frontmatter(digest_text)
+    topic_root = topic_path(hub, args.topic)
+    notes = topic_root / "raw" / "notes"
+    if not notes.exists():
+        raise SystemExit(f"topic raw notes directory not found: {notes}")
+    filename = f"{today()}-session-{slugify(str(state.get('harness')))}-{slugify(str(state.get('native_session_id')))}.md"
+    dest = notes / filename
+    if dest.exists() and not args.force:
+        raise SystemExit(f"promotion note already exists: {dest}")
+    summary = fm.get("summary") or digest_summary(state, "promote")
+    promoted = textwrap.dedent(
+        f"""
+        ---
+        title: {yaml_string('Session Digest Promotion: ' + str(state.get('llm_wiki_session_id')))}
+        source: {yaml_string(str(digest_file))}
+        type: notes
+        ingested: {today()}
+        tags: [session-digest, session-promotion, {yaml_string(args.topic)}]
+        summary: {yaml_string(summary)}
+        ---
+
+        # Session Digest Promotion: {state.get('llm_wiki_session_id')}
+
+        Source digest: [{digest_file.name}]({digest_file})
+
+        This note promotes a distilled session checkpoint into the `{args.topic}` topic raw layer. It intentionally promotes the digest, not the raw transcript.
+
+        {body.strip()}
+        """
+    ).strip() + "\n"
+    atomic_write(dest, promoted)
+    topics = set(as_list(state.get("topics")))
+    topics.add(args.topic)
+    state["topics"] = sorted(topics)
+    promoted_to = as_list(state.get("promoted_to"))
+    promoted_to.append(str(dest))
+    state["promoted_to"] = sorted(set(str(item) for item in promoted_to))
+    write_json(state_path(root, str(state["harness"]), str(state["native_session_id"])), state)
+    rebuild_indexes(root)
+    append_topic_log(topic_root, f"promoted session digest {state.get('llm_wiki_session_id')} → raw/notes/{filename}")
+    print(str(dest))
+    return 0
+
+
+def run_status(args: argparse.Namespace) -> int:
+    hub = resolve_hub(args)
+    root = sessions_dir(hub)
+    config = load_config(root)
+    states = iter_states(root) if root.exists() else []
+    report = {
+        "hub": str(hub),
+        "sessions_root": str(root),
+        "enabled": bool(config.get("enabled")),
+        "mode": config.get("mode"),
+        "session_count": len(states),
+        "config": config,
+    }
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"llm-wiki sessions: {root}")
+        print(f"enabled: {report['enabled']}")
+        print(f"mode: {report['mode']}")
+        print(f"sessions: {report['session_count']}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="llm-wiki-session", description="Capture and rehydrate llm-wiki session context.")
+    parser.add_argument("--hub", help="Override wiki hub path.")
+    parser.add_argument("--local", action="store_true", help="Use .wiki/.sessions in the current directory.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    enable = sub.add_parser("enable", help="Enable automated session capture in HUB/.sessions/config.json.")
+    enable.add_argument("--mode", choices=sorted(MODE_CONFIGS), default="balanced")
+    enable.add_argument("--tool-events", type=int, help="Override automated tool-event checkpoint threshold.")
+    enable.add_argument("--force", action="store_true", help="Replace existing config instead of merging.")
+    enable.set_defaults(func=run_enable)
+
+    disable = sub.add_parser("disable", help="Disable automated session capture.")
+    disable.set_defaults(func=run_disable)
+
+    hook = sub.add_parser("hook", help="Record a harness hook event from JSON on stdin.")
+    hook.add_argument("--harness", help="Harness name, e.g. codex, claude, opencode, gemini.")
+    hook.add_argument("--event-name", help="Override hook event name.")
+    hook.add_argument("--session-id", help="Override native session id.")
+    hook.add_argument("--cwd", help="Override session cwd.")
+    hook.add_argument("--topic", help="Attach a topic tag to this event/state.")
+    hook.add_argument("--summary", help="Manual summary to append to state.")
+    hook.add_argument("--trigger", help="Override capture trigger name.")
+    hook.add_argument("--if-enabled", action="store_true", help="No-op unless .sessions/config.json has enabled=true.")
+    hook.add_argument("--max-event-bytes", type=int, default=MAX_EVENT_PREVIEW_CHARS)
+    hook.set_defaults(func=run_hook)
+
+    capture = sub.add_parser("capture", help="Force a manual session digest checkpoint.")
+    capture.add_argument("--harness", default="manual")
+    capture.add_argument("--session-id", help="Native session id; defaults to manual timestamp.")
+    capture.add_argument("--cwd", help="Session working directory; defaults to current directory.")
+    capture.add_argument("--transcript-path", help="Transcript pointer to record without copying contents.")
+    capture.add_argument("--model", help="Model/profile label to record.")
+    capture.add_argument("--topic", help="Topic tag to attach to this digest.")
+    capture.add_argument("--summary", help="Short manual summary for the digest.")
+    capture.set_defaults(func=run_capture)
+
+    list_cmd = sub.add_parser("list", help="List captured sessions.")
+    list_cmd.add_argument("--harness", help="Filter by harness.")
+    list_cmd.add_argument("--cwd", help="Filter by cwd.")
+    list_cmd.add_argument("--topic", help="Filter by topic tag.")
+    list_cmd.add_argument("--limit", type=int, default=20)
+    list_cmd.add_argument("--json", action="store_true")
+    list_cmd.set_defaults(func=run_list)
+
+    show = sub.add_parser("show", help="Show a session digest.")
+    show.add_argument("session_id", help="llm-wiki session id or native session id.")
+    show.add_argument("--path-only", action="store_true")
+    show.set_defaults(func=run_show)
+
+    rehydrate = sub.add_parser("rehydrate", help="Print a compact context block from matching session digests.")
+    rehydrate.add_argument("--session-id", help="llm-wiki session id or native session id.")
+    rehydrate.add_argument("--cwd", help="Match sessions by cwd; defaults to current cwd.")
+    rehydrate.add_argument("--topic", help="Match sessions by topic tag.")
+    rehydrate.add_argument("--limit", type=int, default=3)
+    rehydrate.set_defaults(func=run_rehydrate)
+
+    promote = sub.add_parser("promote", help="Promote a session digest into a topic raw note.")
+    promote.add_argument("session_id", help="llm-wiki session id or native session id.")
+    promote.add_argument("--topic", required=True, help="Target topic slug.")
+    promote.add_argument("--force", action="store_true")
+    promote.set_defaults(func=run_promote)
+
+    status = sub.add_parser("status", help="Show session capture status.")
+    status.add_argument("--json", action="store_true")
+    status.set_defaults(func=run_status)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except HookSkip:
+        return 0
+    except BrokenPipeError:
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync-codex-plugin.sh
+++ b/scripts/sync-codex-plugin.sh
@@ -52,7 +52,7 @@ cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
             "timeout": 5,
             "statusMessage": "Loading llm-wiki session context"
           }
@@ -64,7 +64,7 @@ cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
             "timeout": 5,
             "statusMessage": "Checking llm-wiki session context"
           }
@@ -77,7 +77,7 @@ cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
             "timeout": 5,
             "statusMessage": "Recording llm-wiki session event"
           }
@@ -90,7 +90,7 @@ cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
             "timeout": 5,
             "statusMessage": "Capturing llm-wiki pre-compact session context"
           }
@@ -103,7 +103,7 @@ cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
             "timeout": 5,
             "statusMessage": "Capturing llm-wiki post-compact session context"
           }
@@ -115,7 +115,7 @@ cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
             "timeout": 5,
             "statusMessage": "Saving llm-wiki session checkpoint"
           }

--- a/scripts/sync-codex-plugin.sh
+++ b/scripts/sync-codex-plugin.sh
@@ -7,6 +7,7 @@ TARGET_PLUGIN="$ROOT/plugins/llm-wiki"
 TARGET_SKILL="$TARGET_PLUGIN/skills/wiki"
 CLAUDE_MANIFEST="$ROOT/claude-plugin/.claude-plugin/plugin.json"
 CODEX_MANIFEST="$TARGET_PLUGIN/.codex-plugin/plugin.json"
+SESSION_HELPER="$ROOT/scripts/llm-wiki-session"
 
 if [ ! -d "$SOURCE_SKILL" ]; then
   echo "Missing source skill: $SOURCE_SKILL" >&2
@@ -23,6 +24,11 @@ if [ ! -f "$CODEX_MANIFEST" ]; then
   exit 1
 fi
 
+if [ ! -f "$SESSION_HELPER" ]; then
+  echo "Missing session helper: $SESSION_HELPER" >&2
+  exit 1
+fi
+
 mkdir -p "$TARGET_PLUGIN/skills"
 # The Codex marketplace caches plugin contents eagerly, so references/ must be
 # copied into the generated tree rather than left as a symlink. agents/ is
@@ -34,13 +40,98 @@ rsync -a --delete \
   "$SOURCE_SKILL/" "$TARGET_SKILL/"
 
 mkdir -p "$TARGET_SKILL/agents"
+mkdir -p "$TARGET_PLUGIN/hooks"
+cp "$SESSION_HELPER" "$TARGET_PLUGIN/hooks/llm_wiki_session.py"
+chmod 0755 "$TARGET_PLUGIN/hooks/llm_wiki_session.py"
+
+cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "timeout": 5,
+            "statusMessage": "Loading llm-wiki session context"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "timeout": 5,
+            "statusMessage": "Checking llm-wiki session context"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "timeout": 5,
+            "statusMessage": "Recording llm-wiki session event"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "timeout": 5,
+            "statusMessage": "Capturing llm-wiki pre-compact session context"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "timeout": 5,
+            "statusMessage": "Capturing llm-wiki post-compact session context"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PLUGIN_ROOT}/hooks/llm_wiki_session.py hook --harness codex --if-enabled",
+            "timeout": 5,
+            "statusMessage": "Saving llm-wiki session checkpoint"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
 
 cat > "$TARGET_SKILL/agents/openai.yaml" <<'EOF'
 interface:
   display_name: "Wiki Manager"
-  short_description: "Initialize, ingest collections, collect catalogs, track inventory, index datasets, compile, audit, query, research, and lint llm-wiki knowledge bases."
+  short_description: "Initialize, ingest collections, capture sessions, track inventory, index datasets, compile, audit, query, research, and lint llm-wiki knowledge bases."
   brand_color: "#2F855A"
-  default_prompt: "Research a topic and compile it into a structured wiki."
+  default_prompt: "Research a topic, capture a session, or compile knowledge into a structured wiki."
 
 policy:
   allow_implicit_invocation: true
@@ -63,14 +154,14 @@ frontmatter = """---
 name: wiki
 description: >
   LLM-compiled knowledge base manager for Codex. Use it to initialize, ingest,
-  import source collections, collect catalogs, track inventory, index datasets, archive old topics, compile, query, lint, audit, research, plan, and generate outputs from topic-scoped wikis.
+  import source collections, collect catalogs, track inventory, index datasets, archive old topics, compile, query, lint, audit, research, plan, capture or rehydrate agent session context, and generate outputs from topic-scoped wikis.
   Activates when the user mentions wiki workflows, knowledge-base management,
   ingestion, collection ingestion, import wiki, collect, catalog, curate,
   find all, inventory, source queue,
   candidate list, watch list, backlog, dataset, large data, data registry,
   dataset manifest, compilation, querying, linting, audit, research, librarian,
   scan quality, article quality, content review, output drift, provenance,
-  archive wiki, archive topic, restore wiki, implementation plan, or uses
+  archive wiki, archive topic, restore wiki, session capture, capture context, rehydrate, resume from session, implementation plan, or uses
   /wiki-style shorthand in a repo with .wiki/, ~/wiki/, or a configured hub path.
 ---
 """
@@ -159,6 +250,7 @@ reference material you need for that workflow:
 - `librarian` → `references/librarian.md`
 - wiki structure, indexes, log format, file placement, init → `references/wiki-structure.md`
 - hub lookup and path handling → `references/hub-resolution.md`
+- session capture, automated hooks, rehydration, promotion → `references/sessions.md`
 
 Collect requests create bounded catalogs of discoverable things: artifacts,
 examples, resources, entities, tools, media, memes, or source candidates. Infer

--- a/scripts/sync-opencode-plugin.sh
+++ b/scripts/sync-opencode-plugin.sh
@@ -42,14 +42,15 @@ frontmatter = """---
 name: wiki-manager
 description: >
   LLM-compiled knowledge base manager for OpenCode. Use it to initialize, ingest,
-  import source collections, collect catalogs, track inventory, index datasets, archive old topics, compile, query, lint, audit, research, plan, and generate outputs from topic-scoped wikis.
+  import source collections, collect catalogs, track inventory, index datasets, archive old topics, compile, query, lint, audit, research, plan, capture or rehydrate agent session context, and generate outputs from topic-scoped wikis.
   Activates when the user mentions wiki workflows, knowledge-base management,
   ingestion, collection ingestion, import wiki, collect, catalog, curate,
   find all, inventory, source queue,
   candidate list, watch list, backlog, dataset, large data, data registry,
   dataset manifest, compilation, querying, linting, audit, research, librarian,
   scan quality, article quality, content review, output drift, provenance,
-  archive wiki, archive topic, restore wiki, lessons learned, implementation
+  archive wiki, archive topic, restore wiki, session capture, capture
+  context, rehydrate, resume from session, lessons learned, implementation
   plan, or uses wiki-related shorthand in a repo with .wiki/, ~/wiki/, or a
   configured hub path.
 ---

--- a/tests/test-local-cli-lint.sh
+++ b/tests/test-local-cli-lint.sh
@@ -276,6 +276,12 @@ expect_success \
   "hub lint stays scoped to hub registry" \
   "$CLI" lint "$hub_scope"
 
+mkdir -p "$hub_scope/.sessions/state/codex"
+echo '{}' > "$hub_scope/.sessions/state/codex/example.json"
+expect_success \
+  "hub lint allows operational .sessions layer" \
+  "$CLI" lint "$hub_scope"
+
 portable_home="$tmpdir/portable-home"
 portable_hub="$portable_home/Library/Mobile Documents/com~apple~CloudDocs/wiki"
 mkdir -p "$portable_home/.config/llm-wiki" "$portable_hub/topics/portable-topic"

--- a/tests/test-plugin-validate.sh
+++ b/tests/test-plugin-validate.sh
@@ -9,7 +9,7 @@ PLUGIN_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
 PASS=0
 FAIL=0
 TOTAL=0
-REFERENCE_NAMES="archive audit command-prelude compilation datasets hub-resolution indexing ingestion inventory librarian linting projects research-infrastructure wiki-structure"
+REFERENCE_NAMES="archive audit command-prelude compilation datasets hub-resolution indexing ingestion inventory librarian linting projects research-infrastructure sessions wiki-structure"
 
 log_pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); printf "  \033[32mPASS\033[0m: %s\n" "$1"; }
 log_fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); printf "  \033[31mFAIL\033[0m: %s — %s\n" "$1" "$2"; }
@@ -114,6 +114,28 @@ if [ -f "$CODEX_MANIFEST" ]; then
   fi
 else
   log_fail ".codex-plugin/plugin.json not found" "missing file"
+fi
+
+
+# Codex bundled hooks for opt-in automated session capture.
+echo ""
+echo "--- Codex bundled hooks ---"
+CODEX_HOOKS="$CODEX_PLUGIN/hooks/hooks.json"
+CODEX_SESSION_HELPER="$CODEX_PLUGIN/hooks/llm_wiki_session.py"
+if [ -f "$CODEX_HOOKS" ]; then
+  log_pass "Codex hooks/hooks.json exists"
+  if python3 -c "import json; json.load(open('$CODEX_HOOKS'))" 2>/dev/null; then
+    log_pass "Codex hooks/hooks.json is valid JSON"
+  else
+    log_fail "Codex hooks/hooks.json invalid" "parse error"
+  fi
+else
+  log_fail "Codex hooks/hooks.json missing" "missing file"
+fi
+if [ -x "$CODEX_SESSION_HELPER" ]; then
+  log_pass "Codex session hook helper exists and is executable"
+else
+  log_fail "Codex session hook helper missing" "expected executable hooks/llm_wiki_session.py"
 fi
 
 # Codex marketplace entry

--- a/tests/test-session-capture.sh
+++ b/tests/test-session-capture.sh
@@ -58,16 +58,24 @@ cat > "$hub/topics/demo/log.md" <<'MD'
 # Demo Log
 MD
 
-skip_hub="$tmpdir/skip-wiki"
-mkdir -p "$skip_hub/topics"
-touch "$skip_hub/_index.md" "$skip_hub/log.md"
-echo '{"wikis":{}}' > "$skip_hub/wikis.json"
-printf '{"session_id":"skip","hook_event_name":"PostToolUse","cwd":"%s","tool_name":"Bash"}' "$PWD" \
-  | "$SESSION" --hub "$skip_hub" hook --harness codex --if-enabled
-if [ ! -e "$skip_hub/.sessions" ]; then
-  log_pass "--if-enabled hook no-ops before opt-in"
+default_hub="$tmpdir/default-on-wiki"
+mkdir -p "$default_hub/topics"
+touch "$default_hub/_index.md" "$default_hub/log.md"
+echo '{"wikis":{}}' > "$default_hub/wikis.json"
+printf '{"session_id":"default-on","hook_event_name":"PostToolUse","cwd":"%s","tool_name":"Bash"}' "$PWD" \
+  | "$SESSION" --hub "$default_hub" hook --harness codex --if-enabled
+if [ -f "$default_hub/.sessions/state/codex/default-on.json" ]; then
+  log_pass "--if-enabled hook captures by default when no config exists"
 else
-  log_fail "--if-enabled hook no-ops before opt-in" "created $skip_hub/.sessions"
+  log_fail "--if-enabled hook captures by default when no config exists" "missing default-on state"
+fi
+"$SESSION" --hub "$default_hub" disable >/dev/null
+printf '{"session_id":"disabled","hook_event_name":"PostToolUse","cwd":"%s","tool_name":"Bash"}' "$PWD" \
+  | "$SESSION" --hub "$default_hub" hook --harness codex --if-enabled
+if [ ! -f "$default_hub/.sessions/state/codex/disabled.json" ]; then
+  log_pass "session disable makes --if-enabled hook no-op"
+else
+  log_fail "session disable makes --if-enabled hook no-op" "created disabled session state"
 fi
 
 if "$SESSION" --hub "$hub" enable --mode balanced --tool-events 2 >/dev/null \

--- a/tests/test-session-capture.sh
+++ b/tests/test-session-capture.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Validate deterministic llm-wiki session capture helper.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+SESSION="$PROJECT_ROOT/scripts/llm-wiki-session"
+PASS=0
+FAIL=0
+TOTAL=0
+
+log_pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); printf "  \033[32mPASS\033[0m: %s\n" "$1"; }
+log_fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); printf "  \033[31mFAIL\033[0m: %s - %s\n" "$1" "$2"; }
+
+echo "=== Session Capture Helper ==="
+
+if [ -x "$SESSION" ]; then
+  log_pass "scripts/llm-wiki-session is executable"
+else
+  log_fail "scripts/llm-wiki-session is executable" "missing executable bit"
+fi
+
+if python3 -m py_compile "$SESSION"; then
+  log_pass "scripts/llm-wiki-session compiles"
+else
+  log_fail "scripts/llm-wiki-session compiles" "py_compile failed"
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+hub="$tmpdir/wiki"
+mkdir -p "$hub/topics/demo/raw/notes" "$hub/topics"
+cat > "$hub/_index.md" <<'MD'
+# Hub
+MD
+cat > "$hub/log.md" <<'MD'
+# Hub Log
+MD
+cat > "$hub/wikis.json" <<'JSON'
+{
+  "default": "<HUB>",
+  "wikis": {
+    "hub": { "path": "<HUB>", "description": "Hub" },
+    "demo": { "path": "topics/demo", "description": "Demo topic" }
+  },
+  "local_wikis": []
+}
+JSON
+cat > "$hub/topics/demo/_index.md" <<'MD'
+# Demo
+MD
+cat > "$hub/topics/demo/config.md" <<'MD'
+---
+title: "Demo"
+---
+MD
+cat > "$hub/topics/demo/log.md" <<'MD'
+# Demo Log
+MD
+
+skip_hub="$tmpdir/skip-wiki"
+mkdir -p "$skip_hub/topics"
+touch "$skip_hub/_index.md" "$skip_hub/log.md"
+echo '{"wikis":{}}' > "$skip_hub/wikis.json"
+printf '{"session_id":"skip","hook_event_name":"PostToolUse","cwd":"%s","tool_name":"Bash"}' "$PWD" \
+  | "$SESSION" --hub "$skip_hub" hook --harness codex --if-enabled
+if [ ! -e "$skip_hub/.sessions" ]; then
+  log_pass "--if-enabled hook no-ops before opt-in"
+else
+  log_fail "--if-enabled hook no-ops before opt-in" "created $skip_hub/.sessions"
+fi
+
+if "$SESSION" --hub "$hub" enable --mode balanced --tool-events 2 >/dev/null \
+  && grep -q '"enabled": true' "$hub/.sessions/config.json" \
+  && grep -q '"mode": "balanced"' "$hub/.sessions/config.json"; then
+  log_pass "enable writes balanced config"
+else
+  log_fail "enable writes balanced config" "$(cat "$hub/.sessions/config.json" 2>/dev/null || true)"
+fi
+
+payload1=$(printf '{"session_id":"test-session","hook_event_name":"PostToolUse","cwd":"%s","prompt":"do not store this raw prompt text","tool_name":"Bash","tool_input":{"api_key":"sk-12345678901234567890","command":"curl -H Authorization: Bearer abcdefghijklmnop"}}' "$PWD")
+payload2=$(printf '{"session_id":"test-session","hook_event_name":"PostToolUse","cwd":"%s","tool_name":"Bash"}' "$PWD")
+printf '%s' "$payload1" | "$SESSION" --hub "$hub" hook --harness codex --if-enabled
+printf '%s' "$payload2" | "$SESSION" --hub "$hub" hook --harness codex --if-enabled
+
+digest="$hub/.sessions/digests/$(date +%Y)/$(date +%m)/codex-test-session.md"
+if [ -f "$digest" ] \
+  && grep -q 'capture_trigger: "tool-count-2"' "$digest" \
+  && grep -q 'llm_wiki_session_id: "codex:test-session"' "$digest"; then
+  log_pass "tool threshold writes markdown digest"
+else
+  log_fail "tool threshold writes markdown digest" "missing or malformed digest at $digest"
+fi
+
+if ! grep -R 'sk-12345678901234567890\|abcdefghijklmnop\|do not store this raw prompt text' "$hub/.sessions" >/dev/null; then
+  log_pass "hook event previews redact secrets and omit raw prompt text"
+else
+  log_fail "hook event previews redact secrets and omit raw prompt text" "secret material found under .sessions"
+fi
+
+rehydrate_output="$("$SESSION" --hub "$hub" rehydrate --session-id codex:test-session 2>&1)"
+if grep -q 'llm-wiki session context' <<<"$rehydrate_output" \
+  && grep -q 'codex:test-session' <<<"$rehydrate_output"; then
+  log_pass "rehydrate prints compact context block"
+else
+  log_fail "rehydrate prints compact context block" "$rehydrate_output"
+fi
+
+session_start_output="$(printf '{"session_id":"test-session","hook_event_name":"SessionStart","cwd":"%s"}' "$PWD" | "$SESSION" --hub "$hub" hook --harness codex --if-enabled 2>&1)"
+if python3 -c 'import json,sys; data=json.load(sys.stdin); assert data["hookSpecificOutput"]["additionalContext"]' <<<"$session_start_output" 2>/dev/null; then
+  log_pass "balanced SessionStart hook emits additionalContext"
+else
+  log_fail "balanced SessionStart hook emits additionalContext" "$session_start_output"
+fi
+
+promote_output="$("$SESSION" --hub "$hub" promote codex:test-session --topic demo 2>&1)"
+if [ -f "$promote_output" ] \
+  && grep -q 'Session Digest Promotion: codex:test-session' "$promote_output" \
+  && grep -q 'promoted session digest codex:test-session' "$hub/topics/demo/log.md" \
+  && grep -q '"demo"' "$hub/.sessions/indexes/by-topic.json"; then
+  log_pass "promote creates topic raw note and index topic tag"
+else
+  log_fail "promote creates topic raw note and index topic tag" "$promote_output"
+fi
+
+list_output="$("$SESSION" --hub "$hub" list --json 2>&1)"
+if python3 -c 'import json,sys; data=json.load(sys.stdin); assert data["sessions"][0]["llm_wiki_session_id"] == "codex:test-session"' <<<"$list_output"; then
+  log_pass "list --json reports captured session"
+else
+  log_fail "list --json reports captured session" "$list_output"
+fi
+
+echo ""
+echo "==========================================="
+printf "Results: \033[32m%d passed\033[0m, \033[31m%d failed\033[0m, %d total\n" "$PASS" "$FAIL" "$TOTAL"
+echo "==========================================="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-session-capture.sh
+++ b/tests/test-session-capture.sh
@@ -78,6 +78,19 @@ else
   log_fail "enable writes balanced config" "$(cat "$hub/.sessions/config.json" 2>/dev/null || true)"
 fi
 
+plugin_root_with_space="$tmpdir/plugin root"
+ln -s "$PROJECT_ROOT/plugins/llm-wiki" "$plugin_root_with_space"
+mkdir -p "$tmpdir/home/.config/llm-wiki"
+printf '{"hub_path":"%s"}\n' "$hub" > "$tmpdir/home/.config/llm-wiki/config.json"
+manifest_hook_cmd="$(python3 -c 'import json; from pathlib import Path; hooks=json.loads(Path("plugins/llm-wiki/hooks/hooks.json").read_text())["hooks"]; print(hooks["PostToolUse"][0]["hooks"][0]["command"])')"
+printf '{"session_id":"manifest-space","hook_event_name":"PostToolUse","cwd":"%s","tool_name":"Bash"}' "$PWD" \
+  | HOME="$tmpdir/home" PLUGIN_ROOT="$plugin_root_with_space" sh -c "$manifest_hook_cmd"
+if [ -f "$hub/.sessions/state/codex/manifest-space.json" ]; then
+  log_pass "Codex bundled hook command handles PLUGIN_ROOT paths with spaces"
+else
+  log_fail "Codex bundled hook command handles PLUGIN_ROOT paths with spaces" "$manifest_hook_cmd"
+fi
+
 payload1=$(printf '{"session_id":"test-session","hook_event_name":"PostToolUse","cwd":"%s","prompt":"do not store this raw prompt text","tool_name":"Bash","tool_input":{"api_key":"sk-12345678901234567890","command":"curl -H Authorization: Bearer abcdefghijklmnop"}}' "$PWD")
 payload2=$(printf '{"session_id":"test-session","hook_event_name":"PostToolUse","cwd":"%s","tool_name":"Bash"}' "$PWD")
 printf '%s' "$payload1" | "$SESSION" --hub "$hub" hook --harness codex --if-enabled
@@ -124,7 +137,7 @@ else
 fi
 
 list_output="$("$SESSION" --hub "$hub" list --json 2>&1)"
-if python3 -c 'import json,sys; data=json.load(sys.stdin); assert data["sessions"][0]["llm_wiki_session_id"] == "codex:test-session"' <<<"$list_output"; then
+if python3 -c 'import json,sys; data=json.load(sys.stdin); assert any(s.get("llm_wiki_session_id") == "codex:test-session" for s in data["sessions"])' <<<"$list_output"; then
   log_pass "list --json reports captured session"
 else
   log_fail "list --json reports captured session" "$list_output"

--- a/tests/test-session-capture.sh
+++ b/tests/test-session-capture.sh
@@ -91,6 +91,24 @@ else
   log_fail "Codex bundled hook command handles PLUGIN_ROOT paths with spaces" "$manifest_hook_cmd"
 fi
 
+claude_payload1=$(printf '{"session_id":"claude-session","hook_event_name":"PostToolUse","cwd":"%s","permission_mode":"default","transcript_path":"%s/transcript.jsonl","tool_name":"Bash","prompt":"do not store this Claude prompt","tool_response":"do not store this Claude tool response","tool_input":{"password":"super-secret-password"}}' "$PWD" "$tmpdir")
+claude_payload2=$(printf '{"session_id":"claude-session","hook_event_name":"PostToolUse","cwd":"%s","permission_mode":"default","transcript_path":"%s/transcript.jsonl","tool_name":"Read"}' "$PWD" "$tmpdir")
+printf '%s' "$claude_payload1" | "$SESSION" --hub "$hub" hook --if-enabled
+printf '%s' "$claude_payload2" | "$SESSION" --hub "$hub" hook --if-enabled
+claude_digest="$hub/.sessions/digests/$(date +%Y)/$(date +%m)/claude-claude-session.md"
+if [ -f "$claude_digest" ] \
+  && grep -q 'harness: "claude"' "$claude_digest" \
+  && grep -q 'llm_wiki_session_id: "claude:claude-session"' "$claude_digest"; then
+  log_pass "Claude-like hook payload auto-detects harness and writes digest"
+else
+  log_fail "Claude-like hook payload auto-detects harness and writes digest" "$claude_digest"
+fi
+if ! grep -R 'super-secret-password\|do not store this Claude prompt\|do not store this Claude tool response' "$hub/.sessions" >/dev/null; then
+  log_pass "Claude-like hook payload redacts secrets and omits content fields"
+else
+  log_fail "Claude-like hook payload redacts secrets and omits content fields" "sensitive Claude payload data found under .sessions"
+fi
+
 payload1=$(printf '{"session_id":"test-session","hook_event_name":"PostToolUse","cwd":"%s","prompt":"do not store this raw prompt text","tool_name":"Bash","tool_input":{"api_key":"sk-12345678901234567890","command":"curl -H Authorization: Bearer abcdefghijklmnop"}}' "$PWD")
 payload2=$(printf '{"session_id":"test-session","hook_event_name":"PostToolUse","cwd":"%s","tool_name":"Bash"}' "$PWD")
 printf '%s' "$payload1" | "$SESSION" --hub "$hub" hook --harness codex --if-enabled


### PR DESCRIPTION
## Summary

Adds an opt-in automated session-capture subsystem for llm-wiki:

- new `scripts/llm-wiki-session` helper for enable/disable/status, hook event capture, manual checkpoints, list/show, rehydrate, and promote
- hidden `.sessions/` operational layout with config JSON, append-only registry/queue JSONL, per-session state JSON, derived indexes, and markdown digests
- Codex plugin-bundled lifecycle hooks that call the helper with `--if-enabled`, so installed hooks remain inert until the user enables sessions
- new `/wiki:session` command spec and `references/sessions.md` architecture guide
- lint allowance for `.sessions/` at hub or local wiki roots
- docs/README updates and session-capture test coverage

Privacy defaults: raw transcripts are not copied; prompt/content-like fields are omitted from event previews; obvious secrets are redacted; promotion into topic `raw/notes/` is explicit only.

## Tests

- `./tests/test-plugin-validate.sh` — 91 passed
- `./tests/test-structure.sh` — 168 passed
- `./tests/test-local-cli-lint.sh` — 22 passed
- `./tests/test-session-capture.sh` — 10 passed
- `./tests/test-codex-sync.sh`
- `./tests/test-opencode-sync.sh`
