### PR TITLE
Fix OS-native path-separator leaks in lint --fix output

### DIFF
--- a/claude-plugin/bin/llm-wiki
+++ b/claude-plugin/bin/llm-wiki
@@ -164,7 +164,7 @@ class LintContext:
         if path is None:
             return ""
         try:
-            return str(path.resolve().relative_to(self.root))
+            return path.resolve().relative_to(self.root).as_posix()
         except ValueError:
             return str(path)
 
@@ -1380,7 +1380,7 @@ def create_or_update_coverage_reference(ctx: LintContext, unreferenced: list[Pat
 
 
 def markdown_relative_link(base_dir: Path, target: Path) -> str:
-    rel = os.path.relpath(target, base_dir)
+    rel = Path(os.path.relpath(target, base_dir)).as_posix()
     return markdown_link_destination(rel)
 
 

--- a/plugins/llm-wiki-opencode/bin/llm-wiki
+++ b/plugins/llm-wiki-opencode/bin/llm-wiki
@@ -164,7 +164,7 @@ class LintContext:
         if path is None:
             return ""
         try:
-            return str(path.resolve().relative_to(self.root))
+            return path.resolve().relative_to(self.root).as_posix()
         except ValueError:
             return str(path)
 
@@ -1380,7 +1380,7 @@ def create_or_update_coverage_reference(ctx: LintContext, unreferenced: list[Pat
 
 
 def markdown_relative_link(base_dir: Path, target: Path) -> str:
-    rel = os.path.relpath(target, base_dir)
+    rel = Path(os.path.relpath(target, base_dir)).as_posix()
     return markdown_link_destination(rel)
 
 

--- a/plugins/llm-wiki/bin/llm-wiki
+++ b/plugins/llm-wiki/bin/llm-wiki
@@ -164,7 +164,7 @@ class LintContext:
         if path is None:
             return ""
         try:
-            return str(path.resolve().relative_to(self.root))
+            return path.resolve().relative_to(self.root).as_posix()
         except ValueError:
             return str(path)
 
@@ -1380,7 +1380,7 @@ def create_or_update_coverage_reference(ctx: LintContext, unreferenced: list[Pat
 
 
 def markdown_relative_link(base_dir: Path, target: Path) -> str:
-    rel = os.path.relpath(target, base_dir)
+    rel = Path(os.path.relpath(target, base_dir)).as_posix()
     return markdown_link_destination(rel)
 
 

--- a/scripts/llm-wiki
+++ b/scripts/llm-wiki
@@ -164,7 +164,7 @@ class LintContext:
         if path is None:
             return ""
         try:
-            return str(path.resolve().relative_to(self.root))
+            return path.resolve().relative_to(self.root).as_posix()
         except ValueError:
             return str(path)
 
@@ -1380,7 +1380,7 @@ def create_or_update_coverage_reference(ctx: LintContext, unreferenced: list[Pat
 
 
 def markdown_relative_link(base_dir: Path, target: Path) -> str:
-    rel = os.path.relpath(target, base_dir)
+    rel = Path(os.path.relpath(target, base_dir)).as_posix()
     return markdown_link_destination(rel)
 
 

--- a/tests/test-local-cli-lint.sh
+++ b/tests/test-local-cli-lint.sh
@@ -49,6 +49,59 @@ else
   log_fail "scripts/llm-wiki is executable" "missing executable bit"
 fi
 
+set +e
+portable_path_output="$(python3 - "$CLI" <<'PY' 2>&1
+import runpy
+import sys
+from pathlib import PureWindowsPath
+
+namespace = runpy.run_path(sys.argv[1])
+
+# Exercise the link helper with Windows-native relpath output even when this
+# test suite runs on POSIX. PureWindowsPath makes as_posix() behavior
+# deterministic without requiring a Windows runner.
+link_helper = namespace["markdown_relative_link"]
+original_path = link_helper.__globals__["Path"]
+original_relpath = link_helper.__globals__["os"].path.relpath
+try:
+    link_helper.__globals__["Path"] = PureWindowsPath
+    link_helper.__globals__["os"].path.relpath = (
+        lambda _target, _base: r"..\..\raw\articles\source.md"
+    )
+    assert link_helper(PureWindowsPath("base"), PureWindowsPath("target")) == (
+        "../../raw/articles/source.md"
+    )
+finally:
+    link_helper.__globals__["Path"] = original_path
+    link_helper.__globals__["os"].path.relpath = original_relpath
+
+
+class FakeResolvedPath:
+    def __init__(self, relative: str) -> None:
+        self.relative = relative
+
+    def resolve(self):
+        return self
+
+    def relative_to(self, _root):
+        return PureWindowsPath(self.relative)
+
+
+ctx = object.__new__(namespace["LintContext"])
+ctx.root = FakeResolvedPath("")
+assert ctx.rel(FakeResolvedPath(r"raw\articles\source.md")) == (
+    "raw/articles/source.md"
+)
+PY
+)"
+portable_path_rc=$?
+set -e
+if [ "$portable_path_rc" -eq 0 ]; then
+  log_pass "generated wiki paths use portable separators"
+else
+  log_fail "generated wiki paths use portable separators" "$portable_path_output"
+fi
+
 expect_success "golden wiki passes local lint" "$CLI" lint "$GOLDEN"
 
 expect_failure_contains \


### PR DESCRIPTION
lint --fix writes canonicalized relative paths back into wiki content in two places: LintContext.rel() (sources: frontmatter entries) and markdown_relative_link() (the generated source-coverage table). Both built these paths with plain str(Path)/os.path.relpath(), which returns backslashes on Windows.

Those values are read back as portable relative paths and matched against forward-slash expectations elsewhere (resolve_source_ref, markdown link rendering), so on Windows lint --fix silently wrote paths that no longer resolved — e.g. raw\papers\file.md instead of raw/papers/file.md, and markdown links like
[title](..\..\raw\articles\file.md).

Fix both call sites to emit Path.as_posix() so written content stays portable. Display-only call sites are unaffected (Windows paths read fine with forward slashes too).