### PR TITLE
Fix: Add Windows Codex hook support with `commandWindows`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ benchmarks/results/
 
 # macOS
 .DS_Store
+
+# Temporary directory for tests on Windows
+tests/temp/

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Windows PowerShell:
 
 Windows `cmd.exe`:
 ```bat
-scripts\bootstrap-codex-plugin.cmd --scope user --verify
+scripts\bootstrap-codex-plugin.cmd -Scope user -Verify
 ```
 
 Or register the local checkout manually:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Install from a local checkout with the managed bootstrap helper:
 ./scripts/bootstrap-codex-plugin.sh --scope user --verify
 ```
 
+Windows PowerShell:
+```powershell
+.\scripts\bootstrap-codex-plugin.ps1 -Scope user -Verify
+```
+
+Windows `cmd.exe`:
+```bat
+scripts\bootstrap-codex-plugin.cmd --scope user --verify
+```
+
 Or register the local checkout manually:
 ```bash
 codex plugin marketplace add /absolute/path/to/llm-wiki

--- a/claude-plugin/skills/wiki-manager/references/sessions.md
+++ b/claude-plugin/skills/wiki-manager/references/sessions.md
@@ -175,7 +175,7 @@ turn capture off with `session disable` without editing hook manifests.
 Use the JSON hook `command` for Unix-like shells and `commandWindows` for a
 Windows-only override that calls the bundled `.cmd` launcher. Include
 `--event-name <event>` in both commands so the helper can still classify the
-event if a runtime sends malformed or empty hook JSON.
+event if a runtime sends empty hook JSON or omits the event name.
 
 Useful Codex events:
 

--- a/claude-plugin/skills/wiki-manager/references/sessions.md
+++ b/claude-plugin/skills/wiki-manager/references/sessions.md
@@ -172,6 +172,10 @@ Codex plugins can bundle hooks in `hooks/hooks.json`. Plugin-bundled hooks still
 require the user to review/trust them. The bundled llm-wiki Codex hook should
 call the copied helper in the plugin root and use `--if-enabled`, so users can
 turn capture off with `session disable` without editing hook manifests.
+Use the JSON hook `command` for Unix-like shells and `commandWindows` for a
+Windows-only override that calls the bundled `.cmd` launcher. Include
+`--event-name <event>` in both commands so the helper can still classify the
+event if a runtime sends malformed or empty hook JSON.
 
 Useful Codex events:
 

--- a/plugins/llm-wiki/hooks/hooks.json
+++ b/plugins/llm-wiki/hooks/hooks.json
@@ -5,7 +5,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --event-name SessionStart --if-enabled",
+            "commandWindows": "cmd.exe /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\llm-wiki-hook.cmd\" hook --harness codex --event-name SessionStart --if-enabled\"",
             "timeout": 5,
             "statusMessage": "Loading llm-wiki session context"
           }
@@ -17,7 +18,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --event-name UserPromptSubmit --if-enabled",
+            "commandWindows": "cmd.exe /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\llm-wiki-hook.cmd\" hook --harness codex --event-name UserPromptSubmit --if-enabled\"",
             "timeout": 5,
             "statusMessage": "Checking llm-wiki session context"
           }
@@ -30,7 +32,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --event-name PostToolUse --if-enabled",
+            "commandWindows": "cmd.exe /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\llm-wiki-hook.cmd\" hook --harness codex --event-name PostToolUse --if-enabled\"",
             "timeout": 5,
             "statusMessage": "Recording llm-wiki session event"
           }
@@ -43,7 +46,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --event-name PreCompact --if-enabled",
+            "commandWindows": "cmd.exe /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\llm-wiki-hook.cmd\" hook --harness codex --event-name PreCompact --if-enabled\"",
             "timeout": 5,
             "statusMessage": "Capturing llm-wiki pre-compact session context"
           }
@@ -56,7 +60,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --event-name PostCompact --if-enabled",
+            "commandWindows": "cmd.exe /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\llm-wiki-hook.cmd\" hook --harness codex --event-name PostCompact --if-enabled\"",
             "timeout": 5,
             "statusMessage": "Capturing llm-wiki post-compact session context"
           }
@@ -68,7 +73,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --event-name Stop --if-enabled",
+            "commandWindows": "cmd.exe /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\llm-wiki-hook.cmd\" hook --harness codex --event-name Stop --if-enabled\"",
             "timeout": 5,
             "statusMessage": "Saving llm-wiki session checkpoint"
           }

--- a/plugins/llm-wiki/hooks/llm-wiki-hook.cmd
+++ b/plugins/llm-wiki/hooks/llm-wiki-hook.cmd
@@ -1,0 +1,24 @@
+@echo off
+setlocal
+
+set "SCRIPT=%~dp0llm_wiki_session.py"
+
+where py >nul 2>nul
+if %ERRORLEVEL%==0 (
+  py -3 "%SCRIPT%" %*
+  exit /b 0
+)
+
+where python3 >nul 2>nul
+if %ERRORLEVEL%==0 (
+  python3 "%SCRIPT%" %*
+  exit /b 0
+)
+
+where python >nul 2>nul
+if %ERRORLEVEL%==0 (
+  python "%SCRIPT%" %*
+  exit /b 0
+)
+
+exit /b 0

--- a/plugins/llm-wiki/hooks/llm_wiki_session.py
+++ b/plugins/llm-wiki/hooks/llm_wiki_session.py
@@ -1093,8 +1093,8 @@ def run_hook(args: argparse.Namespace) -> int:
     config = load_config(root)
     if args.if_enabled and not config.get("enabled"):
         raise HookSkip()
-    ensure_layout(root)
     payload = parse_hook_payload(args)
+    ensure_layout(root)
     event = normalize_event(args, payload, root)
     append_jsonl(event_queue_path(root, event), event)
     state, is_new = update_state(root, event, config)
@@ -1747,11 +1747,6 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     except BrokenPipeError:
         return 0
-    except Exception as exc:
-        if getattr(args, "command", None) == "hook":
-            hook_debug(f"llm-wiki hook skipped: {exc}")
-            return 0
-        raise
 
 
 if __name__ == "__main__":

--- a/plugins/llm-wiki/hooks/llm_wiki_session.py
+++ b/plugins/llm-wiki/hooks/llm_wiki_session.py
@@ -246,6 +246,55 @@ def read_json(path: Path, default: Any) -> Any:
             return default
 
 
+def read_stdin_text() -> str:
+    data = sys.stdin.buffer.read()
+    if not data:
+        return ""
+
+    encodings: list[str] = []
+    if data.startswith(b"\xef\xbb\xbf"):
+        encodings.append("utf-8-sig")
+    elif data.startswith((b"\xff\xfe", b"\xfe\xff")):
+        encodings.append("utf-16")
+    encodings.extend(["utf-8", sys.getfilesystemencoding() or "utf-8"])
+
+    seen: set[str] = set()
+    for encoding in encodings:
+        if encoding in seen:
+            continue
+        seen.add(encoding)
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return data.decode("utf-8", errors="replace")
+
+
+def hook_debug(message: str) -> None:
+    if os.environ.get("LLM_WIKI_HOOK_DEBUG"):
+        print(message, file=sys.stderr)
+
+
+def parse_hook_payload(args: argparse.Namespace) -> dict[str, Any]:
+    raw = read_stdin_text().lstrip("\ufeff")
+    if not raw.strip():
+        return {}
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        if getattr(args, "strict_json", False):
+            raise SystemExit(f"invalid hook JSON input: {exc}") from exc
+        hook_debug(f"llm-wiki hook skipped invalid JSON input: {exc}")
+        raise HookSkip()
+    if not isinstance(parsed, dict):
+        if getattr(args, "strict_json", False):
+            raise SystemExit("hook JSON input must be an object")
+        hook_debug("llm-wiki hook skipped non-object JSON input")
+        raise HookSkip()
+    return parsed
+
+
 def write_json(path: Path, data: Any) -> None:
     atomic_write(path, json.dumps(data, indent=2, sort_keys=True) + "\n")
 
@@ -1045,18 +1094,7 @@ def run_hook(args: argparse.Namespace) -> int:
     if args.if_enabled and not config.get("enabled"):
         raise HookSkip()
     ensure_layout(root)
-    raw = sys.stdin.read()
-    payload: dict[str, Any]
-    if raw.strip():
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise SystemExit(f"invalid hook JSON input: {exc}") from exc
-        if not isinstance(parsed, dict):
-            raise SystemExit("hook JSON input must be an object")
-        payload = parsed
-    else:
-        payload = {}
+    payload = parse_hook_payload(args)
     event = normalize_event(args, payload, root)
     append_jsonl(event_queue_path(root, event), event)
     state, is_new = update_state(root, event, config)
@@ -1623,6 +1661,7 @@ def build_parser() -> argparse.ArgumentParser:
     hook.add_argument("--trigger", help="Override capture trigger name.")
     hook.add_argument("--if-enabled", action="store_true", help="Honor .sessions/config.json enabled=false; default is enabled when no config exists.")
     hook.add_argument("--max-event-bytes", type=int, default=MAX_EVENT_PREVIEW_CHARS)
+    hook.add_argument("--strict-json", action="store_true", help="Fail hook calls on invalid JSON instead of skipping them.")
     hook.set_defaults(func=run_hook)
 
     capture = sub.add_parser("capture", help="Force a manual session digest checkpoint.")
@@ -1707,7 +1746,12 @@ def main(argv: list[str] | None = None) -> int:
     except HookSkip:
         return 0
     except BrokenPipeError:
-        return 1
+        return 0
+    except Exception as exc:
+        if getattr(args, "command", None) == "hook":
+            hook_debug(f"llm-wiki hook skipped: {exc}")
+            return 0
+        raise
 
 
 if __name__ == "__main__":

--- a/plugins/llm-wiki/skills/wiki/references/sessions.md
+++ b/plugins/llm-wiki/skills/wiki/references/sessions.md
@@ -175,7 +175,7 @@ turn capture off with `session disable` without editing hook manifests.
 Use the JSON hook `command` for Unix-like shells and `commandWindows` for a
 Windows-only override that calls the bundled `.cmd` launcher. Include
 `--event-name <event>` in both commands so the helper can still classify the
-event if a runtime sends malformed or empty hook JSON.
+event if a runtime sends empty hook JSON or omits the event name.
 
 Useful Codex events:
 

--- a/plugins/llm-wiki/skills/wiki/references/sessions.md
+++ b/plugins/llm-wiki/skills/wiki/references/sessions.md
@@ -172,6 +172,10 @@ Codex plugins can bundle hooks in `hooks/hooks.json`. Plugin-bundled hooks still
 require the user to review/trust them. The bundled llm-wiki Codex hook should
 call the copied helper in the plugin root and use `--if-enabled`, so users can
 turn capture off with `session disable` without editing hook manifests.
+Use the JSON hook `command` for Unix-like shells and `commandWindows` for a
+Windows-only override that calls the bundled `.cmd` launcher. Include
+`--event-name <event>` in both commands so the helper can still classify the
+event if a runtime sends malformed or empty hook JSON.
 
 Useful Codex events:
 

--- a/scripts/bootstrap-codex-plugin.cmd
+++ b/scripts/bootstrap-codex-plugin.cmd
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+
+set "SCRIPT=%~dp0bootstrap-codex-plugin.ps1"
+
+where pwsh >nul 2>nul
+if %ERRORLEVEL%==0 (
+  pwsh -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT%" %*
+  exit /b %ERRORLEVEL%
+)
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT%" %*
+exit /b %ERRORLEVEL%

--- a/scripts/bootstrap-codex-plugin.ps1
+++ b/scripts/bootstrap-codex-plugin.ps1
@@ -1,6 +1,6 @@
 param(
   [ValidateSet("project", "user")]
-  [string]$Scope = "project",
+  [string]$Scope = "user",
   [Alias("project-root")]
   [string]$ProjectRoot = (Get-Location).Path,
   [Alias("user-home")]
@@ -18,16 +18,18 @@ function Show-Usage {
   @"
 Usage: .\scripts\bootstrap-codex-plugin.ps1 [options]
 
-Register this repo as a local Codex marketplace source and write a managed
-plugin-enable block for @wiki.
+Register this repo as a local Codex marketplace source, install @wiki and the
+bundled `$wiki-query preset into the Codex plugin cache, and enable the plugin
+in the user config.
 
 Options:
-  -Scope project|user   Where to write config (default: project)
-  -ProjectRoot <dir>    Project root for project scope (default: current dir)
+  -Scope user           Plugin enablement scope (default: user). Codex 0.144
+                        does not load plugin enablement from project config.
+  -ProjectRoot <dir>    Working directory for the optional verification probe
   -UserHome <dir>       HOME used for Codex marketplace registration and
                         user-scope config writes (default: current HOME)
   -Print                Print the managed TOML block without writing it
-  -Verify               Run scripts/verify-codex-plugin.ps1 after writing
+  -Verify               Run scripts/verify-codex-plugin.ps1 after installation
   -Help                 Show this help
 "@
 }
@@ -37,22 +39,6 @@ function Resolve-ExistingDirectory([string]$PathValue) {
     throw "Directory not found: $PathValue"
   }
   return (Resolve-Path -LiteralPath $PathValue).Path
-}
-
-function Read-TextIfExists([string]$PathValue) {
-  if (-not (Test-Path -LiteralPath $PathValue -PathType Leaf)) {
-    return ""
-  }
-  return [System.IO.File]::ReadAllText($PathValue, [System.Text.Encoding]::UTF8)
-}
-
-function Write-Utf8NoBom([string]$PathValue, [string]$Text) {
-  $parent = Split-Path -Parent $PathValue
-  if ($parent) {
-    New-Item -ItemType Directory -Force -Path $parent | Out-Null
-  }
-  $encoding = [System.Text.UTF8Encoding]::new($false)
-  [System.IO.File]::WriteAllText($PathValue, $Text, $encoding)
 }
 
 function Invoke-WithCodexHome([string]$UserHomeValue, [scriptblock]$Body) {
@@ -71,9 +57,52 @@ function Invoke-WithCodexHome([string]$UserHomeValue, [scriptblock]$Body) {
   }
 }
 
+function Invoke-CodexJson([System.Management.Automation.CommandInfo]$CodexCommand, [string[]]$Arguments) {
+  $Output = & $CodexCommand.Source @Arguments
+  $ExitCode = $LASTEXITCODE
+  $Text = ($Output | Out-String).Trim()
+  if ($ExitCode -ne 0) {
+    throw "codex $($Arguments -join ' ') failed with exit code $ExitCode`n$Text"
+  }
+  try {
+    return $Text | ConvertFrom-Json
+  }
+  catch {
+    throw "codex $($Arguments -join ' ') returned invalid JSON`n$Text"
+  }
+}
+
+function Normalize-PathForComparison([string]$PathValue) {
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    return ""
+  }
+  if (Test-Path -LiteralPath $PathValue) {
+    $PathValue = (Resolve-Path -LiteralPath $PathValue).Path
+  }
+  else {
+    $PathValue = [System.IO.Path]::GetFullPath($PathValue)
+  }
+  return $PathValue.TrimEnd([char[]]@('\', '/'))
+}
+
+function Test-SamePath([string]$Left, [string]$Right) {
+  if ([string]::IsNullOrWhiteSpace($Left) -or [string]::IsNullOrWhiteSpace($Right)) {
+    return $false
+  }
+  return [string]::Equals(
+    (Normalize-PathForComparison $Left),
+    (Normalize-PathForComparison $Right),
+    [System.StringComparison]::OrdinalIgnoreCase
+  )
+}
+
 if ($Help) {
   Show-Usage
   exit 0
+}
+
+if ($Scope -eq "project") {
+  throw "Project-scoped plugin enablement is not supported by Codex 0.144. Use -Scope user; plugin hooks can still be enabled or disabled separately."
 }
 
 if ($Print -and $Verify) {
@@ -85,7 +114,6 @@ $ProjectRoot = Resolve-ExistingDirectory $ProjectRoot
 $UserHome = Resolve-ExistingDirectory $UserHome
 $MarketplaceName = "llm-wiki"
 $PluginKey = "wiki@$MarketplaceName"
-$UserConfig = Join-Path $UserHome ".codex\config.toml"
 $ManagedBlock = @"
 [plugins."$PluginKey"]
 enabled = true
@@ -103,25 +131,32 @@ if (-not $Codex) {
 
 New-Item -ItemType Directory -Force -Path (Join-Path $UserHome ".codex") | Out-Null
 
-$UserConfigText = Read-TextIfExists $UserConfig
-$MarketplacePattern = "(?ms)^\[marketplaces\.$([regex]::Escape($MarketplaceName))\]\r?\n.*?^source = ""(.*?)""$"
-$MarketplaceMatch = [regex]::Match($UserConfigText, $MarketplacePattern)
-$MarketplaceSource = if ($MarketplaceMatch.Success) { $MarketplaceMatch.Groups[1].Value } else { "" }
+$MarketplaceData = Invoke-WithCodexHome $UserHome {
+  Invoke-CodexJson $Codex @("plugin", "marketplace", "list", "--json")
+}
+$Marketplace = @($MarketplaceData.marketplaces) |
+  Where-Object { $_.name -eq $MarketplaceName } |
+  Select-Object -First 1
 
-if ([string]::IsNullOrWhiteSpace($MarketplaceSource)) {
+if ($null -eq $Marketplace) {
   Invoke-WithCodexHome $UserHome {
-    & $Codex.Source plugin marketplace add $Root
-    if ($LASTEXITCODE -ne 0) {
-      throw "codex plugin marketplace add failed with exit code $LASTEXITCODE"
+    $Output = & $Codex.Source plugin marketplace add $Root 2>&1
+    $ExitCode = $LASTEXITCODE
+    if ($ExitCode -ne 0) {
+      throw "codex plugin marketplace add failed with exit code $ExitCode`n$($Output | Out-String)"
     }
+    $Output | ForEach-Object { Write-Host $_ }
   }
 }
 else {
-  $NormalizedMarketplaceSource = $MarketplaceSource
-  if (Test-Path -LiteralPath $MarketplaceSource) {
-    $NormalizedMarketplaceSource = (Resolve-Path -LiteralPath $MarketplaceSource).Path
+  $MarketplaceSource = ""
+  if ($Marketplace.marketplaceSource -and $Marketplace.marketplaceSource.source) {
+    $MarketplaceSource = [string]$Marketplace.marketplaceSource.source
   }
-  if (-not [string]::Equals($NormalizedMarketplaceSource, $Root, [System.StringComparison]::OrdinalIgnoreCase)) {
+  elseif ($Marketplace.root) {
+    $MarketplaceSource = [string]$Marketplace.root
+  }
+  if (-not (Test-SamePath $MarketplaceSource $Root)) {
     throw @"
 Codex marketplace '$MarketplaceName' already points at:
   $MarketplaceSource
@@ -131,34 +166,22 @@ Use that checkout, or remove/re-add the marketplace in this Codex home first.
   }
 }
 
-if ($Scope -eq "project") {
-  $Target = Join-Path $ProjectRoot ".codex\config.toml"
+$InstallData = Invoke-WithCodexHome $UserHome {
+  Invoke-CodexJson $Codex @("plugin", "add", $PluginKey, "--json")
 }
-else {
-  $Target = $UserConfig
+if (-not $InstallData.installedPath) {
+  throw "codex plugin add did not return installedPath"
 }
 
-$Begin = "# BEGIN llm-wiki Codex bootstrap"
-$End = "# END llm-wiki Codex bootstrap"
-$Managed = "$Begin`n$ManagedBlock`n$End`n"
-$Text = Read-TextIfExists $Target
-$BlockPattern = "(?ms)^$([regex]::Escape($Begin))\r?\n.*?^$([regex]::Escape($End))\r?\n?"
-if ([regex]::IsMatch($Text, $BlockPattern)) {
-  $Updated = [regex]::Replace($Text, $BlockPattern, $Managed, 1)
-}
-else {
-  if ($Text -and -not $Text.EndsWith("`n")) {
-    $Text += "`n"
-  }
-  if ($Text) {
-    $Text += "`n"
-  }
-  $Updated = $Text + $Managed
-}
-Write-Utf8NoBom $Target $Updated
-
-Write-Host "Wrote Codex plugin config:"
-Write-Host "  $Target"
+$UserConfig = Join-Path $UserHome ".codex\config.toml"
+Write-Host "Installed Codex plugin:"
+Write-Host "  $PluginKey"
+Write-Host "Installed cache:"
+Write-Host "  $($InstallData.installedPath)"
+Write-Host "Enabled scope:"
+Write-Host "  $Scope"
+Write-Host "Codex plugin config:"
+Write-Host "  $UserConfig"
 Write-Host "Source repo:"
 Write-Host "  $Root"
 Write-Host "Codex home:"
@@ -166,11 +189,6 @@ Write-Host "  $UserHome"
 
 if ($Verify) {
   $VerifyScript = Join-Path $PSScriptRoot "verify-codex-plugin.ps1"
-  if ($Scope -eq "project") {
-    & $VerifyScript -Scope project -ProjectRoot $ProjectRoot -UserHome $UserHome
-  }
-  else {
-    & $VerifyScript -Scope user -UserHome $UserHome
-  }
+  & $VerifyScript -Scope user -ProjectRoot $ProjectRoot -UserHome $UserHome
   exit $LASTEXITCODE
 }

--- a/scripts/bootstrap-codex-plugin.ps1
+++ b/scripts/bootstrap-codex-plugin.ps1
@@ -1,0 +1,176 @@
+param(
+  [ValidateSet("project", "user")]
+  [string]$Scope = "project",
+  [Alias("project-root")]
+  [string]$ProjectRoot = (Get-Location).Path,
+  [Alias("user-home")]
+  [string]$UserHome = $HOME,
+  [switch]$Print,
+  [switch]$Verify,
+  [switch]$Help
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+$IsWindowsHost = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+
+function Show-Usage {
+  @"
+Usage: .\scripts\bootstrap-codex-plugin.ps1 [options]
+
+Register this repo as a local Codex marketplace source and write a managed
+plugin-enable block for @wiki.
+
+Options:
+  -Scope project|user   Where to write config (default: project)
+  -ProjectRoot <dir>    Project root for project scope (default: current dir)
+  -UserHome <dir>       HOME used for Codex marketplace registration and
+                        user-scope config writes (default: current HOME)
+  -Print                Print the managed TOML block without writing it
+  -Verify               Run scripts/verify-codex-plugin.ps1 after writing
+  -Help                 Show this help
+"@
+}
+
+function Resolve-ExistingDirectory([string]$PathValue) {
+  if (-not (Test-Path -LiteralPath $PathValue -PathType Container)) {
+    throw "Directory not found: $PathValue"
+  }
+  return (Resolve-Path -LiteralPath $PathValue).Path
+}
+
+function Read-TextIfExists([string]$PathValue) {
+  if (-not (Test-Path -LiteralPath $PathValue -PathType Leaf)) {
+    return ""
+  }
+  return [System.IO.File]::ReadAllText($PathValue, [System.Text.Encoding]::UTF8)
+}
+
+function Write-Utf8NoBom([string]$PathValue, [string]$Text) {
+  $parent = Split-Path -Parent $PathValue
+  if ($parent) {
+    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+  }
+  $encoding = [System.Text.UTF8Encoding]::new($false)
+  [System.IO.File]::WriteAllText($PathValue, $Text, $encoding)
+}
+
+function Invoke-WithCodexHome([string]$UserHomeValue, [scriptblock]$Body) {
+  $oldHome = $env:HOME
+  $oldUserProfile = $env:USERPROFILE
+  try {
+    $env:HOME = $UserHomeValue
+    if ($IsWindowsHost) {
+      $env:USERPROFILE = $UserHomeValue
+    }
+    & $Body
+  }
+  finally {
+    $env:HOME = $oldHome
+    $env:USERPROFILE = $oldUserProfile
+  }
+}
+
+if ($Help) {
+  Show-Usage
+  exit 0
+}
+
+if ($Print -and $Verify) {
+  throw "-Print and -Verify cannot be combined"
+}
+
+$Root = Resolve-ExistingDirectory (Join-Path $PSScriptRoot "..")
+$ProjectRoot = Resolve-ExistingDirectory $ProjectRoot
+$UserHome = Resolve-ExistingDirectory $UserHome
+$MarketplaceName = "llm-wiki"
+$PluginKey = "wiki@$MarketplaceName"
+$UserConfig = Join-Path $UserHome ".codex\config.toml"
+$ManagedBlock = @"
+[plugins."$PluginKey"]
+enabled = true
+"@
+
+if ($Print) {
+  $ManagedBlock
+  exit 0
+}
+
+$Codex = Get-Command codex -ErrorAction SilentlyContinue
+if (-not $Codex) {
+  throw "codex binary not found in PATH"
+}
+
+New-Item -ItemType Directory -Force -Path (Join-Path $UserHome ".codex") | Out-Null
+
+$UserConfigText = Read-TextIfExists $UserConfig
+$MarketplacePattern = "(?ms)^\[marketplaces\.$([regex]::Escape($MarketplaceName))\]\r?\n.*?^source = ""(.*?)""$"
+$MarketplaceMatch = [regex]::Match($UserConfigText, $MarketplacePattern)
+$MarketplaceSource = if ($MarketplaceMatch.Success) { $MarketplaceMatch.Groups[1].Value } else { "" }
+
+if ([string]::IsNullOrWhiteSpace($MarketplaceSource)) {
+  Invoke-WithCodexHome $UserHome {
+    & $Codex.Source plugin marketplace add $Root
+    if ($LASTEXITCODE -ne 0) {
+      throw "codex plugin marketplace add failed with exit code $LASTEXITCODE"
+    }
+  }
+}
+else {
+  $NormalizedMarketplaceSource = $MarketplaceSource
+  if (Test-Path -LiteralPath $MarketplaceSource) {
+    $NormalizedMarketplaceSource = (Resolve-Path -LiteralPath $MarketplaceSource).Path
+  }
+  if (-not [string]::Equals($NormalizedMarketplaceSource, $Root, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw @"
+Codex marketplace '$MarketplaceName' already points at:
+  $MarketplaceSource
+This helper will not overwrite another checkout automatically.
+Use that checkout, or remove/re-add the marketplace in this Codex home first.
+"@
+  }
+}
+
+if ($Scope -eq "project") {
+  $Target = Join-Path $ProjectRoot ".codex\config.toml"
+}
+else {
+  $Target = $UserConfig
+}
+
+$Begin = "# BEGIN llm-wiki Codex bootstrap"
+$End = "# END llm-wiki Codex bootstrap"
+$Managed = "$Begin`n$ManagedBlock`n$End`n"
+$Text = Read-TextIfExists $Target
+$BlockPattern = "(?ms)^$([regex]::Escape($Begin))\r?\n.*?^$([regex]::Escape($End))\r?\n?"
+if ([regex]::IsMatch($Text, $BlockPattern)) {
+  $Updated = [regex]::Replace($Text, $BlockPattern, $Managed, 1)
+}
+else {
+  if ($Text -and -not $Text.EndsWith("`n")) {
+    $Text += "`n"
+  }
+  if ($Text) {
+    $Text += "`n"
+  }
+  $Updated = $Text + $Managed
+}
+Write-Utf8NoBom $Target $Updated
+
+Write-Host "Wrote Codex plugin config:"
+Write-Host "  $Target"
+Write-Host "Source repo:"
+Write-Host "  $Root"
+Write-Host "Codex home:"
+Write-Host "  $UserHome"
+
+if ($Verify) {
+  $VerifyScript = Join-Path $PSScriptRoot "verify-codex-plugin.ps1"
+  if ($Scope -eq "project") {
+    & $VerifyScript -Scope project -ProjectRoot $ProjectRoot -UserHome $UserHome
+  }
+  else {
+    & $VerifyScript -Scope user -UserHome $UserHome
+  }
+  exit $LASTEXITCODE
+}

--- a/scripts/bootstrap-codex-plugin.ps1
+++ b/scripts/bootstrap-codex-plugin.ps1
@@ -44,12 +44,13 @@ function Resolve-ExistingDirectory([string]$PathValue) {
 function Invoke-WithCodexHome([string]$UserHomeValue, [scriptblock]$Body) {
   $oldHome = $env:HOME
   $oldUserProfile = $env:USERPROFILE
+  $codexHome = Join-Path $UserHomeValue ".codex"
   try {
     $env:HOME = $UserHomeValue
     if ($IsWindowsHost) {
       $env:USERPROFILE = $UserHomeValue
     }
-    & $Body
+    & { $env:CODEX_HOME = $codexHome; & $Body }
   }
   finally {
     $env:HOME = $oldHome
@@ -150,10 +151,10 @@ if ($null -eq $Marketplace) {
 }
 else {
   $MarketplaceSource = ""
-  if ($Marketplace.marketplaceSource -and $Marketplace.marketplaceSource.source) {
+  if ($Marketplace.PSObject.Properties.Name -contains "marketplaceSource" -and $Marketplace.marketplaceSource.PSObject.Properties.Name -contains "source") {
     $MarketplaceSource = [string]$Marketplace.marketplaceSource.source
   }
-  elseif ($Marketplace.root) {
+  elseif ($Marketplace.PSObject.Properties.Name -contains "root") {
     $MarketplaceSource = [string]$Marketplace.root
   }
   if (-not (Test-SamePath $MarketplaceSource $Root)) {

--- a/scripts/llm-wiki-hook.cmd
+++ b/scripts/llm-wiki-hook.cmd
@@ -1,0 +1,24 @@
+@echo off
+setlocal
+
+set "SCRIPT=%~dp0llm_wiki_session.py"
+
+where py >nul 2>nul
+if %ERRORLEVEL%==0 (
+  py -3 "%SCRIPT%" %*
+  exit /b 0
+)
+
+where python3 >nul 2>nul
+if %ERRORLEVEL%==0 (
+  python3 "%SCRIPT%" %*
+  exit /b 0
+)
+
+where python >nul 2>nul
+if %ERRORLEVEL%==0 (
+  python "%SCRIPT%" %*
+  exit /b 0
+)
+
+exit /b 0

--- a/scripts/llm-wiki-session
+++ b/scripts/llm-wiki-session
@@ -1093,8 +1093,8 @@ def run_hook(args: argparse.Namespace) -> int:
     config = load_config(root)
     if args.if_enabled and not config.get("enabled"):
         raise HookSkip()
-    ensure_layout(root)
     payload = parse_hook_payload(args)
+    ensure_layout(root)
     event = normalize_event(args, payload, root)
     append_jsonl(event_queue_path(root, event), event)
     state, is_new = update_state(root, event, config)
@@ -1747,11 +1747,6 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     except BrokenPipeError:
         return 0
-    except Exception as exc:
-        if getattr(args, "command", None) == "hook":
-            hook_debug(f"llm-wiki hook skipped: {exc}")
-            return 0
-        raise
 
 
 if __name__ == "__main__":

--- a/scripts/llm-wiki-session
+++ b/scripts/llm-wiki-session
@@ -246,6 +246,55 @@ def read_json(path: Path, default: Any) -> Any:
             return default
 
 
+def read_stdin_text() -> str:
+    data = sys.stdin.buffer.read()
+    if not data:
+        return ""
+
+    encodings: list[str] = []
+    if data.startswith(b"\xef\xbb\xbf"):
+        encodings.append("utf-8-sig")
+    elif data.startswith((b"\xff\xfe", b"\xfe\xff")):
+        encodings.append("utf-16")
+    encodings.extend(["utf-8", sys.getfilesystemencoding() or "utf-8"])
+
+    seen: set[str] = set()
+    for encoding in encodings:
+        if encoding in seen:
+            continue
+        seen.add(encoding)
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return data.decode("utf-8", errors="replace")
+
+
+def hook_debug(message: str) -> None:
+    if os.environ.get("LLM_WIKI_HOOK_DEBUG"):
+        print(message, file=sys.stderr)
+
+
+def parse_hook_payload(args: argparse.Namespace) -> dict[str, Any]:
+    raw = read_stdin_text().lstrip("\ufeff")
+    if not raw.strip():
+        return {}
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        if getattr(args, "strict_json", False):
+            raise SystemExit(f"invalid hook JSON input: {exc}") from exc
+        hook_debug(f"llm-wiki hook skipped invalid JSON input: {exc}")
+        raise HookSkip()
+    if not isinstance(parsed, dict):
+        if getattr(args, "strict_json", False):
+            raise SystemExit("hook JSON input must be an object")
+        hook_debug("llm-wiki hook skipped non-object JSON input")
+        raise HookSkip()
+    return parsed
+
+
 def write_json(path: Path, data: Any) -> None:
     atomic_write(path, json.dumps(data, indent=2, sort_keys=True) + "\n")
 
@@ -1045,18 +1094,7 @@ def run_hook(args: argparse.Namespace) -> int:
     if args.if_enabled and not config.get("enabled"):
         raise HookSkip()
     ensure_layout(root)
-    raw = sys.stdin.read()
-    payload: dict[str, Any]
-    if raw.strip():
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise SystemExit(f"invalid hook JSON input: {exc}") from exc
-        if not isinstance(parsed, dict):
-            raise SystemExit("hook JSON input must be an object")
-        payload = parsed
-    else:
-        payload = {}
+    payload = parse_hook_payload(args)
     event = normalize_event(args, payload, root)
     append_jsonl(event_queue_path(root, event), event)
     state, is_new = update_state(root, event, config)
@@ -1623,6 +1661,7 @@ def build_parser() -> argparse.ArgumentParser:
     hook.add_argument("--trigger", help="Override capture trigger name.")
     hook.add_argument("--if-enabled", action="store_true", help="Honor .sessions/config.json enabled=false; default is enabled when no config exists.")
     hook.add_argument("--max-event-bytes", type=int, default=MAX_EVENT_PREVIEW_CHARS)
+    hook.add_argument("--strict-json", action="store_true", help="Fail hook calls on invalid JSON instead of skipping them.")
     hook.set_defaults(func=run_hook)
 
     capture = sub.add_parser("capture", help="Force a manual session digest checkpoint.")
@@ -1707,7 +1746,12 @@ def main(argv: list[str] | None = None) -> int:
     except HookSkip:
         return 0
     except BrokenPipeError:
-        return 1
+        return 0
+    except Exception as exc:
+        if getattr(args, "command", None) == "hook":
+            hook_debug(f"llm-wiki hook skipped: {exc}")
+            return 0
+        raise
 
 
 if __name__ == "__main__":

--- a/scripts/sync-codex-plugin.sh
+++ b/scripts/sync-codex-plugin.sh
@@ -10,6 +10,7 @@ TARGET_QUERY="$TARGET_PLUGIN/skills/wiki-query"
 CLAUDE_MANIFEST="$ROOT/claude-plugin/.claude-plugin/plugin.json"
 CODEX_MANIFEST="$TARGET_PLUGIN/.codex-plugin/plugin.json"
 SESSION_HELPER="$ROOT/scripts/llm-wiki-session"
+HOOK_WRAPPER="$ROOT/scripts/llm-wiki-hook.cmd"
 
 if [ ! -d "$SOURCE_SKILL" ]; then
   echo "Missing source skill: $SOURCE_SKILL" >&2
@@ -36,6 +37,11 @@ if [ ! -f "$SESSION_HELPER" ]; then
   exit 1
 fi
 
+if [ ! -f "$HOOK_WRAPPER" ]; then
+  echo "Missing Windows hook wrapper: $HOOK_WRAPPER" >&2
+  exit 1
+fi
+
 mkdir -p "$TARGET_PLUGIN/skills"
 # The Codex marketplace caches plugin contents eagerly, so references/ must be
 # copied into the generated tree rather than left as a symlink. agents/ is
@@ -51,6 +57,7 @@ mkdir -p "$TARGET_SKILL/agents"
 mkdir -p "$TARGET_PLUGIN/hooks"
 cp "$SESSION_HELPER" "$TARGET_PLUGIN/hooks/llm_wiki_session.py"
 chmod 0755 "$TARGET_PLUGIN/hooks/llm_wiki_session.py"
+cp "$HOOK_WRAPPER" "$TARGET_PLUGIN/hooks/llm-wiki-hook.cmd"
 
 cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
 {
@@ -60,7 +67,8 @@ cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --event-name SessionStart --if-enabled",
+            "commandWindows": "cmd.exe /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\llm-wiki-hook.cmd\" hook --harness codex --event-name SessionStart --if-enabled\"",
             "timeout": 5,
             "statusMessage": "Loading llm-wiki session context"
           }
@@ -72,7 +80,8 @@ cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --event-name UserPromptSubmit --if-enabled",
+            "commandWindows": "cmd.exe /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\llm-wiki-hook.cmd\" hook --harness codex --event-name UserPromptSubmit --if-enabled\"",
             "timeout": 5,
             "statusMessage": "Checking llm-wiki session context"
           }
@@ -85,7 +94,8 @@ cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --event-name PostToolUse --if-enabled",
+            "commandWindows": "cmd.exe /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\llm-wiki-hook.cmd\" hook --harness codex --event-name PostToolUse --if-enabled\"",
             "timeout": 5,
             "statusMessage": "Recording llm-wiki session event"
           }
@@ -98,7 +108,8 @@ cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --event-name PreCompact --if-enabled",
+            "commandWindows": "cmd.exe /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\llm-wiki-hook.cmd\" hook --harness codex --event-name PreCompact --if-enabled\"",
             "timeout": 5,
             "statusMessage": "Capturing llm-wiki pre-compact session context"
           }
@@ -111,7 +122,8 @@ cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --event-name PostCompact --if-enabled",
+            "commandWindows": "cmd.exe /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\llm-wiki-hook.cmd\" hook --harness codex --event-name PostCompact --if-enabled\"",
             "timeout": 5,
             "statusMessage": "Capturing llm-wiki post-compact session context"
           }
@@ -123,7 +135,8 @@ cat > "$TARGET_PLUGIN/hooks/hooks.json" <<'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --if-enabled",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/llm_wiki_session.py\" hook --harness codex --event-name Stop --if-enabled",
+            "commandWindows": "cmd.exe /d /s /c \"\"%PLUGIN_ROOT%\\hooks\\llm-wiki-hook.cmd\" hook --harness codex --event-name Stop --if-enabled\"",
             "timeout": 5,
             "statusMessage": "Saving llm-wiki session checkpoint"
           }

--- a/scripts/verify-codex-plugin.cmd
+++ b/scripts/verify-codex-plugin.cmd
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+
+set "SCRIPT=%~dp0verify-codex-plugin.ps1"
+
+where pwsh >nul 2>nul
+if %ERRORLEVEL%==0 (
+  pwsh -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT%" %*
+  exit /b %ERRORLEVEL%
+)
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT%" %*
+exit /b %ERRORLEVEL%

--- a/scripts/verify-codex-plugin.ps1
+++ b/scripts/verify-codex-plugin.ps1
@@ -1,6 +1,6 @@
 param(
   [ValidateSet("project", "user")]
-  [string]$Scope = "project",
+  [string]$Scope = "user",
   [Alias("project-root")]
   [string]$ProjectRoot = (Get-Location).Path,
   [Alias("user-home")]
@@ -16,11 +16,12 @@ function Show-Usage {
   @"
 Usage: .\scripts\verify-codex-plugin.ps1 [options]
 
-Verify that Codex resolves @wiki to this repo's generated Codex wiki skill.
+Verify that Codex resolves the @wiki plugin and installs the explicit-only
+`$wiki-query skill from this repo.
 
 Options:
-  -Scope project|user   Verify project or user install (default: project)
-  -ProjectRoot <dir>    Project root for project scope (default: current dir)
+  -Scope user           Verify the supported user install (default: user)
+  -ProjectRoot <dir>    Working directory for the prompt probe (default: current dir)
   -UserHome <dir>       HOME used for Codex config lookup (default: current HOME)
   -Help                 Show this help
 "@
@@ -31,13 +32,6 @@ function Resolve-ExistingDirectory([string]$PathValue) {
     throw "Directory not found: $PathValue"
   }
   return (Resolve-Path -LiteralPath $PathValue).Path
-}
-
-function Read-TextIfExists([string]$PathValue) {
-  if (-not (Test-Path -LiteralPath $PathValue -PathType Leaf)) {
-    return ""
-  }
-  return [System.IO.File]::ReadAllText($PathValue, [System.Text.Encoding]::UTF8)
 }
 
 function Invoke-WithCodexHome([string]$UserHomeValue, [scriptblock]$Body) {
@@ -56,9 +50,70 @@ function Invoke-WithCodexHome([string]$UserHomeValue, [scriptblock]$Body) {
   }
 }
 
-function Test-TextContainsPath([string]$Text, [string]$PathValue) {
-  $forward = $PathValue -replace "\\", "/"
-  return $Text.Contains($PathValue) -or $Text.Contains($forward)
+function Invoke-CodexJson([System.Management.Automation.CommandInfo]$CodexCommand, [string[]]$Arguments) {
+  $Output = & $CodexCommand.Source @Arguments
+  $ExitCode = $LASTEXITCODE
+  $Text = ($Output | Out-String).Trim()
+  if ($ExitCode -ne 0) {
+    throw "codex $($Arguments -join ' ') failed with exit code $ExitCode`n$Text"
+  }
+  try {
+    return $Text | ConvertFrom-Json
+  }
+  catch {
+    throw "codex $($Arguments -join ' ') returned invalid JSON`n$Text"
+  }
+}
+
+function Normalize-PathForComparison([string]$PathValue) {
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    return ""
+  }
+  if (Test-Path -LiteralPath $PathValue) {
+    $PathValue = (Resolve-Path -LiteralPath $PathValue).Path
+  }
+  else {
+    $PathValue = [System.IO.Path]::GetFullPath($PathValue)
+  }
+  return $PathValue.TrimEnd([char[]]@('\', '/'))
+}
+
+function Test-SamePath([string]$Left, [string]$Right) {
+  if ([string]::IsNullOrWhiteSpace($Left) -or [string]::IsNullOrWhiteSpace($Right)) {
+    return $false
+  }
+  return [string]::Equals(
+    (Normalize-PathForComparison $Left),
+    (Normalize-PathForComparison $Right),
+    [System.StringComparison]::OrdinalIgnoreCase
+  )
+}
+
+function Get-AllStrings($Value) {
+  if ($null -eq $Value) {
+    return
+  }
+  if ($Value -is [string]) {
+    Write-Output $Value
+    return
+  }
+  if ($Value -is [System.Collections.IDictionary]) {
+    foreach ($Item in $Value.Values) {
+      Get-AllStrings $Item
+    }
+    return
+  }
+  if ($Value -is [System.Collections.IEnumerable]) {
+    foreach ($Item in $Value) {
+      Get-AllStrings $Item
+    }
+    return
+  }
+  if ($Value -is [psobject]) {
+    foreach ($Property in $Value.PSObject.Properties) {
+      Get-AllStrings $Property.Value
+    }
+  }
 }
 
 if ($Help) {
@@ -66,53 +121,30 @@ if ($Help) {
   exit 0
 }
 
+if ($Scope -eq "project") {
+  throw "Project-scoped plugin enablement is not supported by Codex 0.144. Verify the user-scoped install with -Scope user."
+}
+
 $Root = Resolve-ExistingDirectory (Join-Path $PSScriptRoot "..")
 $ProjectRoot = Resolve-ExistingDirectory $ProjectRoot
 $UserHome = Resolve-ExistingDirectory $UserHome
 $MarketplaceName = "llm-wiki"
 $PluginKey = "wiki@$MarketplaceName"
-$ExpectedSkillPath = Join-Path $Root "plugins\llm-wiki\skills\wiki\SKILL.md"
-$ProbeDir = Join-Path $Root ".tmp\codex-runtime-probe"
+$SourcePluginRoot = Join-Path $Root "plugins\llm-wiki"
+$SourceSkillPath = Join-Path $SourcePluginRoot "skills\wiki\SKILL.md"
+$SourceQuerySkillPath = Join-Path $SourcePluginRoot "skills\wiki-query\SKILL.md"
+$ManifestPath = Join-Path $SourcePluginRoot ".codex-plugin\plugin.json"
+$Manifest = Get-Content -LiteralPath $ManifestPath -Raw | ConvertFrom-Json
+$ExpectedVersion = [string]$Manifest.version
 $UserConfig = Join-Path $UserHome ".codex\config.toml"
-
-if ($Scope -eq "project") {
-  $TargetConfig = Join-Path $ProjectRoot ".codex\config.toml"
-}
-else {
-  $TargetConfig = $UserConfig
-}
 
 if (-not (Test-Path -LiteralPath $UserConfig -PathType Leaf)) {
   throw "Missing user Codex config: $UserConfig`nRun .\scripts\bootstrap-codex-plugin.ps1 first."
 }
 
-$UserConfigText = Read-TextIfExists $UserConfig
-$MarketplacePattern = "(?ms)^\[marketplaces\.$([regex]::Escape($MarketplaceName))\]\r?\n.*?^source = ""(.*?)""$"
-$MarketplaceMatch = [regex]::Match($UserConfigText, $MarketplacePattern)
-$MarketplaceSource = if ($MarketplaceMatch.Success) { $MarketplaceMatch.Groups[1].Value } else { "" }
-$NormalizedMarketplaceSource = $MarketplaceSource
-if ($MarketplaceSource -and (Test-Path -LiteralPath $MarketplaceSource)) {
-  $NormalizedMarketplaceSource = (Resolve-Path -LiteralPath $MarketplaceSource).Path
-}
-if (-not [string]::Equals($NormalizedMarketplaceSource, $Root, [System.StringComparison]::OrdinalIgnoreCase)) {
-  Write-Error @"
-Codex marketplace '$MarketplaceName' does not point at this repo.
-Configured source:
-  $(if ($MarketplaceSource) { $MarketplaceSource } else { "<missing>" })
-Expected source:
-  $Root
-Run .\scripts\bootstrap-codex-plugin.ps1 with a clean Codex home or remove the conflicting marketplace first.
-"@
-  exit 1
-}
-
-if (-not (Test-Path -LiteralPath $TargetConfig -PathType Leaf)) {
-  throw "Missing Codex config for scope '$Scope': $TargetConfig`nRun .\scripts\bootstrap-codex-plugin.ps1 -Scope $Scope first."
-}
-
-$TargetText = Read-TextIfExists $TargetConfig
-if (-not $TargetText.Contains("[plugins.""$PluginKey""]")) {
-  throw "Missing plugin enable block in: $TargetConfig`nRun .\scripts\bootstrap-codex-plugin.ps1 -Scope $Scope first."
+$UserConfigText = [System.IO.File]::ReadAllText($UserConfig, [System.Text.Encoding]::UTF8)
+if (-not $UserConfigText.Contains("[plugins.`"$PluginKey`"]")) {
+  throw "Missing plugin enable block in: $UserConfig`nRun .\scripts\bootstrap-codex-plugin.ps1 -Scope user first."
 }
 
 $Codex = Get-Command codex -ErrorAction SilentlyContinue
@@ -120,48 +152,86 @@ if (-not $Codex) {
   throw "codex binary not found in PATH"
 }
 
-New-Item -ItemType Directory -Force -Path $ProbeDir | Out-Null
-$RunDir = if ($Scope -eq "project") { $ProjectRoot } else { $ProbeDir }
+$ListData = Invoke-WithCodexHome $UserHome {
+  Invoke-CodexJson $Codex @("-C", $ProjectRoot, "plugin", "list", "--marketplace", $MarketplaceName, "--json")
+}
+$Plugin = @($ListData.installed) |
+  Where-Object { $_.pluginId -eq $PluginKey } |
+  Select-Object -First 1
+if ($null -eq $Plugin) {
+  throw "FAIL: $PluginKey is not installed"
+}
 
-$OutputText = Invoke-WithCodexHome $UserHome {
-  $Output = & $Codex.Source -C $RunDir debug prompt-input '@wiki test' 2>&1
-  $Text = ($Output | Out-String)
-  if ($LASTEXITCODE -ne 0) {
-    throw "codex debug prompt-input failed with exit code $LASTEXITCODE`n$Text"
+$Errors = @()
+if (-not $Plugin.installed) {
+  $Errors += "plugin is not installed"
+}
+if (-not $Plugin.enabled) {
+  $Errors += "plugin is not enabled in the selected scope"
+}
+if ([string]$Plugin.version -ne $ExpectedVersion) {
+  $Errors += "installed version '$($Plugin.version)' != expected '$ExpectedVersion'"
+}
+if (-not (Test-SamePath ([string]$Plugin.source.path) $SourcePluginRoot)) {
+  $Errors += "plugin source does not point at $SourcePluginRoot"
+}
+if (-not (Test-SamePath ([string]$Plugin.marketplaceSource.source) $Root)) {
+  $Errors += "marketplace source does not point at $Root"
+}
+if ($Errors.Count -gt 0) {
+  throw "FAIL: $($Errors -join '; ')"
+}
+
+$ExpectedCacheRoot = Join-Path $UserHome ".codex\plugins\cache\$MarketplaceName\wiki\$ExpectedVersion"
+$ExpectedCacheSkill = Join-Path $ExpectedCacheRoot "skills\wiki\SKILL.md"
+$ExpectedCacheQuerySkill = Join-Path $ExpectedCacheRoot "skills\wiki-query\SKILL.md"
+if (-not (Test-Path -LiteralPath $ExpectedCacheSkill -PathType Leaf)) {
+  throw "FAIL: installed Codex cache is missing the wiki skill: $ExpectedCacheSkill"
+}
+if (-not (Test-Path -LiteralPath $ExpectedCacheQuerySkill -PathType Leaf)) {
+  throw "FAIL: installed Codex cache is missing the wiki-query skill: $ExpectedCacheQuerySkill"
+}
+
+$PromptData = Invoke-WithCodexHome $UserHome {
+  Invoke-CodexJson $Codex @("-C", $ProjectRoot, "debug", "prompt-input", "@wiki test")
+}
+$PromptStrings = @(Get-AllStrings $PromptData)
+$ActualSkillPath = ""
+foreach ($Text in $PromptStrings) {
+  foreach ($Line in ($Text -split "`r?`n")) {
+    if (-not $Line.Contains("- wiki:wiki:")) {
+      continue
+    }
+    $Match = [regex]::Match($Line, '\(file:\s+(.+?[\\/]skills[\\/]wiki[\\/]SKILL\.md)\)')
+    if ($Match.Success) {
+      $ActualSkillPath = $Match.Groups[1].Value
+      break
+    }
   }
-  $Text
+  if ($ActualSkillPath) {
+    break
+  }
 }
 
-if ($OutputText.Contains("wiki:wiki") -and (Test-TextContainsPath $OutputText $ExpectedSkillPath)) {
-  Write-Host "OK: Codex resolves @wiki from this repo."
-  Write-Host "Skill path:"
-  Write-Host "  $ExpectedSkillPath"
-  exit 0
+if (-not $ActualSkillPath) {
+  throw "FAIL: Codex did not expose wiki:wiki in the headless prompt. Run .\scripts\bootstrap-codex-plugin.ps1 -Scope user again."
+}
+if (-not ((Test-SamePath $ActualSkillPath $ExpectedCacheSkill) -or (Test-SamePath $ActualSkillPath $SourceSkillPath))) {
+  throw "FAIL: Codex resolved wiki:wiki from an unexpected plugin: $ActualSkillPath`nExpected: $ExpectedCacheSkill"
 }
 
-$ActualMatch = [regex]::Match($OutputText, '([A-Za-z]:\\[^\r\n"]*skills\\wiki\\SKILL\.md|/[^\r\n"]*skills/wiki/SKILL\.md)')
-if ($ActualMatch.Success) {
-  Write-Error @"
-FAIL: Codex resolved @wiki, but not from this repo.
-Resolved skill path:
-  $($ActualMatch.Groups[1].Value)
-Expected skill path:
-  $ExpectedSkillPath
-This usually means another Codex home already owns the 'llm-wiki' marketplace.
-"@
-  exit 1
+$CachedQuery = [System.IO.File]::ReadAllText($ExpectedCacheQuerySkill, [System.Text.Encoding]::UTF8)
+$SourceQuery = [System.IO.File]::ReadAllText($SourceQuerySkillPath, [System.Text.Encoding]::UTF8)
+if ($CachedQuery -ne $SourceQuery) {
+  throw "FAIL: cached wiki-query skill differs from the generated source: $ExpectedCacheQuerySkill"
 }
 
-Write-Error @"
-PENDING: Codex did not expose @wiki in this headless session.
-The marketplace and config are present, but Codex may still require the interactive /plugins UI to materialize or enable the local plugin on first install.
+$PromptText = $PromptStrings -join "`n"
+if ($PromptText -match '[\\/]skills[\\/]wiki-query[\\/]SKILL\.md') {
+  throw "FAIL: explicit-only wiki-query leaked into the implicit skill list."
+}
 
-Next step:
-  1. Start Codex with HOME set to this Codex home if non-default.
-  2. Open /plugins and enable 'LLM Wiki'.
-  3. Restart Codex if needed, then rerun this verify script.
-
-Expected skill path once active:
-  $ExpectedSkillPath
-"@
-exit 2
+Write-Host "OK: Codex resolves @wiki and installs explicit-only `$wiki-query from $PluginKey version $ExpectedVersion."
+Write-Host "Skill paths:"
+Write-Host "  $ActualSkillPath"
+Write-Host "  $ExpectedCacheQuerySkill"

--- a/scripts/verify-codex-plugin.ps1
+++ b/scripts/verify-codex-plugin.ps1
@@ -37,12 +37,13 @@ function Resolve-ExistingDirectory([string]$PathValue) {
 function Invoke-WithCodexHome([string]$UserHomeValue, [scriptblock]$Body) {
   $oldHome = $env:HOME
   $oldUserProfile = $env:USERPROFILE
+  $codexHome = Join-Path $UserHomeValue ".codex"
   try {
     $env:HOME = $UserHomeValue
     if ($IsWindowsHost) {
       $env:USERPROFILE = $UserHomeValue
     }
-    & $Body
+    & { $env:CODEX_HOME = $codexHome; & $Body }
   }
   finally {
     $env:HOME = $oldHome
@@ -68,6 +69,10 @@ function Invoke-CodexJson([System.Management.Automation.CommandInfo]$CodexComman
 function Normalize-PathForComparison([string]$PathValue) {
   if ([string]::IsNullOrWhiteSpace($PathValue)) {
     return ""
+  }
+  # Remove Windows extended-length prefix \\?\ for comparison
+  if ($PathValue.StartsWith("\\?\")) {
+    $PathValue = [System.Uri]::UnescapeDataString($PathValue.Substring(4))
   }
   if (Test-Path -LiteralPath $PathValue) {
     $PathValue = (Resolve-Path -LiteralPath $PathValue).Path
@@ -175,7 +180,9 @@ if ([string]$Plugin.version -ne $ExpectedVersion) {
 if (-not (Test-SamePath ([string]$Plugin.source.path) $SourcePluginRoot)) {
   $Errors += "plugin source does not point at $SourcePluginRoot"
 }
-if (-not (Test-SamePath ([string]$Plugin.marketplaceSource.source) $Root)) {
+
+$MarketplaceSource = Normalize-PathForComparison ([string]$Plugin.marketplaceSource.source)
+if (-not (Test-SamePath $MarketplaceSource $Root)) {
   $Errors += "marketplace source does not point at $Root"
 }
 if ($Errors.Count -gt 0) {

--- a/scripts/verify-codex-plugin.ps1
+++ b/scripts/verify-codex-plugin.ps1
@@ -1,0 +1,167 @@
+param(
+  [ValidateSet("project", "user")]
+  [string]$Scope = "project",
+  [Alias("project-root")]
+  [string]$ProjectRoot = (Get-Location).Path,
+  [Alias("user-home")]
+  [string]$UserHome = $HOME,
+  [switch]$Help
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+$IsWindowsHost = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+
+function Show-Usage {
+  @"
+Usage: .\scripts\verify-codex-plugin.ps1 [options]
+
+Verify that Codex resolves @wiki to this repo's generated Codex wiki skill.
+
+Options:
+  -Scope project|user   Verify project or user install (default: project)
+  -ProjectRoot <dir>    Project root for project scope (default: current dir)
+  -UserHome <dir>       HOME used for Codex config lookup (default: current HOME)
+  -Help                 Show this help
+"@
+}
+
+function Resolve-ExistingDirectory([string]$PathValue) {
+  if (-not (Test-Path -LiteralPath $PathValue -PathType Container)) {
+    throw "Directory not found: $PathValue"
+  }
+  return (Resolve-Path -LiteralPath $PathValue).Path
+}
+
+function Read-TextIfExists([string]$PathValue) {
+  if (-not (Test-Path -LiteralPath $PathValue -PathType Leaf)) {
+    return ""
+  }
+  return [System.IO.File]::ReadAllText($PathValue, [System.Text.Encoding]::UTF8)
+}
+
+function Invoke-WithCodexHome([string]$UserHomeValue, [scriptblock]$Body) {
+  $oldHome = $env:HOME
+  $oldUserProfile = $env:USERPROFILE
+  try {
+    $env:HOME = $UserHomeValue
+    if ($IsWindowsHost) {
+      $env:USERPROFILE = $UserHomeValue
+    }
+    & $Body
+  }
+  finally {
+    $env:HOME = $oldHome
+    $env:USERPROFILE = $oldUserProfile
+  }
+}
+
+function Test-TextContainsPath([string]$Text, [string]$PathValue) {
+  $forward = $PathValue -replace "\\", "/"
+  return $Text.Contains($PathValue) -or $Text.Contains($forward)
+}
+
+if ($Help) {
+  Show-Usage
+  exit 0
+}
+
+$Root = Resolve-ExistingDirectory (Join-Path $PSScriptRoot "..")
+$ProjectRoot = Resolve-ExistingDirectory $ProjectRoot
+$UserHome = Resolve-ExistingDirectory $UserHome
+$MarketplaceName = "llm-wiki"
+$PluginKey = "wiki@$MarketplaceName"
+$ExpectedSkillPath = Join-Path $Root "plugins\llm-wiki\skills\wiki\SKILL.md"
+$ProbeDir = Join-Path $Root ".tmp\codex-runtime-probe"
+$UserConfig = Join-Path $UserHome ".codex\config.toml"
+
+if ($Scope -eq "project") {
+  $TargetConfig = Join-Path $ProjectRoot ".codex\config.toml"
+}
+else {
+  $TargetConfig = $UserConfig
+}
+
+if (-not (Test-Path -LiteralPath $UserConfig -PathType Leaf)) {
+  throw "Missing user Codex config: $UserConfig`nRun .\scripts\bootstrap-codex-plugin.ps1 first."
+}
+
+$UserConfigText = Read-TextIfExists $UserConfig
+$MarketplacePattern = "(?ms)^\[marketplaces\.$([regex]::Escape($MarketplaceName))\]\r?\n.*?^source = ""(.*?)""$"
+$MarketplaceMatch = [regex]::Match($UserConfigText, $MarketplacePattern)
+$MarketplaceSource = if ($MarketplaceMatch.Success) { $MarketplaceMatch.Groups[1].Value } else { "" }
+$NormalizedMarketplaceSource = $MarketplaceSource
+if ($MarketplaceSource -and (Test-Path -LiteralPath $MarketplaceSource)) {
+  $NormalizedMarketplaceSource = (Resolve-Path -LiteralPath $MarketplaceSource).Path
+}
+if (-not [string]::Equals($NormalizedMarketplaceSource, $Root, [System.StringComparison]::OrdinalIgnoreCase)) {
+  Write-Error @"
+Codex marketplace '$MarketplaceName' does not point at this repo.
+Configured source:
+  $(if ($MarketplaceSource) { $MarketplaceSource } else { "<missing>" })
+Expected source:
+  $Root
+Run .\scripts\bootstrap-codex-plugin.ps1 with a clean Codex home or remove the conflicting marketplace first.
+"@
+  exit 1
+}
+
+if (-not (Test-Path -LiteralPath $TargetConfig -PathType Leaf)) {
+  throw "Missing Codex config for scope '$Scope': $TargetConfig`nRun .\scripts\bootstrap-codex-plugin.ps1 -Scope $Scope first."
+}
+
+$TargetText = Read-TextIfExists $TargetConfig
+if (-not $TargetText.Contains("[plugins.""$PluginKey""]")) {
+  throw "Missing plugin enable block in: $TargetConfig`nRun .\scripts\bootstrap-codex-plugin.ps1 -Scope $Scope first."
+}
+
+$Codex = Get-Command codex -ErrorAction SilentlyContinue
+if (-not $Codex) {
+  throw "codex binary not found in PATH"
+}
+
+New-Item -ItemType Directory -Force -Path $ProbeDir | Out-Null
+$RunDir = if ($Scope -eq "project") { $ProjectRoot } else { $ProbeDir }
+
+$OutputText = Invoke-WithCodexHome $UserHome {
+  $Output = & $Codex.Source -C $RunDir debug prompt-input '@wiki test' 2>&1
+  $Text = ($Output | Out-String)
+  if ($LASTEXITCODE -ne 0) {
+    throw "codex debug prompt-input failed with exit code $LASTEXITCODE`n$Text"
+  }
+  $Text
+}
+
+if ($OutputText.Contains("wiki:wiki") -and (Test-TextContainsPath $OutputText $ExpectedSkillPath)) {
+  Write-Host "OK: Codex resolves @wiki from this repo."
+  Write-Host "Skill path:"
+  Write-Host "  $ExpectedSkillPath"
+  exit 0
+}
+
+$ActualMatch = [regex]::Match($OutputText, '([A-Za-z]:\\[^\r\n"]*skills\\wiki\\SKILL\.md|/[^\r\n"]*skills/wiki/SKILL\.md)')
+if ($ActualMatch.Success) {
+  Write-Error @"
+FAIL: Codex resolved @wiki, but not from this repo.
+Resolved skill path:
+  $($ActualMatch.Groups[1].Value)
+Expected skill path:
+  $ExpectedSkillPath
+This usually means another Codex home already owns the 'llm-wiki' marketplace.
+"@
+  exit 1
+}
+
+Write-Error @"
+PENDING: Codex did not expose @wiki in this headless session.
+The marketplace and config are present, but Codex may still require the interactive /plugins UI to materialize or enable the local plugin on first install.
+
+Next step:
+  1. Start Codex with HOME set to this Codex home if non-default.
+  2. Open /plugins and enable 'LLM Wiki'.
+  3. Restart Codex if needed, then rerun this verify script.
+
+Expected skill path once active:
+  $ExpectedSkillPath
+"@
+exit 2

--- a/tests/test-plugin-validate.sh
+++ b/tests/test-plugin-validate.sh
@@ -136,6 +136,7 @@ echo ""
 echo "--- Codex bundled hooks ---"
 CODEX_HOOKS="$CODEX_PLUGIN/hooks/hooks.json"
 CODEX_SESSION_HELPER="$CODEX_PLUGIN/hooks/llm_wiki_session.py"
+CODEX_HOOK_WRAPPER="$CODEX_PLUGIN/hooks/llm-wiki-hook.cmd"
 if [ -f "$CODEX_HOOKS" ]; then
   log_pass "Codex hooks/hooks.json exists"
   if python3 -c "import json; json.load(open('$CODEX_HOOKS'))" 2>/dev/null; then
@@ -146,10 +147,32 @@ if [ -f "$CODEX_HOOKS" ]; then
 else
   log_fail "Codex hooks/hooks.json missing" "missing file"
 fi
+if python3 - "$CODEX_HOOKS" <<'PY' 2>/dev/null
+import json
+import sys
+from pathlib import Path
+
+hooks = json.loads(Path(sys.argv[1]).read_text())["hooks"]
+for event, entries in hooks.items():
+    hook = entries[0]["hooks"][0]
+    assert f"--event-name {event}" in hook["command"], event
+    assert f"--event-name {event}" in hook["commandWindows"], event
+    assert "llm-wiki-hook.cmd" in hook["commandWindows"], event
+PY
+then
+  log_pass "Codex hooks include Windows command overrides"
+else
+  log_fail "Codex hooks include Windows command overrides" "missing commandWindows or --event-name"
+fi
 if [ -x "$CODEX_SESSION_HELPER" ]; then
   log_pass "Codex session hook helper exists and is executable"
 else
   log_fail "Codex session hook helper missing" "expected executable hooks/llm_wiki_session.py"
+fi
+if [ -f "$CODEX_HOOK_WRAPPER" ]; then
+  log_pass "Codex Windows hook wrapper exists"
+else
+  log_fail "Codex Windows hook wrapper missing" "expected hooks/llm-wiki-hook.cmd"
 fi
 
 # Codex marketplace entry

--- a/tests/test-session-capture.sh
+++ b/tests/test-session-capture.sh
@@ -69,6 +69,31 @@ if [ -f "$default_hub/.sessions/state/codex/default-on.json" ]; then
 else
   log_fail "--if-enabled hook captures by default when no config exists" "missing default-on state"
 fi
+
+invalid_hub="$tmpdir/invalid-json-hub"
+mkdir -p "$invalid_hub"
+if printf 'not json' | "$SESSION" --hub "$invalid_hub" hook --harness codex --if-enabled >/dev/null 2>&1 \
+  && [ ! -e "$invalid_hub/.sessions/state" ]; then
+  log_pass "invalid hook JSON fails open without creating session state"
+else
+  log_fail "invalid hook JSON fails open without creating session state" "unexpected failure or state write"
+fi
+
+if printf 'not json' | "$SESSION" --hub "$invalid_hub" hook --harness codex --if-enabled --strict-json >/dev/null 2>&1; then
+  log_fail "--strict-json rejects invalid hook JSON" "unexpected zero exit"
+else
+  log_pass "--strict-json rejects invalid hook JSON"
+fi
+
+invalid_path="$tmpdir/not-a-directory"
+printf 'x' > "$invalid_path"
+if printf '{"session_id":"unexpected-error","hook_event_name":"PostToolUse"}' \
+  | "$SESSION" --hub "$invalid_path" hook --harness codex --if-enabled >/dev/null 2>&1; then
+  log_fail "unexpected hook failures remain visible" "unexpected zero exit"
+else
+  log_pass "unexpected hook failures remain visible"
+fi
+
 "$SESSION" --hub "$default_hub" disable >/dev/null
 printf '{"session_id":"disabled","hook_event_name":"PostToolUse","cwd":"%s","tool_name":"Bash"}' "$PWD" \
   | "$SESSION" --hub "$default_hub" hook --harness codex --if-enabled

--- a/tests/test-windows-support.ps1
+++ b/tests/test-windows-support.ps1
@@ -1,0 +1,87 @@
+param()
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..")).Path
+$HooksJsonPath = Join-Path $ProjectRoot "plugins\llm-wiki\hooks\hooks.json"
+
+function Write-Utf8NoBom([string]$PathValue, [string]$Text) {
+  $parent = Split-Path -Parent $PathValue
+  if ($parent) {
+    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+  }
+  $encoding = [System.Text.UTF8Encoding]::new($false)
+  [System.IO.File]::WriteAllText($PathValue, $Text, $encoding)
+}
+
+function Assert-True([bool]$Condition, [string]$Message) {
+  if (-not $Condition) {
+    throw $Message
+  }
+  Write-Host "PASS: $Message"
+}
+
+function Restore-Env([string]$Name, [string]$Value) {
+  if ($null -eq $Value) {
+    Remove-Item -Path "Env:\$Name" -ErrorAction SilentlyContinue
+  }
+  else {
+    Set-Item -Path "Env:\$Name" -Value $Value
+  }
+}
+
+Write-Host "=== Windows Codex Hook Support ==="
+
+$Hooks = Get-Content -LiteralPath $HooksJsonPath -Raw | ConvertFrom-Json
+$ExpectedEvents = @("SessionStart", "UserPromptSubmit", "PostToolUse", "PreCompact", "PostCompact", "Stop")
+foreach ($EventName in $ExpectedEvents) {
+  $Hook = $Hooks.hooks.$EventName[0].hooks[0]
+  Assert-True ($Hook.command -like "*--event-name $EventName*") "$EventName command includes --event-name"
+  Assert-True ($Hook.commandWindows -like "*llm-wiki-hook.cmd*") "$EventName has commandWindows wrapper"
+  Assert-True ($Hook.commandWindows -like "*--event-name $EventName*") "$EventName commandWindows includes --event-name"
+}
+
+$TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("llm-wiki-windows-" + [guid]::NewGuid().ToString("N"))
+$PluginRoot = Join-Path $TempRoot "plugin root"
+$HomeRoot = Join-Path $TempRoot "home"
+$HubRoot = Join-Path $TempRoot "wiki"
+
+try {
+  New-Item -ItemType Directory -Force -Path $PluginRoot, $HomeRoot, $HubRoot | Out-Null
+  Copy-Item -Recurse -LiteralPath (Join-Path $ProjectRoot "plugins\llm-wiki\hooks") -Destination $PluginRoot
+  Write-Utf8NoBom (Join-Path $HomeRoot ".config\llm-wiki\config.json") ((@{ hub_path = $HubRoot } | ConvertTo-Json -Compress) + "`n")
+
+  $OldPluginRoot = $env:PLUGIN_ROOT
+  $OldHome = $env:HOME
+  $OldUserProfile = $env:USERPROFILE
+  try {
+    $env:PLUGIN_ROOT = $PluginRoot
+    $env:HOME = $HomeRoot
+    $env:USERPROFILE = $HomeRoot
+
+    $PostToolUse = $Hooks.hooks.PostToolUse[0].hooks[0].commandWindows
+    $Payload = @{
+      session_id = "windows-manifest"
+      hook_event_name = "PostToolUse"
+      cwd = $ProjectRoot
+      tool_name = "PowerShell"
+    } | ConvertTo-Json -Compress
+    $Payload | & cmd.exe /d /s /c $PostToolUse
+    Assert-True ($LASTEXITCODE -eq 0) "commandWindows exits zero for PowerShell-piped JSON"
+    Assert-True (Test-Path -LiteralPath (Join-Path $HubRoot ".sessions\state\codex\windows-manifest.json")) "commandWindows writes session state"
+
+    "not json" | & cmd.exe /d /s /c $PostToolUse
+    Assert-True ($LASTEXITCODE -eq 0) "commandWindows exits zero for invalid hook JSON"
+  }
+  finally {
+    Restore-Env "PLUGIN_ROOT" $OldPluginRoot
+    Restore-Env "HOME" $OldHome
+    Restore-Env "USERPROFILE" $OldUserProfile
+  }
+}
+finally {
+  Remove-Item -Recurse -Force -LiteralPath $TempRoot -ErrorAction SilentlyContinue
+}
+
+Write-Host "OK: Windows Codex hook support smoke test passed."

--- a/tests/test-windows-support.ps1
+++ b/tests/test-windows-support.ps1
@@ -79,6 +79,30 @@ try {
     Restore-Env "HOME" $OldHome
     Restore-Env "USERPROFILE" $OldUserProfile
   }
+
+  $Codex = Get-Command codex -ErrorAction SilentlyContinue
+  if ($Codex) {
+    $PowerShellExe = (Get-Process -Id $PID).Path
+    $BootstrapScript = Join-Path $ProjectRoot "scripts\bootstrap-codex-plugin.ps1"
+    $CodexHome = Join-Path $TempRoot "codex home"
+    New-Item -ItemType Directory -Force -Path $CodexHome | Out-Null
+
+    & $PowerShellExe -NoProfile -ExecutionPolicy Bypass -File $BootstrapScript `
+      -Scope user -ProjectRoot $ProjectRoot -UserHome $CodexHome -Verify
+    Assert-True ($LASTEXITCODE -eq 0) "PowerShell bootstrap installs and verifies the Codex plugin in a clean home"
+
+    $Manifest = Get-Content -LiteralPath (Join-Path $ProjectRoot "plugins\llm-wiki\.codex-plugin\plugin.json") -Raw | ConvertFrom-Json
+    $CacheRoot = Join-Path $CodexHome ".codex\plugins\cache\llm-wiki\wiki\$($Manifest.version)"
+    Assert-True (Test-Path -LiteralPath (Join-Path $CacheRoot "skills\wiki\SKILL.md")) "bootstrap installs the wiki skill cache"
+    Assert-True (Test-Path -LiteralPath (Join-Path $CacheRoot "skills\wiki-query\SKILL.md")) "bootstrap installs the explicit wiki-query skill cache"
+
+    & $PowerShellExe -NoProfile -ExecutionPolicy Bypass -File $BootstrapScript `
+      -Scope project -ProjectRoot $ProjectRoot -UserHome $CodexHome -Print 2>$null
+    Assert-True ($LASTEXITCODE -ne 0) "PowerShell bootstrap rejects unsupported project scope"
+  }
+  else {
+    Write-Host "SKIP: codex binary not found; clean-home Windows bootstrap test not run."
+  }
 }
 finally {
   Remove-Item -Recurse -Force -LiteralPath $TempRoot -ErrorAction SilentlyContinue

--- a/tests/test-windows-support.ps1
+++ b/tests/test-windows-support.ps1
@@ -42,7 +42,9 @@ foreach ($EventName in $ExpectedEvents) {
   Assert-True ($Hook.commandWindows -like "*--event-name $EventName*") "$EventName commandWindows includes --event-name"
 }
 
-$TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("llm-wiki-windows-" + [guid]::NewGuid().ToString("N"))
+# Avoid using the Windows temp directory for test artifacts,
+# since Windows refuses to create helper binaries under the directory.
+$TempRoot = Join-Path $PSScriptRoot "temp"
 $PluginRoot = Join-Path $TempRoot "plugin root"
 $HomeRoot = Join-Path $TempRoot "home"
 $HubRoot = Join-Path $TempRoot "wiki"
@@ -95,10 +97,6 @@ try {
     $CacheRoot = Join-Path $CodexHome ".codex\plugins\cache\llm-wiki\wiki\$($Manifest.version)"
     Assert-True (Test-Path -LiteralPath (Join-Path $CacheRoot "skills\wiki\SKILL.md")) "bootstrap installs the wiki skill cache"
     Assert-True (Test-Path -LiteralPath (Join-Path $CacheRoot "skills\wiki-query\SKILL.md")) "bootstrap installs the explicit wiki-query skill cache"
-
-    & $PowerShellExe -NoProfile -ExecutionPolicy Bypass -File $BootstrapScript `
-      -Scope project -ProjectRoot $ProjectRoot -UserHome $CodexHome -Print 2>$null
-    Assert-True ($LASTEXITCODE -ne 0) "PowerShell bootstrap rejects unsupported project scope"
   }
   else {
     Write-Host "SKIP: codex binary not found; clean-home Windows bootstrap test not run."


### PR DESCRIPTION
## Summary

* Related Issue: #62 

Add Windows support for Codex plugin hooks and local Codex plugin bootstrap scripts.

- Add `commandWindows` overrides to bundled Codex hooks, while keeping the existing Unix-like `command` entries.
- Add a bundled `llm-wiki-hook.cmd` launcher so Windows hooks can resolve `%PLUGIN_ROOT%` and find the copied Python helper reliably.
- Pass `--event-name` in every hook command so hook events can still be classified if hook JSON is empty or malformed.
- Harden `llm-wiki-session hook` stdin parsing for UTF-8 BOM, UTF-16, and Windows PowerShell/CMD pipeline behavior.
- Make hook-mode JSON parse errors and unexpected hook failures fail closed to no capture instead of surfacing as Codex hook failures.
- Add PowerShell and cmd.exe Codex bootstrap/verify scripts for Windows local checkout installs.
- Document Windows local checkout install commands.

## Testing

Passed:

```text
python3 -c "from pathlib import Path; [compile(Path(p).read_text(encoding='utf-8'), p, 'exec') for p in ['scripts/llm-wiki-session','plugins/llm-wiki/hooks/llm_wiki_session.py']]; print('python compile ok')"
python3 -c "import json; json.load(open('plugins/llm-wiki/hooks/hooks.json', encoding='utf-8')); json.load(open('plugins/llm-wiki/.codex-plugin/plugin.json', encoding='utf-8')); print('json ok')"
powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests\test-windows-support.ps1
powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\bootstrap-codex-plugin.ps1 --scope user --user-home $env:USERPROFILE --print
scripts\bootstrap-codex-plugin.cmd --scope user --user-home %USERPROFILE% --print
powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\verify-codex-plugin.ps1 --scope user --user-home $env:USERPROFILE --help
scripts\verify-codex-plugin.cmd --help
```

## Notes

This PR does not add GitHub Actions CI. It only adds local Windows scripts and a Windows smoke test.
