### PR TITLE
feat: add lightweight Hermes support

### DIFF
--- a/.claude/release-checklist.md
+++ b/.claude/release-checklist.md
@@ -22,6 +22,7 @@ Standard process for testing and shipping a new version of the llm-wiki plugin.
    - `.claude-plugin/marketplace.json`
    - `claude-plugin/.claude-plugin/plugin.json`
    - `plugins/llm-wiki/.codex-plugin/plugin.json`
+   - `plugins/llm-wiki-hermes/plugin.yaml`
 
 ## Test
 
@@ -33,6 +34,9 @@ Standard process for testing and shipping a new version of the llm-wiki plugin.
    ./tests/test-docs-consistency.sh
    ./tests/test-structure.sh
    ./tests/test-local-cli-lint.sh
+   ./tests/test-session-capture.sh
+   ./tests/test-session-concurrency.sh
+   ./tests/test-hermes-runtime.sh
    ./tests/test-codex-sync.sh
    ./tests/test-opencode-sync.sh
    ./tests/test-codex-runtime.sh
@@ -51,31 +55,37 @@ Standard process for testing and shipping a new version of the llm-wiki plugin.
    - Load via: `"instructions": ["plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md"]` in `opencode.json`
    - Verify web search works with `OPENCODE_ENABLE_EXA=1`
 
-6. **Test the changed feature** — whatever was added/fixed in this release:
+6. **Verify Hermes profiles and optional session adapter**:
+   - Confirm root `AGENTS.md` and `profiles/query-lite/SKILL.md` retain valid skill frontmatter
+   - Run `./tests/test-hermes-runtime.sh`
+   - If Hermes is installed, invoke `/wiki-query` and confirm the optional plugin does not replace skills or register tools
+
+7. **Test the changed feature** — whatever was added/fixed in this release:
    - Invoke the relevant `/wiki:*` subcommand
    - Confirm expected behavior, no errors
 
-6. **Spot-check routing** (if routing changed):
+8. **Spot-check routing** (if routing changed):
    - `/wiki <url>` → should route to ingest
    - `/wiki what is X?` → should route to query
    - `/wiki research Y` → should route to research
 
 ## Ship
 
-7. **Commit version bumps** — both files in one commit:
+9. **Commit version bumps** — all manifests in one commit:
    ```bash
-   git add .claude-plugin/marketplace.json claude-plugin/.claude-plugin/plugin.json
+   git add .claude-plugin/marketplace.json claude-plugin/.claude-plugin/plugin.json \
+     plugins/llm-wiki/.codex-plugin/plugin.json plugins/llm-wiki-hermes/plugin.yaml
    git commit -m "Bump to v0.0.XX"
    ```
 
-8. **Push to master**:
+10. **Push to master**:
    ```bash
    git -c credential.helper='!gh auth git-credential' push https://github.com/nvk/llm-wiki.git <branch>:master
    ```
    - If in a worktree: replace `<branch>` with `worktree-<name>`
    - Do not use SSH remotes from agent sessions; use `gh auth` + HTTPS.
 
-9. **Create GitHub release**:
+11. **Create GitHub release**:
    ```bash
    GH_TOKEN="" gh release create v0.0.XX \
      --repo nvk/llm-wiki \
@@ -93,7 +103,7 @@ Standard process for testing and shipping a new version of the llm-wiki plugin.
    - `GH_TOKEN=""` is required to clear a bad env token and use `gh auth` credentials
    - Release title format: `v0.0.XX — <Feature Name>`
 
-10. **Update plugin cache** (so local Claude Code picks up new version):
+12. **Update plugin cache** (so local Claude Code picks up new version):
    ```bash
    git -C ~/.claude/plugins/marketplaces/llm-wiki remote set-url origin https://github.com/nvk/llm-wiki.git
    claude plugin update wiki@llm-wiki
@@ -106,10 +116,11 @@ Standard process for testing and shipping a new version of the llm-wiki plugin.
    # Copy commands/ skills/ .claude-plugin/ from the repo's claude-plugin/ dir
    ```
 
-11. **Verify install**:
+13. **Verify install**:
    - Claude Code: start a fresh session and run `/wiki status`
    - Codex: start a fresh session and run `@wiki test` or `./scripts/verify-codex-plugin.sh --scope user`
    - OpenCode: start a session with the SKILL.md loaded and ask "wiki status"
+   - Hermes: update `wiki-query` and `wiki-manager`, then test the session adapter if enabled
 
 ## Post-ship: README
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,8 @@
+---
+name: wiki-manager
+description: Build and maintain source-backed llm-wiki knowledge bases.
+---
+
 # LLM Wiki — Agent Instructions
 
 > This is an "idea file" in the spirit of [Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). Paste it into any LLM agent (OpenAI Codex, Claude Code, OpenCode, Gemini Code Assist, or similar) and it will build and manage a wiki for you. The agent customizes the specifics; this file communicates the system.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ git -C ~/.claude/plugins/marketplaces/llm-wiki remote set-url origin https://git
 ./tests/test-local-cli-lint.sh     # local scripts/llm-wiki lint helper
 ./tests/test-session-capture.sh    # deterministic session capture helper
 ./tests/test-session-concurrency.sh # concurrent session-state regression
+./tests/test-hermes-runtime.sh     # optional Hermes session adapter
 ./tests/test-codex-sync.sh         # Codex plugin mirror matches Claude source
 ./tests/test-opencode-sync.sh     # OpenCode plugin mirror matches Claude source
 ./tests/test-token-benchmarks.sh  # budgets + fake Codex/Claude protocol fixtures
@@ -92,6 +93,7 @@ Requires `ANTHROPIC_API_KEY`. Costs ~$2-5 per run.
 - **Edited `claude-plugin/skills/wiki-manager/`**: both `test-codex-sync.sh` and `test-opencode-sync.sh` will fail until you re-run both sync scripts and commit `plugins/`. Never edit `plugins/llm-wiki/` or `plugins/llm-wiki-opencode/` by hand — they are generated. Codex gets copied references for marketplace caching; OpenCode keeps a symlink into the Claude source.
 - **Added a runtime-specific text rewrite to a sync script**: update the corresponding sync script's SKILL.md replacement list. References are runtime-neutral and shared verbatim — do not add per-file replacements there.
 - **Changed Codex install docs or bootstrap flow**: run `./tests/test-codex-runtime.sh` to verify a user-scoped install materializes the plugin cache, resolves `@wiki`, and installs `$wiki-query` as explicit-only from a clean scratch Codex home without an interactive `/plugins` step. Codex 0.144 reads plugin enablement from user config, not project config; the test also guards the unsupported project-scope path.
+- **Changed the Hermes adapter or session engine API**: run `./tests/test-hermes-runtime.sh`. Keep Hermes support session-only: do not bundle another skill copy, register tools, inject ambient wiki memory, or mutate Hermes skill/config state.
 
 ### Test file locations
 
@@ -126,6 +128,7 @@ plugins/llm-wiki-opencode/      — generated OpenCode packaging mirror (do NOT 
     references → ../../../../claude-plugin/skills/wiki-manager/references  (symlink)
   README.md                     — OpenCode install instructions
   skills/wiki-query/SKILL.md    — best-effort compact read-only preset
+plugins/llm-wiki-hermes/        — thin optional Hermes session hooks; no skills/tools/config mutation
 profiles/query-lite/SKILL.md    — portable generated read-only query profile
 .agents/plugins/marketplace.json — repo-local Codex marketplace entry
 scripts/sync-codex-plugin.sh    — regenerates plugins/llm-wiki/ from claude-plugin/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [github.com/nvk/llm-wiki](https://github.com/nvk/llm-wiki)
 
-LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, collector catalogs, automated session capture, feedback curation, thesis-driven investigation, source ingestion, wiki compilation, truth-seeking audits, querying, and artifact generation. Ships as a Claude Code plugin, an OpenAI Codex plugin, an OpenCode instruction file, or a portable AGENTS.md for any other LLM agent. Obsidian-compatible.
+LLM-compiled knowledge bases for any AI agent. Parallel multi-agent research, collector catalogs, automated session capture, feedback curation, thesis-driven investigation, source ingestion, wiki compilation, truth-seeking audits, querying, and artifact generation. Ships as a Claude Code plugin, an OpenAI Codex plugin, OpenCode/Pi instructions, native Hermes skill profiles, or a portable AGENTS.md for any other LLM agent. Obsidian-compatible.
 
 ---
 
@@ -171,6 +171,44 @@ skill for ingest, research, compile, lint, or other mutating workflows. See
 [`profiles/ds4/README.md`](profiles/ds4/README.md) and the reproducible
 [`benchmarks/README.md`](benchmarks/README.md) DS4 lane.
 
+**Hermes** (skills, plus optional session capture):
+
+Install only the profile you need through Hermes' native Skills Hub. This does
+not replace Hermes' bundled `llm-wiki` skill or change Hermes configuration:
+
+```bash
+# Small, read-only, index-first queries
+hermes skills install \
+  https://raw.githubusercontent.com/nvk/llm-wiki/master/profiles/query-lite/SKILL.md
+
+# Complete research and maintenance protocol
+hermes skills install \
+  https://raw.githubusercontent.com/nvk/llm-wiki/master/AGENTS.md
+```
+
+Invoke `/wiki-query` for lookups and `/wiki-manager` for write-capable work.
+The complete protocol is intentionally larger; install it only when Hermes
+must ingest, research, compile, lint, or otherwise modify a wiki.
+
+Session capture and rehydration are optional. They use a thin plugin that
+registers lifecycle hooks only: no custom tools, proactive memory injection,
+skill replacement, or automatic config mutation.
+
+```bash
+REPO="$HOME/.local/share/llm-wiki"
+git clone https://github.com/nvk/llm-wiki.git "$REPO"
+mkdir -p "$HOME/.hermes/plugins"
+ln -sfn "$REPO/plugins/llm-wiki-hermes" \
+  "$HOME/.hermes/plugins/llm-wiki-hermes"
+hermes plugins enable llm-wiki-hermes
+"$REPO/scripts/llm-wiki-session" enable --mode balanced
+hermes gateway restart
+```
+
+The plugin must remain linked to the persistent full checkout because it calls
+the shared session engine there. Set `LLM_WIKI_SESSION_SCRIPT` only when that
+checkout uses a non-standard layout.
+
 **Any LLM Agent** (portable instruction file):
 ```bash
 # Read-only queries: small default
@@ -194,6 +232,8 @@ Claude Code is the principal user. Keep one shared behavior layer and thin packa
 - `claude-plugin/skills/wiki-manager/references/query-lite.md` is the canonical read-only query protocol.
 - `profiles/query-lite/SKILL.md` and generated `wiki-query` skills expose that protocol without the full research context.
 - `plugins/llm-wiki-opencode/` is the OpenCode and Pi packaging target.
+- `plugins/llm-wiki-hermes/` is an optional session-only Hermes adapter; Hermes
+  installs the existing portable profiles directly instead of bundling another copy.
 - `.agents/plugins/marketplace.json` makes the Codex plugin installable from this repo.
 - `AGENTS.md` is the portable single-file protocol for any other LLM agent.
 
@@ -205,6 +245,7 @@ Claude Code is the principal user. Keep one shared behavior layer and thin packa
 | Codex | Explicit-only `$wiki-query` (~2.8 KB) | `@wiki` (~11.7 KB before lazy references) | Deterministic fixtures plus app-server live runs |
 | Pi / DS4 | `scripts/pi-wiki-query`, or the isolated DS4 launcher, with read-only tools (~2.8 KB profile) | `pi --skill .../wiki-manager/SKILL.md` | Deterministic fixtures plus exact DS4 provider-payload measurement |
 | OpenCode | `wiki-query/SKILL.md` (~2.8 KB) | `wiki-manager/SKILL.md` (~25.2 KB) | Static budgets and generated-package sync; live model is best effort |
+| Hermes | Install `profiles/query-lite/SKILL.md` by URL | Install root `AGENTS.md` by URL as `wiki-manager` | Static profiles plus a hermetic session-adapter runtime test |
 | Any agent | Copy `profiles/query-lite/SKILL.md` (~2.8 KB) | Copy root `AGENTS.md` (~51.2 KB) | Static budgets |
 
 Sizes are checked-in UTF-8 bytes, not provider token estimates. Use query mode
@@ -356,6 +397,14 @@ codex plugin add wiki@llm-wiki
 **OpenCode** — if using the GitHub URL in `instructions`, updates are automatic (fetched every session). If using a local copy:
 ```bash
 curl -sL https://raw.githubusercontent.com/nvk/llm-wiki/master/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md > ~/.config/opencode/AGENTS.md
+```
+
+**Hermes** — refresh installed profiles and, if used, the optional session adapter:
+```bash
+hermes skills update wiki-query
+hermes skills update wiki-manager
+git -C "$HOME/.local/share/llm-wiki" pull --ff-only
+hermes gateway restart
 ```
 
 **AGENTS.md** — just pull the latest and replace:

--- a/plugins/llm-wiki-hermes/__init__.py
+++ b/plugins/llm-wiki-hermes/__init__.py
@@ -1,0 +1,12 @@
+"""Thin Hermes adapter for llm-wiki's optional session harness."""
+
+from . import adapter
+
+
+def register(ctx):
+    """Register session hooks without replacing skills or changing user config."""
+    ctx.register_hook("on_session_start", adapter.on_session_start)
+    ctx.register_hook("pre_llm_call", adapter.pre_llm_call)
+    ctx.register_hook("post_tool_call", adapter.post_tool_call)
+    ctx.register_hook("on_session_finalize", adapter.on_session_finalize)
+    ctx.register_hook("on_session_end", adapter.on_session_end)

--- a/plugins/llm-wiki-hermes/adapter.py
+++ b/plugins/llm-wiki-hermes/adapter.py
@@ -1,0 +1,233 @@
+"""Map Hermes lifecycle hooks into the shared llm-wiki session engine."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.machinery
+import importlib.util
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("llm-wiki-hermes")
+
+_engine = None
+_engine_attempted = False
+
+
+def _session_script_candidates():
+    override = os.environ.get("LLM_WIKI_SESSION_SCRIPT")
+    if override:
+        yield Path(override).expanduser()
+    # Expected install: this plugin is symlinked from a persistent llm-wiki
+    # checkout, so resolving __file__ returns <repo>/plugins/.../adapter.py.
+    repo_root = Path(__file__).resolve().parents[2]
+    yield repo_root / "plugins" / "llm-wiki" / "hooks" / "llm_wiki_session.py"
+    yield repo_root / "scripts" / "llm-wiki-session"
+
+
+def _get_engine():
+    """Load the shared engine once; return None when the checkout is incomplete."""
+    global _engine, _engine_attempted
+    if _engine_attempted:
+        return _engine
+    _engine_attempted = True
+
+    for path in _session_script_candidates():
+        if not path.is_file():
+            continue
+        try:
+            loader = importlib.machinery.SourceFileLoader(
+                "llm_wiki_hermes_session_engine", str(path)
+            )
+            spec = importlib.util.spec_from_loader(loader.name, loader)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            if not hasattr(module, "handle_event"):
+                logger.warning("llm-wiki session engine lacks handle_event: %s", path)
+                continue
+            _engine = module
+            return _engine
+        except Exception as exc:  # pragma: no cover - defensive runtime guard
+            logger.warning("failed to load llm-wiki session engine %s: %s", path, exc)
+
+    logger.warning(
+        "llm-wiki session engine not found; symlink the plugin from a full "
+        "checkout or set LLM_WIKI_SESSION_SCRIPT"
+    )
+    return None
+
+
+def _event_args(engine, event_name: str, session_id: str | None, cwd: str):
+    return argparse.Namespace(
+        harness="hermes",
+        event_name=event_name,
+        session_id=session_id,
+        cwd=cwd,
+        topic=None,
+        summary=None,
+        trigger=None,
+        max_event_bytes=engine.MAX_EVENT_PREVIEW_CHARS,
+        if_enabled=True,
+        hub=None,
+        local=False,
+    )
+
+
+def _first(value, *alternatives):
+    if value not in (None, ""):
+        return value
+    return next((item for item in alternatives if item not in (None, "")), None)
+
+
+def _capture(
+    event_name: str,
+    *,
+    session_id: str | None,
+    cwd: str | None,
+    payload: dict[str, Any],
+) -> str:
+    engine = _get_engine()
+    if engine is None:
+        return ""
+    resolved_cwd = cwd or os.getcwd()
+    try:
+        return engine.handle_event(
+            _event_args(engine, event_name, session_id, resolved_cwd), payload
+        )
+    except engine.HookSkip:
+        return ""
+    except Exception as exc:  # pragma: no cover - never break the host harness
+        logger.warning("llm-wiki %s hook failed: %s", event_name, exc)
+        return ""
+
+
+def on_session_start(
+    session_id=None,
+    task_id=None,
+    carry_over_context=None,
+    model=None,
+    cwd=None,
+    **kwargs,
+):
+    native_id = _first(session_id, task_id, kwargs.get("conversation_id"))
+    prompt = _first(
+        carry_over_context,
+        kwargs.get("user_message"),
+        kwargs.get("message"),
+    )
+    _capture(
+        "SessionStart",
+        session_id=native_id,
+        cwd=cwd,
+        payload={
+            "session_id": native_id,
+            "model": model,
+            "user_prompt": prompt,
+        },
+    )
+    # Hermes discards context returned by on_session_start. Rehydration is
+    # returned from pre_llm_call instead.
+    return None
+
+
+def pre_llm_call(
+    session_id=None,
+    task_id=None,
+    turn_id=None,
+    user_message="",
+    model=None,
+    cwd=None,
+    **kwargs,
+):
+    native_id = _first(session_id, task_id, kwargs.get("conversation_id"))
+    prompt = _first(
+        user_message,
+        kwargs.get("message"),
+        kwargs.get("prompt"),
+        kwargs.get("content"),
+    ) or ""
+    context = _capture(
+        "UserPromptSubmit",
+        session_id=native_id,
+        cwd=cwd,
+        payload={
+            "session_id": native_id,
+            "turn_id": turn_id,
+            "model": model,
+            "user_prompt": prompt,
+        },
+    )
+    return context or None
+
+
+def post_tool_call(
+    tool_name=None,
+    args=None,
+    result=None,
+    session_id=None,
+    task_id=None,
+    tool_call_id=None,
+    turn_id=None,
+    cwd=None,
+    model=None,
+    **kwargs,
+):
+    native_id = _first(session_id, task_id, kwargs.get("conversation_id"))
+    _capture(
+        "PostToolUse",
+        session_id=native_id,
+        cwd=cwd,
+        payload={
+            "session_id": native_id,
+            "turn_id": turn_id,
+            "model": model,
+            "tool_name": tool_name,
+            "tool_use_id": tool_call_id,
+            "args": args,
+            "tool_output": result,
+        },
+    )
+    return None
+
+
+def on_session_finalize(
+    session_id=None, task_id=None, reason=None, cwd=None, model=None, **kwargs
+):
+    native_id = _first(session_id, task_id, kwargs.get("conversation_id"))
+    _capture(
+        "PreCompact",
+        session_id=native_id,
+        cwd=cwd,
+        payload={"session_id": native_id, "reason": reason, "model": model},
+    )
+    return None
+
+
+def on_session_end(
+    session_id=None,
+    task_id=None,
+    reason=None,
+    completed=None,
+    interrupted=None,
+    cwd=None,
+    model=None,
+    **kwargs,
+):
+    native_id = _first(session_id, task_id, kwargs.get("conversation_id"))
+    _capture(
+        "SessionEnd",
+        session_id=native_id,
+        cwd=cwd,
+        payload={
+            "session_id": native_id,
+            "reason": reason,
+            "completed": completed,
+            "interrupted": interrupted,
+            "model": model,
+        },
+    )
+    return None

--- a/plugins/llm-wiki-hermes/plugin.yaml
+++ b/plugins/llm-wiki-hermes/plugin.yaml
@@ -1,0 +1,10 @@
+name: llm-wiki-hermes
+version: "0.16.0"
+description: Optional Hermes session capture and rehydration for llm-wiki.
+author: nvk
+provides_hooks:
+  - on_session_start
+  - pre_llm_call
+  - post_tool_call
+  - on_session_finalize
+  - on_session_end

--- a/plugins/llm-wiki/hooks/llm_wiki_session.py
+++ b/plugins/llm-wiki/hooks/llm_wiki_session.py
@@ -1039,24 +1039,13 @@ def hook_output(event_name: str, context: str) -> None:
     )
 
 
-def run_hook(args: argparse.Namespace) -> int:
+def handle_event(args: argparse.Namespace, payload: dict[str, Any]) -> str:
+    """Record one harness event and return context for in-process adapters."""
     root = sessions_dir(resolve_hub(args))
     config = load_config(root)
     if args.if_enabled and not config.get("enabled"):
         raise HookSkip()
     ensure_layout(root)
-    raw = sys.stdin.read()
-    payload: dict[str, Any]
-    if raw.strip():
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise SystemExit(f"invalid hook JSON input: {exc}") from exc
-        if not isinstance(parsed, dict):
-            raise SystemExit("hook JSON input must be an object")
-        payload = parsed
-    else:
-        payload = {}
     event = normalize_event(args, payload, root)
     append_jsonl(event_queue_path(root, event), event)
     state, is_new = update_state(root, event, config)
@@ -1084,9 +1073,35 @@ def run_hook(args: argparse.Namespace) -> int:
     event_name = str(event.get("hook_event_name") or "")
     rehydrate_cfg = config.get("rehydrate") if isinstance(config.get("rehydrate"), dict) else {}
     if event_name == "SessionStart" and rehydrate_cfg.get("session_start"):
-        hook_output(event_name, build_rehydrate_context(root, cwd=event.get("cwd"), limit=3))
-    elif event_name == "UserPromptSubmit" and rehydrate_cfg.get("user_prompt"):
-        hook_output(event_name, build_rehydrate_context(root, cwd=event.get("cwd"), limit=3))
+        return build_rehydrate_context(root, cwd=event.get("cwd"), limit=3)
+    if event_name == "UserPromptSubmit" and rehydrate_cfg.get("user_prompt"):
+        return build_rehydrate_context(root, cwd=event.get("cwd"), limit=3)
+    return ""
+
+
+def run_hook(args: argparse.Namespace) -> int:
+    raw = sys.stdin.read()
+    payload: dict[str, Any]
+    if raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"invalid hook JSON input: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise SystemExit("hook JSON input must be an object")
+        payload = parsed
+    else:
+        payload = {}
+    context = handle_event(args, payload)
+    if context:
+        event_name = str(
+            getattr(args, "event_name", None)
+            or payload.get("hook_event_name")
+            or payload.get("hookEventName")
+            or payload.get("event")
+            or "manual"
+        )
+        hook_output(event_name, context)
     return 0
 
 

--- a/scripts/llm-wiki-session
+++ b/scripts/llm-wiki-session
@@ -1039,24 +1039,13 @@ def hook_output(event_name: str, context: str) -> None:
     )
 
 
-def run_hook(args: argparse.Namespace) -> int:
+def handle_event(args: argparse.Namespace, payload: dict[str, Any]) -> str:
+    """Record one harness event and return context for in-process adapters."""
     root = sessions_dir(resolve_hub(args))
     config = load_config(root)
     if args.if_enabled and not config.get("enabled"):
         raise HookSkip()
     ensure_layout(root)
-    raw = sys.stdin.read()
-    payload: dict[str, Any]
-    if raw.strip():
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise SystemExit(f"invalid hook JSON input: {exc}") from exc
-        if not isinstance(parsed, dict):
-            raise SystemExit("hook JSON input must be an object")
-        payload = parsed
-    else:
-        payload = {}
     event = normalize_event(args, payload, root)
     append_jsonl(event_queue_path(root, event), event)
     state, is_new = update_state(root, event, config)
@@ -1084,9 +1073,35 @@ def run_hook(args: argparse.Namespace) -> int:
     event_name = str(event.get("hook_event_name") or "")
     rehydrate_cfg = config.get("rehydrate") if isinstance(config.get("rehydrate"), dict) else {}
     if event_name == "SessionStart" and rehydrate_cfg.get("session_start"):
-        hook_output(event_name, build_rehydrate_context(root, cwd=event.get("cwd"), limit=3))
-    elif event_name == "UserPromptSubmit" and rehydrate_cfg.get("user_prompt"):
-        hook_output(event_name, build_rehydrate_context(root, cwd=event.get("cwd"), limit=3))
+        return build_rehydrate_context(root, cwd=event.get("cwd"), limit=3)
+    if event_name == "UserPromptSubmit" and rehydrate_cfg.get("user_prompt"):
+        return build_rehydrate_context(root, cwd=event.get("cwd"), limit=3)
+    return ""
+
+
+def run_hook(args: argparse.Namespace) -> int:
+    raw = sys.stdin.read()
+    payload: dict[str, Any]
+    if raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"invalid hook JSON input: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise SystemExit("hook JSON input must be an object")
+        payload = parsed
+    else:
+        payload = {}
+    context = handle_event(args, payload)
+    if context:
+        event_name = str(
+            getattr(args, "event_name", None)
+            or payload.get("hook_event_name")
+            or payload.get("hookEventName")
+            or payload.get("event")
+            or "manual"
+        )
+        hook_output(event_name, context)
     return 0
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,6 +34,7 @@ No LLM calls. Validates wiki file structure, default `schema.md`, frontmatter sc
 # Validate plugin manifest and docs/version consistency
 ./tests/test-plugin-validate.sh
 ./tests/test-docs-consistency.sh
+./tests/test-hermes-runtime.sh
 ```
 
 ### What it checks
@@ -59,6 +60,8 @@ No LLM calls. Validates wiki file structure, default `schema.md`, frontmatter sc
   Pi/DS4 launcher remain read-only and synchronized from one canonical protocol
 - OpenCode: full and query packages remain generated and within static budgets;
   live provider/model behavior is best effort
+- Hermes: the optional session adapter registers hooks only, preserves skill and
+  config state, captures events, and returns rehydration context
 
 ### Defect fixtures
 
@@ -99,6 +102,7 @@ Copy `tests/ci/plugin-tests.yml` to `.github/workflows/` to enable:
 - Structural tests run when plugin, profile, benchmark, script, or docs inputs change
 - Static token budgets and benchmark protocol tests run on every push
 - Codex/OpenCode mirrors and the portable query profile are regenerated and checked
+- The thin Hermes session adapter is exercised without requiring a Hermes install
 - Behavioral evals run on PRs only (requires `ANTHROPIC_API_KEY` secret)
 
 ## Fixtures

--- a/tests/ci/plugin-tests.yml
+++ b/tests/ci/plugin-tests.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Run session concurrency regression
         run: chmod +x tests/test-session-concurrency.sh && ./tests/test-session-concurrency.sh
 
+      - name: Run Hermes session adapter test
+        run: chmod +x tests/test-hermes-runtime.sh && ./tests/test-hermes-runtime.sh
+
   behavioral:
     name: "Layer 2: Behavioral Evals"
     runs-on: ubuntu-latest

--- a/tests/test-hermes-runtime.sh
+++ b/tests/test-hermes-runtime.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Hermetic runtime test for the optional Hermes session adapter.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/home" "$TMP/hub"
+HOME="$TMP/home" python3 - "$REPO_ROOT" "$TMP/hub" <<'PY'
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+hub = Path(sys.argv[2])
+plugin = repo / "plugins" / "llm-wiki-hermes"
+
+
+def load(name, path, package=False):
+    kwargs = {"submodule_search_locations": [str(path.parent)]} if package else {}
+    spec = importlib.util.spec_from_file_location(name, str(path), **kwargs)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+engine = load(
+    "llm_wiki_hermes_test_engine",
+    repo / "plugins" / "llm-wiki" / "hooks" / "llm_wiki_session.py",
+)
+engine.resolve_hub = lambda args: hub
+
+package = load("llm_wiki_hermes", plugin / "__init__.py", package=True)
+adapter = package.adapter
+adapter._engine = engine
+adapter._engine_attempted = True
+
+sessions = hub / ".sessions"
+sessions.mkdir()
+(sessions / "config.json").write_text(
+    json.dumps(
+        {
+            "enabled": True,
+            "mode": "balanced",
+            "rehydrate": {"session_start": False, "user_prompt": True},
+        }
+    )
+)
+
+
+class Context:
+    def __init__(self):
+        self.hooks = {}
+        self.tools = []
+        self.skills = []
+
+    def register_hook(self, name, callback):
+        self.hooks[name] = callback
+
+    def register_tool(self, *args, **kwargs):
+        self.tools.append((args, kwargs))
+
+    def register_skill(self, *args, **kwargs):
+        self.skills.append((args, kwargs))
+
+
+ctx = Context()
+package.register(ctx)
+assert set(ctx.hooks) == {
+    "on_session_start",
+    "pre_llm_call",
+    "post_tool_call",
+    "on_session_finalize",
+    "on_session_end",
+}
+assert not ctx.tools, "session adapter must not register tools"
+assert not ctx.skills, "session adapter must not replace or seed skills"
+
+# Finish one session so the next session can rehydrate it.
+adapter.on_session_start(session_id="old", model="test", cwd="/fixture")
+adapter.on_session_end(session_id="old", completed=True, cwd="/fixture")
+
+adapter.on_session_start(task_id="new", model="test", cwd="/fixture")
+context = adapter.pre_llm_call(
+    task_id="new", turn_id="t1", user_message="resume", cwd="/fixture"
+)
+assert context and "llm-wiki session context" in context
+assert "hermes:old" in context
+adapter.post_tool_call(
+    task_id="new",
+    tool_name="terminal",
+    args={"command": "printf test"},
+    result="test",
+    cwd="/fixture",
+)
+adapter.on_session_finalize(task_id="new", reason="compact", cwd="/fixture")
+adapter.on_session_end(task_id="new", completed=True, cwd="/fixture")
+
+state = sessions / "state" / "hermes" / "new.json"
+assert state.exists(), state
+data = json.loads(state.read_text())
+assert data["harness"] == "hermes"
+assert data["native_session_id"] == "new"
+
+# Registration must not mutate Hermes skill/config state.
+assert not (Path.home() / ".hermes" / "skills").exists()
+assert not (Path.home() / ".hermes" / "config.yaml").exists()
+
+print("PASS: Hermes session adapter captures, rehydrates, and stays skill-neutral")
+PY

--- a/tests/test-plugin-validate.sh
+++ b/tests/test-plugin-validate.sh
@@ -84,6 +84,12 @@ echo ""
 echo "--- Project files ---"
 if [ -f "$PROJECT_ROOT/AGENTS.md" ]; then
   log_pass "AGENTS.md exists"
+  if head -1 "$PROJECT_ROOT/AGENTS.md" | grep -q '^---$' \
+    && grep -q '^name: wiki-manager$' "$PROJECT_ROOT/AGENTS.md"; then
+    log_pass "AGENTS.md is directly installable as wiki-manager"
+  else
+    log_fail "AGENTS.md skill frontmatter invalid" "expected name: wiki-manager"
+  fi
 else
   log_fail "AGENTS.md missing" "missing file"
 fi
@@ -291,6 +297,50 @@ if [ -f "$OPENCODE_PLUGIN/README.md" ]; then
   log_pass "OpenCode README.md exists"
 else
   log_fail "OpenCode README.md not found" "missing file"
+fi
+
+# Hermes deliberately gets only a thin optional session adapter. Full and
+# query-only skills install from the existing canonical/generated profiles.
+echo ""
+echo "=== Hermes Session Adapter Validation ==="
+HERMES_PLUGIN="$PROJECT_ROOT/plugins/llm-wiki-hermes"
+HERMES_MANIFEST="$HERMES_PLUGIN/plugin.yaml"
+
+if [ -f "$HERMES_MANIFEST" ]; then
+  log_pass "Hermes plugin.yaml exists"
+  EXPECTED_VERSION=$(python3 -c "import json; print(json.load(open('$PLUGIN_JSON'))['version'])")
+  if grep -q '^name: llm-wiki-hermes$' "$HERMES_MANIFEST" \
+    && grep -q "^version: \"$EXPECTED_VERSION\"$" "$HERMES_MANIFEST" \
+    && grep -q '^provides_hooks:$' "$HERMES_MANIFEST"; then
+    log_pass "Hermes manifest name, version, and hook key are valid"
+  else
+    log_fail "Hermes manifest invalid" "expected current version and provides_hooks"
+  fi
+  for hook in on_session_start pre_llm_call post_tool_call on_session_finalize on_session_end; do
+    if grep -q "^  - $hook$" "$HERMES_MANIFEST"; then
+      log_pass "Hermes manifest declares $hook"
+    else
+      log_fail "Hermes manifest missing $hook" "required session hook"
+    fi
+  done
+else
+  log_fail "Hermes plugin.yaml missing" "missing file"
+fi
+
+for file in __init__.py adapter.py; do
+  if [ -f "$HERMES_PLUGIN/$file" ] && python3 -m py_compile "$HERMES_PLUGIN/$file" 2>/dev/null; then
+    log_pass "Hermes $file exists and compiles"
+  else
+    log_fail "Hermes $file invalid" "missing file or syntax error"
+  fi
+done
+
+if [ ! -e "$HERMES_PLUGIN/skills" ] \
+  && [ ! -e "$HERMES_PLUGIN/tools.py" ] \
+  && [ ! -e "$HERMES_PLUGIN/install.py" ]; then
+  log_pass "Hermes adapter does not duplicate skills, tools, or installers"
+else
+  log_fail "Hermes adapter exceeds session-only scope" "remove bundled skills, tools, and installers"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Replaces #65 with a deliberately small Hermes integration built on Hermes' native skill installer and llm-wiki's existing session engine.

## What changed

- Makes the portable `AGENTS.md` directly installable as the `wiki-manager` Hermes skill.
- Documents native URL installation for full `wiki-manager` and read-only `wiki-query` profiles.
- Adds an **optional session-only Hermes plugin** for capture and rehydration.
- Exposes a small in-process `handle_event()` API from the existing session engine.
- Adds deterministic manifest, scope, capture, and rehydration tests.

## Deliberate non-goals

The Hermes adapter does **not**:

- replace or disable Hermes' built-in skill
- bundle another copy of the wiki-manager skill or references
- register a custom wiki tool
- inject ambient wiki memory on every prompt
- use regex steering
- mutate Hermes skill or config state

## Size

- This PR: **565 additions, 41 deletions, 13 files**
- Superseded #65: **7,110 additions, 1,163 deletions, 37 files**

## Validation

- plugin validation: 115 passed
- structure: 170 passed
- local CLI lint: 27 passed
- session capture: 17 passed
- session concurrency: 10 passed
- Hermes runtime: passed
- Codex/OpenCode sync: passed
- Codex clean-home runtime: passed
- query-lite and token benchmark gates: passed
- static context budget: passed

Closes #64.
Supersedes #65.
