### PR TITLE
Don't quarantine README.md and git-root meta files during lint --fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -995,11 +995,15 @@ Flags: `--dry-run` (preview without writing), `--rules` (also propose CLAUDE.md/
 
 Auto-run lightweight checks after write operations:
 
-1. Hub should only have `wikis.json`, `_index.md`, `log.md`, `topics/`, and
-   optional `.sessions/` and `.skills/`. `topics/.archive/` is allowed for
-   archived topic wikis. Validate `.skills/` with the instruction-only package
-   and active-topic allowlist rules. Warn on anything else; never delete
-   hub-level content automatically.
+1. Hub should only have `wikis.json`, `_index.md`, optional `README.md`,
+   `log.md`, `topics/`, and optional `.sessions/` and `.skills/`.
+   `topics/.archive/` is allowed for archived topic wikis. When the hub or a
+   topic wiki is itself a Git repository root, preserve its conventional Git
+   and project metadata (`.git`, `.github/`, ignore/attribute files, agent
+   instructions, contribution/security/changelog files, and licenses).
+   Validate `.skills/` with the instruction-only package and active-topic
+   allowlist rules. Warn on anything else; never delete hub-level content
+   automatically.
 2. Index freshness: file counts match index rows, including inventory and dataset indexes. Ignore maintenance/report directories such as `.librarian/` and `.audit/`. Auto-fix mismatches by regenerating the affected directory index.
 3. Orphan detection: files not in any index → add them.
 4. Missing core topic directories → create with empty _index.md. Inventory and dataset layers are lazy: repair indexes when they already exist, but do not create absent optional trees unless the current inventory or dataset workflow needs them. For older compiled articles, infer safe schema fields from the directory/body and rewrite fuzzy raw-source refs only when they resolve unambiguously.

--- a/claude-plugin/bin/llm-wiki
+++ b/claude-plugin/bin/llm-wiki
@@ -83,6 +83,7 @@ SPECIALIST_REQUIRED_SECTIONS = [
 
 ROOT_ALLOWED = {
     "_index.md",
+    "README.md",
     "config.md",
     "schema.md",
     "log.md",
@@ -101,7 +102,27 @@ ROOT_ALLOWED = {
     ".session-checkpoint.json",
     ".sessions",
 }
-HUB_ALLOWED = {"wikis.json", "_index.md", "log.md", "topics", ".sessions", ".skills"}
+HUB_ALLOWED = {
+    "wikis.json",
+    "_index.md",
+    "README.md",
+    "log.md",
+    "topics",
+    ".sessions",
+    ".skills",
+}
+# When a wiki or hub root is itself a git repository root, these conventional
+# VCS/project files legitimately coexist with the wiki schema and must never
+# be treated as unexpected content to quarantine into inbox/.unknown.
+GIT_ROOT_META_ALLOWED = {
+    "AGENTS.md",
+    "CLAUDE.md",
+    "LICENSE",
+    "LICENSE.md",
+    ".gitignore",
+    ".gitattributes",
+    ".gitmodules",
+}
 RAW_ALLOWED = {"_index.md", "articles", "papers", "repos", "notes", "data"}
 WIKI_ALLOWED = {"_index.md", "concepts", "topics", "references", "theses"}
 INVENTORY_ALLOWED = {
@@ -900,6 +921,8 @@ def check_unknown_files(ctx: LintContext) -> None:
     if not ctx.root.exists():
         return
     root_allowed = HUB_ALLOWED if is_hub(ctx.root) else ROOT_ALLOWED
+    if (ctx.root / ".git").exists():
+        root_allowed = root_allowed | GIT_ROOT_META_ALLOWED
     for child in sorted(ctx.root.iterdir()):
         if child.name not in root_allowed:
             handle_unknown(ctx, child, "Unexpected file or directory at wiki root.")

--- a/claude-plugin/bin/llm-wiki
+++ b/claude-plugin/bin/llm-wiki
@@ -129,10 +129,16 @@ HUB_ALLOWED = {
 # VCS/project files legitimately coexist with the wiki schema and must never
 # be treated as unexpected content to quarantine into inbox/.unknown.
 GIT_ROOT_META_ALLOWED = {
+    ".git",
+    ".github",
     "AGENTS.md",
     "CLAUDE.md",
+    "CHANGELOG.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
     "LICENSE",
     "LICENSE.md",
+    "SECURITY.md",
     ".gitignore",
     ".gitattributes",
     ".gitmodules",

--- a/claude-plugin/skills/wiki-manager/references/linting.md
+++ b/claude-plugin/skills/wiki-manager/references/linting.md
@@ -227,12 +227,12 @@ Any file that is not in the canonical allowlist for its location is either a use
 
 | Location | Allowed items |
 |----------|--------------|
-| HUB | `wikis.json`, `_index.md`, `log.md`, `topics/`, optional `.sessions/`, optional `.skills/` |
+| HUB | `wikis.json`, `_index.md`, `README.md`, `log.md`, `topics/`, optional `.sessions/`, optional `.skills/` |
 | `HUB/.skills/` | `_index.md`, `registry.json`, and lowercase specialist package directories |
 | `HUB/.skills/<name>/` | `SKILL.md` and optional `references/` containing Markdown only |
 | `HUB/topics/` | active topic directories plus `.archive/` |
 | `HUB/topics/.archive/` | archived topic directories |
-| Topic wiki root | `_index.md`, `config.md`, `schema.md`, `log.md`, `raw/`, `wiki/`, `inventory/`, `datasets/`, `output/`, `inbox/`, `.obsidian/`, `.librarian/`, `.audit/`, `.research-session.json`, `.thesis-session.json`, `.session-events.jsonl`, `.session-checkpoint.json` |
+| Topic wiki root | `_index.md`, `README.md`, `config.md`, `schema.md`, `log.md`, `raw/`, `wiki/`, `inventory/`, `datasets/`, `output/`, `inbox/`, `.obsidian/`, `.librarian/`, `.audit/`, `.research-session.json`, `.thesis-session.json`, `.session-events.jsonl`, `.session-checkpoint.json` |
 | `raw/` | `_index.md`, `articles/`, `papers/`, `repos/`, `notes/`, `data/` |
 | `wiki/` | `_index.md`, `concepts/`, `topics/`, `references/`, `theses/` |
 | `inventory/` | `_index.md`, `items/`, `ideas/`, `candidates/`, `entities/`, `corpora/`, `views/` |
@@ -244,6 +244,14 @@ Any file that is not in the canonical allowlist for its location is either a use
 | `datasets/<slug>/` | `_index.md`, `MANIFEST.md`, `samples/`, `profiles/`, `queries/` |
 | `datasets/<slug>/{samples,profiles,queries}/` | `_index.md` + `*.md` notes |
 | `inbox/` | `.processed/`, `.unknown/`, user-dropped files |
+
+When the hub or topic wiki root is itself a Git repository root (a `.git`
+directory or worktree `.git` file exists there), also allow the repository's
+`.git`, optional `.github/`, `AGENTS.md`, `CLAUDE.md`, `CHANGELOG.md`,
+`CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE`, `LICENSE.md`,
+`.gitignore`, `.gitattributes`, and `.gitmodules`. Do not apply this exception
+merely because some parent directory is a repository: project metadata does not
+belong inside an ordinary nested `.wiki/`.
 
 **Checks**:
 

--- a/plugins/llm-wiki-opencode/bin/llm-wiki
+++ b/plugins/llm-wiki-opencode/bin/llm-wiki
@@ -83,6 +83,7 @@ SPECIALIST_REQUIRED_SECTIONS = [
 
 ROOT_ALLOWED = {
     "_index.md",
+    "README.md",
     "config.md",
     "schema.md",
     "log.md",
@@ -101,7 +102,27 @@ ROOT_ALLOWED = {
     ".session-checkpoint.json",
     ".sessions",
 }
-HUB_ALLOWED = {"wikis.json", "_index.md", "log.md", "topics", ".sessions", ".skills"}
+HUB_ALLOWED = {
+    "wikis.json",
+    "_index.md",
+    "README.md",
+    "log.md",
+    "topics",
+    ".sessions",
+    ".skills",
+}
+# When a wiki or hub root is itself a git repository root, these conventional
+# VCS/project files legitimately coexist with the wiki schema and must never
+# be treated as unexpected content to quarantine into inbox/.unknown.
+GIT_ROOT_META_ALLOWED = {
+    "AGENTS.md",
+    "CLAUDE.md",
+    "LICENSE",
+    "LICENSE.md",
+    ".gitignore",
+    ".gitattributes",
+    ".gitmodules",
+}
 RAW_ALLOWED = {"_index.md", "articles", "papers", "repos", "notes", "data"}
 WIKI_ALLOWED = {"_index.md", "concepts", "topics", "references", "theses"}
 INVENTORY_ALLOWED = {
@@ -900,6 +921,8 @@ def check_unknown_files(ctx: LintContext) -> None:
     if not ctx.root.exists():
         return
     root_allowed = HUB_ALLOWED if is_hub(ctx.root) else ROOT_ALLOWED
+    if (ctx.root / ".git").exists():
+        root_allowed = root_allowed | GIT_ROOT_META_ALLOWED
     for child in sorted(ctx.root.iterdir()):
         if child.name not in root_allowed:
             handle_unknown(ctx, child, "Unexpected file or directory at wiki root.")

--- a/plugins/llm-wiki-opencode/bin/llm-wiki
+++ b/plugins/llm-wiki-opencode/bin/llm-wiki
@@ -129,10 +129,16 @@ HUB_ALLOWED = {
 # VCS/project files legitimately coexist with the wiki schema and must never
 # be treated as unexpected content to quarantine into inbox/.unknown.
 GIT_ROOT_META_ALLOWED = {
+    ".git",
+    ".github",
     "AGENTS.md",
     "CLAUDE.md",
+    "CHANGELOG.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
     "LICENSE",
     "LICENSE.md",
+    "SECURITY.md",
     ".gitignore",
     ".gitattributes",
     ".gitmodules",

--- a/plugins/llm-wiki/bin/llm-wiki
+++ b/plugins/llm-wiki/bin/llm-wiki
@@ -83,6 +83,7 @@ SPECIALIST_REQUIRED_SECTIONS = [
 
 ROOT_ALLOWED = {
     "_index.md",
+    "README.md",
     "config.md",
     "schema.md",
     "log.md",
@@ -101,7 +102,27 @@ ROOT_ALLOWED = {
     ".session-checkpoint.json",
     ".sessions",
 }
-HUB_ALLOWED = {"wikis.json", "_index.md", "log.md", "topics", ".sessions", ".skills"}
+HUB_ALLOWED = {
+    "wikis.json",
+    "_index.md",
+    "README.md",
+    "log.md",
+    "topics",
+    ".sessions",
+    ".skills",
+}
+# When a wiki or hub root is itself a git repository root, these conventional
+# VCS/project files legitimately coexist with the wiki schema and must never
+# be treated as unexpected content to quarantine into inbox/.unknown.
+GIT_ROOT_META_ALLOWED = {
+    "AGENTS.md",
+    "CLAUDE.md",
+    "LICENSE",
+    "LICENSE.md",
+    ".gitignore",
+    ".gitattributes",
+    ".gitmodules",
+}
 RAW_ALLOWED = {"_index.md", "articles", "papers", "repos", "notes", "data"}
 WIKI_ALLOWED = {"_index.md", "concepts", "topics", "references", "theses"}
 INVENTORY_ALLOWED = {
@@ -900,6 +921,8 @@ def check_unknown_files(ctx: LintContext) -> None:
     if not ctx.root.exists():
         return
     root_allowed = HUB_ALLOWED if is_hub(ctx.root) else ROOT_ALLOWED
+    if (ctx.root / ".git").exists():
+        root_allowed = root_allowed | GIT_ROOT_META_ALLOWED
     for child in sorted(ctx.root.iterdir()):
         if child.name not in root_allowed:
             handle_unknown(ctx, child, "Unexpected file or directory at wiki root.")

--- a/plugins/llm-wiki/bin/llm-wiki
+++ b/plugins/llm-wiki/bin/llm-wiki
@@ -129,10 +129,16 @@ HUB_ALLOWED = {
 # VCS/project files legitimately coexist with the wiki schema and must never
 # be treated as unexpected content to quarantine into inbox/.unknown.
 GIT_ROOT_META_ALLOWED = {
+    ".git",
+    ".github",
     "AGENTS.md",
     "CLAUDE.md",
+    "CHANGELOG.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
     "LICENSE",
     "LICENSE.md",
+    "SECURITY.md",
     ".gitignore",
     ".gitattributes",
     ".gitmodules",

--- a/plugins/llm-wiki/skills/wiki/references/linting.md
+++ b/plugins/llm-wiki/skills/wiki/references/linting.md
@@ -227,12 +227,12 @@ Any file that is not in the canonical allowlist for its location is either a use
 
 | Location | Allowed items |
 |----------|--------------|
-| HUB | `wikis.json`, `_index.md`, `log.md`, `topics/`, optional `.sessions/`, optional `.skills/` |
+| HUB | `wikis.json`, `_index.md`, `README.md`, `log.md`, `topics/`, optional `.sessions/`, optional `.skills/` |
 | `HUB/.skills/` | `_index.md`, `registry.json`, and lowercase specialist package directories |
 | `HUB/.skills/<name>/` | `SKILL.md` and optional `references/` containing Markdown only |
 | `HUB/topics/` | active topic directories plus `.archive/` |
 | `HUB/topics/.archive/` | archived topic directories |
-| Topic wiki root | `_index.md`, `config.md`, `schema.md`, `log.md`, `raw/`, `wiki/`, `inventory/`, `datasets/`, `output/`, `inbox/`, `.obsidian/`, `.librarian/`, `.audit/`, `.research-session.json`, `.thesis-session.json`, `.session-events.jsonl`, `.session-checkpoint.json` |
+| Topic wiki root | `_index.md`, `README.md`, `config.md`, `schema.md`, `log.md`, `raw/`, `wiki/`, `inventory/`, `datasets/`, `output/`, `inbox/`, `.obsidian/`, `.librarian/`, `.audit/`, `.research-session.json`, `.thesis-session.json`, `.session-events.jsonl`, `.session-checkpoint.json` |
 | `raw/` | `_index.md`, `articles/`, `papers/`, `repos/`, `notes/`, `data/` |
 | `wiki/` | `_index.md`, `concepts/`, `topics/`, `references/`, `theses/` |
 | `inventory/` | `_index.md`, `items/`, `ideas/`, `candidates/`, `entities/`, `corpora/`, `views/` |
@@ -244,6 +244,14 @@ Any file that is not in the canonical allowlist for its location is either a use
 | `datasets/<slug>/` | `_index.md`, `MANIFEST.md`, `samples/`, `profiles/`, `queries/` |
 | `datasets/<slug>/{samples,profiles,queries}/` | `_index.md` + `*.md` notes |
 | `inbox/` | `.processed/`, `.unknown/`, user-dropped files |
+
+When the hub or topic wiki root is itself a Git repository root (a `.git`
+directory or worktree `.git` file exists there), also allow the repository's
+`.git`, optional `.github/`, `AGENTS.md`, `CLAUDE.md`, `CHANGELOG.md`,
+`CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE`, `LICENSE.md`,
+`.gitignore`, `.gitattributes`, and `.gitmodules`. Do not apply this exception
+merely because some parent directory is a repository: project metadata does not
+belong inside an ordinary nested `.wiki/`.
 
 **Checks**:
 

--- a/scripts/llm-wiki
+++ b/scripts/llm-wiki
@@ -83,6 +83,7 @@ SPECIALIST_REQUIRED_SECTIONS = [
 
 ROOT_ALLOWED = {
     "_index.md",
+    "README.md",
     "config.md",
     "schema.md",
     "log.md",
@@ -101,7 +102,27 @@ ROOT_ALLOWED = {
     ".session-checkpoint.json",
     ".sessions",
 }
-HUB_ALLOWED = {"wikis.json", "_index.md", "log.md", "topics", ".sessions", ".skills"}
+HUB_ALLOWED = {
+    "wikis.json",
+    "_index.md",
+    "README.md",
+    "log.md",
+    "topics",
+    ".sessions",
+    ".skills",
+}
+# When a wiki or hub root is itself a git repository root, these conventional
+# VCS/project files legitimately coexist with the wiki schema and must never
+# be treated as unexpected content to quarantine into inbox/.unknown.
+GIT_ROOT_META_ALLOWED = {
+    "AGENTS.md",
+    "CLAUDE.md",
+    "LICENSE",
+    "LICENSE.md",
+    ".gitignore",
+    ".gitattributes",
+    ".gitmodules",
+}
 RAW_ALLOWED = {"_index.md", "articles", "papers", "repos", "notes", "data"}
 WIKI_ALLOWED = {"_index.md", "concepts", "topics", "references", "theses"}
 INVENTORY_ALLOWED = {
@@ -900,6 +921,8 @@ def check_unknown_files(ctx: LintContext) -> None:
     if not ctx.root.exists():
         return
     root_allowed = HUB_ALLOWED if is_hub(ctx.root) else ROOT_ALLOWED
+    if (ctx.root / ".git").exists():
+        root_allowed = root_allowed | GIT_ROOT_META_ALLOWED
     for child in sorted(ctx.root.iterdir()):
         if child.name not in root_allowed:
             handle_unknown(ctx, child, "Unexpected file or directory at wiki root.")

--- a/scripts/llm-wiki
+++ b/scripts/llm-wiki
@@ -129,10 +129,16 @@ HUB_ALLOWED = {
 # VCS/project files legitimately coexist with the wiki schema and must never
 # be treated as unexpected content to quarantine into inbox/.unknown.
 GIT_ROOT_META_ALLOWED = {
+    ".git",
+    ".github",
     "AGENTS.md",
     "CLAUDE.md",
+    "CHANGELOG.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
     "LICENSE",
     "LICENSE.md",
+    "SECURITY.md",
     ".gitignore",
     ".gitattributes",
     ".gitmodules",

--- a/tests/test-local-cli-lint.sh
+++ b/tests/test-local-cli-lint.sh
@@ -104,6 +104,68 @@ fi
 
 expect_success "golden wiki passes local lint" "$CLI" lint "$GOLDEN"
 
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+readme_root="$tmpdir/readme-root"
+mkdir "$readme_root"
+cp -R "$GOLDEN/." "$readme_root/"
+printf '# Wiki README\n' > "$readme_root/README.md"
+set +e
+readme_output="$("$CLI" lint --fix "$readme_root" 2>&1)"
+readme_rc=$?
+set -e
+if [ "$readme_rc" -eq 0 ] \
+  && [ -f "$readme_root/README.md" ] \
+  && [ ! -e "$readme_root/inbox/.unknown/README.md" ]; then
+  log_pass "--fix preserves README.md at any wiki root"
+else
+  log_fail "--fix preserves README.md at any wiki root" "$readme_output"
+fi
+
+git_root="$tmpdir/git-root"
+mkdir "$git_root"
+cp -R "$GOLDEN/." "$git_root/"
+mkdir "$git_root/.git" "$git_root/.github"
+for file in AGENTS.md CLAUDE.md CHANGELOG.md CODE_OF_CONDUCT.md \
+  CONTRIBUTING.md SECURITY.md LICENSE LICENSE.md .gitignore .gitattributes \
+  .gitmodules; do
+  printf '# project metadata\n' > "$git_root/$file"
+done
+set +e
+git_root_output="$("$CLI" lint --fix "$git_root" 2>&1)"
+git_root_rc=$?
+set -e
+if [ "$git_root_rc" -eq 0 ] \
+  && grep -q "Result: PASS" <<<"$git_root_output" \
+  && [ -d "$git_root/.git" ] \
+  && [ -d "$git_root/.github" ] \
+  && [ -f "$git_root/AGENTS.md" ] \
+  && [ -f "$git_root/.gitignore" ] \
+  && [ ! -d "$git_root/inbox/.unknown" ]; then
+  log_pass "--fix preserves conventional metadata at a Git-backed wiki root"
+else
+  log_fail "--fix preserves conventional metadata at a Git-backed wiki root" "$git_root_output"
+fi
+
+worktree_root="$tmpdir/worktree-root"
+mkdir "$worktree_root"
+cp -R "$GOLDEN/." "$worktree_root/"
+printf 'gitdir: ../repo/.git/worktrees/wiki\n' > "$worktree_root/.git"
+printf '# Agent instructions\n' > "$worktree_root/AGENTS.md"
+set +e
+worktree_output="$("$CLI" lint --fix "$worktree_root" 2>&1)"
+worktree_rc=$?
+set -e
+if [ "$worktree_rc" -eq 0 ] \
+  && [ -f "$worktree_root/.git" ] \
+  && [ -f "$worktree_root/AGENTS.md" ] \
+  && [ ! -d "$worktree_root/inbox/.unknown" ]; then
+  log_pass "--fix recognizes a worktree .git file as a Git root"
+else
+  log_fail "--fix recognizes a worktree .git file as a Git root" "$worktree_output"
+fi
+
 expect_failure_contains \
   "missing-index fixture fails local lint" \
   "Required _index.md is missing" \
@@ -113,9 +175,6 @@ expect_failure_contains \
   "bad-frontmatter fixture fails local lint" \
   "Invalid type" \
   "$CLI" lint "$SCRIPT_DIR/fixtures/defects/bad-frontmatter"
-
-tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' EXIT
 
 ideas_wiki="$tmpdir/ideas-wiki"
 mkdir "$ideas_wiki"


### PR DESCRIPTION
check_unknown_files() treats any file at a wiki or hub root not in ROOT_ALLOWED/HUB_ALLOWED as unexpected and, under --fix, moves it into inbox/.unknown/. Two related false positives:

1. When a wiki or hub root doubles as a git repository root (a normal setup), this wrongly quarantined AGENTS.md, CLAUDE.md, LICENSE, .gitignore, and similar conventional VCS/project files. Add GIT_ROOT_META_ALLOWED and widen the allowlist with it only when ctx.root/.git exists, so genuinely stray files are still caught.

2. README.md got the same false positive even at wiki/hub roots that are *not* themselves a git root (e.g. a topic subdirectory of a hub repo) — a case the git-root check above doesn't cover, since a topic subdirectory never has its own .git. README.md is a reasonable entrypoint at any wiki or hub root on its own merits, so it's added directly to ROOT_ALLOWED/HUB_ALLOWED rather than gated on being a git root.

Found via a private wiki hub: lint --fix moved its real AGENTS.md, README.md, and .gitignore out of the hub root, and a topic subdirectory's README.md got a permanent, non-fixable warning.