### PR TITLE
Normalize Windows absolute paths; enforce portable hub registry paths

### DIFF
--- a/claude-plugin/bin/llm-wiki
+++ b/claude-plugin/bin/llm-wiki
@@ -1532,11 +1532,26 @@ def expand_leading_tilde(value: str) -> Path:
 
 
 def windows_absolute_path(value: str) -> Path | None:
-    if os.name != "nt" or not WINDOWS_ABSOLUTE_PATH_RE.match(value):
+    normalized = normalize_windows_absolute_path(value)
+    if normalized is None:
         return None
-    if value.startswith("/") and len(value) >= 4 and value[2] == ":":
+    return Path(normalized)
+
+
+def normalize_windows_absolute_path(
+    value: str, platform: str | None = None
+) -> str | None:
+    """Return a canonical drive path only when Windows semantics apply.
+
+    Keeping recognition separate from ``Path`` construction makes the three
+    accepted spellings testable on every development platform. POSIX must not
+    reinterpret a valid filename such as ``C:\\notes`` as an absolute path.
+    """
+    if (platform or os.name) != "nt" or not WINDOWS_ABSOLUTE_PATH_RE.match(value):
+        return None
+    if value.startswith("/"):
         value = value[1:]
-    return Path(value)
+    return value.replace("\\", "/")
 
 
 def initialized_wiki_root(path: Path) -> bool:
@@ -1611,19 +1626,17 @@ def check_hub_registry(ctx: LintContext) -> None:
     changed = False
     default_path = data.get("default")
     if isinstance(default_path, str) and default_path not in {"<HUB>", "HUB", "."}:
-        resolved_default = resolve_registry_path(default_path, ctx.root)
-        if resolved_default.is_absolute():
-            if ctx.fix:
-                data["default"] = "<HUB>"
-                ctx.fixed("Rewrote hub registry default to <HUB>.")
-                changed = True
-            else:
-                ctx.issue(
-                    "suggestion",
-                    "Hub registry default should be portable: use <HUB> instead of an absolute path.",
-                    registry,
-                    fixable=True,
-                )
+        if ctx.fix:
+            data["default"] = "<HUB>"
+            ctx.fixed("Rewrote hub registry default to <HUB>.")
+            changed = True
+        else:
+            ctx.issue(
+                "suggestion",
+                "Hub registry default should use the portable <HUB> token.",
+                registry,
+                fixable=True,
+            )
 
     wikis = data.get("wikis")
     if not isinstance(wikis, dict):

--- a/claude-plugin/bin/llm-wiki
+++ b/claude-plugin/bin/llm-wiki
@@ -58,6 +58,7 @@ SCHEMA_STATUSES = {"unknown", "inferred", "declared", "validated"}
 CONFIDENCE_VALUES = {"high", "medium", "low"}
 VOLATILITY_VALUES = {"hot", "warm", "cold"}
 PERMISSION_DENIED_ERRNOS = {1, 13}
+WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^/?[A-Za-z]:[\\/]")
 ADAPTER_PROTOCOL = "llm-wiki-adapter/v1"
 ADAPTER_REGISTRY_SCHEMA = 1
 ADAPTER_MANIFEST_NAME = ".llm-wiki-adapter.json"
@@ -1104,6 +1105,9 @@ def is_local_markdown_link(link: str) -> bool:
 
 def resolve_link_target(base_dir: Path, link: str) -> Path:
     target = link.split("#", 1)[0]
+    windows_target = windows_absolute_path(target)
+    if windows_target is not None:
+        return windows_target
     if target.startswith("/"):
         return Path(target)
     return (base_dir / target).resolve()
@@ -1216,8 +1220,9 @@ def resolve_source_ref(ctx: LintContext, owner: Path, ref: str, wiki_source: boo
     if ref.startswith(("http://", "https://")):
         return None if wiki_source else Path(ref)
     candidates: list[Path] = []
-    ref_path = Path(ref)
-    if ref_path.is_absolute():
+    windows_ref = windows_absolute_path(ref)
+    ref_path = windows_ref or Path(ref)
+    if windows_ref is not None or ref_path.is_absolute():
         candidates.append(ref_path)
     elif ref.startswith(("../", "./")):
         candidates.append((owner.parent / ref).resolve())
@@ -1463,10 +1468,21 @@ def append_lint_log(ctx: LintContext) -> None:
 
 
 def expand_leading_tilde(value: str) -> Path:
+    windows_path = windows_absolute_path(value)
+    if windows_path is not None:
+        return windows_path
     if value == "~":
         return Path.home()
     if value.startswith("~/"):
         return Path.home() / value[2:]
+    return Path(value)
+
+
+def windows_absolute_path(value: str) -> Path | None:
+    if os.name != "nt" or not WINDOWS_ABSOLUTE_PATH_RE.match(value):
+        return None
+    if value.startswith("/") and len(value) >= 4 and value[2] == ":":
+        value = value[1:]
     return Path(value)
 
 
@@ -1521,6 +1537,100 @@ def resolve_registry_path(raw_path: str, hub: Path) -> Path:
     if path.is_absolute():
         return path
     return hub / path
+
+
+def check_hub_registry(ctx: LintContext) -> None:
+    registry = ctx.root / "wikis.json"
+    if not registry.exists():
+        return
+    try:
+        data = json.loads(registry.read_text(encoding="utf-8"))
+    except OSError as exc:
+        if is_permission_denied(exc):
+            ctx.issue("critical", permission_denied_message(registry, "read wiki registry", exc), registry)
+            return
+        ctx.issue("critical", f"Could not read wiki registry: {exc}", registry)
+        return
+    except json.JSONDecodeError as exc:
+        ctx.issue("critical", f"Invalid wiki registry: {exc}", registry)
+        return
+
+    changed = False
+    default_path = data.get("default")
+    if isinstance(default_path, str) and default_path not in {"<HUB>", "HUB", "."}:
+        resolved_default = resolve_registry_path(default_path, ctx.root)
+        if resolved_default.is_absolute():
+            if ctx.fix:
+                data["default"] = "<HUB>"
+                ctx.fixed("Rewrote hub registry default to <HUB>.")
+                changed = True
+            else:
+                ctx.issue(
+                    "suggestion",
+                    "Hub registry default should be portable: use <HUB> instead of an absolute path.",
+                    registry,
+                    fixable=True,
+                )
+
+    wikis = data.get("wikis")
+    if not isinstance(wikis, dict):
+        return
+    for slug, entry in sorted(wikis.items()):
+        if not isinstance(entry, dict):
+            continue
+        raw_path = entry.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            continue
+        if slug == "hub":
+            if raw_path not in {"<HUB>", "HUB", "."}:
+                if ctx.fix:
+                    entry["path"] = "<HUB>"
+                    ctx.fixed("Rewrote hub registry entry path to <HUB>.")
+                    changed = True
+                else:
+                    ctx.issue(
+                        "suggestion",
+                        "Hub registry entry should use portable path <HUB>.",
+                        registry,
+                        fixable=True,
+                    )
+            continue
+
+        relative_path = (
+            f"topics/.archive/{slug}" if is_archived_registry_entry(entry) else f"topics/{slug}"
+        )
+        hub_topic = ctx.root / relative_path
+        if initialized_wiki_root(hub_topic) and raw_path != relative_path:
+            if ctx.fix:
+                entry["path"] = relative_path
+                ctx.fixed(f"Rewrote hub-owned registry path for {slug} to {relative_path}.")
+                changed = True
+            else:
+                ctx.issue(
+                    "suggestion",
+                    f"Hub-owned wiki path should be portable: use {relative_path}.",
+                    registry,
+                    fixable=True,
+                )
+            continue
+
+        resolved = resolve_registry_path(raw_path, ctx.root)
+        if resolved.is_absolute() and not is_under(resolved, ctx.root):
+            if resolved.exists():
+                ctx.issue(
+                    "info",
+                    f"Registry path for {slug} is an external local absolute path that exists: {raw_path}.",
+                    registry,
+                )
+            else:
+                ctx.issue(
+                    "warning",
+                    f"Registry path for {slug} is an external local absolute path that does not exist: {raw_path}.",
+                    registry,
+                )
+
+    if changed:
+        write_registry(ctx.root, data)
 
 
 def is_archived_registry_entry(entry: dict[str, Any] | None) -> bool:
@@ -1657,6 +1767,7 @@ def run_lint(args: argparse.Namespace) -> int:
     check_unknown_files(ctx)
     if hub_root:
         check_specialist_library(ctx)
+        check_hub_registry(ctx)
         append_lint_log(ctx)
         if args.json:
             print_json_report(ctx)

--- a/plugins/llm-wiki-opencode/bin/llm-wiki
+++ b/plugins/llm-wiki-opencode/bin/llm-wiki
@@ -1532,11 +1532,26 @@ def expand_leading_tilde(value: str) -> Path:
 
 
 def windows_absolute_path(value: str) -> Path | None:
-    if os.name != "nt" or not WINDOWS_ABSOLUTE_PATH_RE.match(value):
+    normalized = normalize_windows_absolute_path(value)
+    if normalized is None:
         return None
-    if value.startswith("/") and len(value) >= 4 and value[2] == ":":
+    return Path(normalized)
+
+
+def normalize_windows_absolute_path(
+    value: str, platform: str | None = None
+) -> str | None:
+    """Return a canonical drive path only when Windows semantics apply.
+
+    Keeping recognition separate from ``Path`` construction makes the three
+    accepted spellings testable on every development platform. POSIX must not
+    reinterpret a valid filename such as ``C:\\notes`` as an absolute path.
+    """
+    if (platform or os.name) != "nt" or not WINDOWS_ABSOLUTE_PATH_RE.match(value):
+        return None
+    if value.startswith("/"):
         value = value[1:]
-    return Path(value)
+    return value.replace("\\", "/")
 
 
 def initialized_wiki_root(path: Path) -> bool:
@@ -1611,19 +1626,17 @@ def check_hub_registry(ctx: LintContext) -> None:
     changed = False
     default_path = data.get("default")
     if isinstance(default_path, str) and default_path not in {"<HUB>", "HUB", "."}:
-        resolved_default = resolve_registry_path(default_path, ctx.root)
-        if resolved_default.is_absolute():
-            if ctx.fix:
-                data["default"] = "<HUB>"
-                ctx.fixed("Rewrote hub registry default to <HUB>.")
-                changed = True
-            else:
-                ctx.issue(
-                    "suggestion",
-                    "Hub registry default should be portable: use <HUB> instead of an absolute path.",
-                    registry,
-                    fixable=True,
-                )
+        if ctx.fix:
+            data["default"] = "<HUB>"
+            ctx.fixed("Rewrote hub registry default to <HUB>.")
+            changed = True
+        else:
+            ctx.issue(
+                "suggestion",
+                "Hub registry default should use the portable <HUB> token.",
+                registry,
+                fixable=True,
+            )
 
     wikis = data.get("wikis")
     if not isinstance(wikis, dict):

--- a/plugins/llm-wiki-opencode/bin/llm-wiki
+++ b/plugins/llm-wiki-opencode/bin/llm-wiki
@@ -58,6 +58,7 @@ SCHEMA_STATUSES = {"unknown", "inferred", "declared", "validated"}
 CONFIDENCE_VALUES = {"high", "medium", "low"}
 VOLATILITY_VALUES = {"hot", "warm", "cold"}
 PERMISSION_DENIED_ERRNOS = {1, 13}
+WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^/?[A-Za-z]:[\\/]")
 ADAPTER_PROTOCOL = "llm-wiki-adapter/v1"
 ADAPTER_REGISTRY_SCHEMA = 1
 ADAPTER_MANIFEST_NAME = ".llm-wiki-adapter.json"
@@ -1104,6 +1105,9 @@ def is_local_markdown_link(link: str) -> bool:
 
 def resolve_link_target(base_dir: Path, link: str) -> Path:
     target = link.split("#", 1)[0]
+    windows_target = windows_absolute_path(target)
+    if windows_target is not None:
+        return windows_target
     if target.startswith("/"):
         return Path(target)
     return (base_dir / target).resolve()
@@ -1216,8 +1220,9 @@ def resolve_source_ref(ctx: LintContext, owner: Path, ref: str, wiki_source: boo
     if ref.startswith(("http://", "https://")):
         return None if wiki_source else Path(ref)
     candidates: list[Path] = []
-    ref_path = Path(ref)
-    if ref_path.is_absolute():
+    windows_ref = windows_absolute_path(ref)
+    ref_path = windows_ref or Path(ref)
+    if windows_ref is not None or ref_path.is_absolute():
         candidates.append(ref_path)
     elif ref.startswith(("../", "./")):
         candidates.append((owner.parent / ref).resolve())
@@ -1463,10 +1468,21 @@ def append_lint_log(ctx: LintContext) -> None:
 
 
 def expand_leading_tilde(value: str) -> Path:
+    windows_path = windows_absolute_path(value)
+    if windows_path is not None:
+        return windows_path
     if value == "~":
         return Path.home()
     if value.startswith("~/"):
         return Path.home() / value[2:]
+    return Path(value)
+
+
+def windows_absolute_path(value: str) -> Path | None:
+    if os.name != "nt" or not WINDOWS_ABSOLUTE_PATH_RE.match(value):
+        return None
+    if value.startswith("/") and len(value) >= 4 and value[2] == ":":
+        value = value[1:]
     return Path(value)
 
 
@@ -1521,6 +1537,100 @@ def resolve_registry_path(raw_path: str, hub: Path) -> Path:
     if path.is_absolute():
         return path
     return hub / path
+
+
+def check_hub_registry(ctx: LintContext) -> None:
+    registry = ctx.root / "wikis.json"
+    if not registry.exists():
+        return
+    try:
+        data = json.loads(registry.read_text(encoding="utf-8"))
+    except OSError as exc:
+        if is_permission_denied(exc):
+            ctx.issue("critical", permission_denied_message(registry, "read wiki registry", exc), registry)
+            return
+        ctx.issue("critical", f"Could not read wiki registry: {exc}", registry)
+        return
+    except json.JSONDecodeError as exc:
+        ctx.issue("critical", f"Invalid wiki registry: {exc}", registry)
+        return
+
+    changed = False
+    default_path = data.get("default")
+    if isinstance(default_path, str) and default_path not in {"<HUB>", "HUB", "."}:
+        resolved_default = resolve_registry_path(default_path, ctx.root)
+        if resolved_default.is_absolute():
+            if ctx.fix:
+                data["default"] = "<HUB>"
+                ctx.fixed("Rewrote hub registry default to <HUB>.")
+                changed = True
+            else:
+                ctx.issue(
+                    "suggestion",
+                    "Hub registry default should be portable: use <HUB> instead of an absolute path.",
+                    registry,
+                    fixable=True,
+                )
+
+    wikis = data.get("wikis")
+    if not isinstance(wikis, dict):
+        return
+    for slug, entry in sorted(wikis.items()):
+        if not isinstance(entry, dict):
+            continue
+        raw_path = entry.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            continue
+        if slug == "hub":
+            if raw_path not in {"<HUB>", "HUB", "."}:
+                if ctx.fix:
+                    entry["path"] = "<HUB>"
+                    ctx.fixed("Rewrote hub registry entry path to <HUB>.")
+                    changed = True
+                else:
+                    ctx.issue(
+                        "suggestion",
+                        "Hub registry entry should use portable path <HUB>.",
+                        registry,
+                        fixable=True,
+                    )
+            continue
+
+        relative_path = (
+            f"topics/.archive/{slug}" if is_archived_registry_entry(entry) else f"topics/{slug}"
+        )
+        hub_topic = ctx.root / relative_path
+        if initialized_wiki_root(hub_topic) and raw_path != relative_path:
+            if ctx.fix:
+                entry["path"] = relative_path
+                ctx.fixed(f"Rewrote hub-owned registry path for {slug} to {relative_path}.")
+                changed = True
+            else:
+                ctx.issue(
+                    "suggestion",
+                    f"Hub-owned wiki path should be portable: use {relative_path}.",
+                    registry,
+                    fixable=True,
+                )
+            continue
+
+        resolved = resolve_registry_path(raw_path, ctx.root)
+        if resolved.is_absolute() and not is_under(resolved, ctx.root):
+            if resolved.exists():
+                ctx.issue(
+                    "info",
+                    f"Registry path for {slug} is an external local absolute path that exists: {raw_path}.",
+                    registry,
+                )
+            else:
+                ctx.issue(
+                    "warning",
+                    f"Registry path for {slug} is an external local absolute path that does not exist: {raw_path}.",
+                    registry,
+                )
+
+    if changed:
+        write_registry(ctx.root, data)
 
 
 def is_archived_registry_entry(entry: dict[str, Any] | None) -> bool:
@@ -1657,6 +1767,7 @@ def run_lint(args: argparse.Namespace) -> int:
     check_unknown_files(ctx)
     if hub_root:
         check_specialist_library(ctx)
+        check_hub_registry(ctx)
         append_lint_log(ctx)
         if args.json:
             print_json_report(ctx)

--- a/plugins/llm-wiki/bin/llm-wiki
+++ b/plugins/llm-wiki/bin/llm-wiki
@@ -1532,11 +1532,26 @@ def expand_leading_tilde(value: str) -> Path:
 
 
 def windows_absolute_path(value: str) -> Path | None:
-    if os.name != "nt" or not WINDOWS_ABSOLUTE_PATH_RE.match(value):
+    normalized = normalize_windows_absolute_path(value)
+    if normalized is None:
         return None
-    if value.startswith("/") and len(value) >= 4 and value[2] == ":":
+    return Path(normalized)
+
+
+def normalize_windows_absolute_path(
+    value: str, platform: str | None = None
+) -> str | None:
+    """Return a canonical drive path only when Windows semantics apply.
+
+    Keeping recognition separate from ``Path`` construction makes the three
+    accepted spellings testable on every development platform. POSIX must not
+    reinterpret a valid filename such as ``C:\\notes`` as an absolute path.
+    """
+    if (platform or os.name) != "nt" or not WINDOWS_ABSOLUTE_PATH_RE.match(value):
+        return None
+    if value.startswith("/"):
         value = value[1:]
-    return Path(value)
+    return value.replace("\\", "/")
 
 
 def initialized_wiki_root(path: Path) -> bool:
@@ -1611,19 +1626,17 @@ def check_hub_registry(ctx: LintContext) -> None:
     changed = False
     default_path = data.get("default")
     if isinstance(default_path, str) and default_path not in {"<HUB>", "HUB", "."}:
-        resolved_default = resolve_registry_path(default_path, ctx.root)
-        if resolved_default.is_absolute():
-            if ctx.fix:
-                data["default"] = "<HUB>"
-                ctx.fixed("Rewrote hub registry default to <HUB>.")
-                changed = True
-            else:
-                ctx.issue(
-                    "suggestion",
-                    "Hub registry default should be portable: use <HUB> instead of an absolute path.",
-                    registry,
-                    fixable=True,
-                )
+        if ctx.fix:
+            data["default"] = "<HUB>"
+            ctx.fixed("Rewrote hub registry default to <HUB>.")
+            changed = True
+        else:
+            ctx.issue(
+                "suggestion",
+                "Hub registry default should use the portable <HUB> token.",
+                registry,
+                fixable=True,
+            )
 
     wikis = data.get("wikis")
     if not isinstance(wikis, dict):

--- a/plugins/llm-wiki/bin/llm-wiki
+++ b/plugins/llm-wiki/bin/llm-wiki
@@ -58,6 +58,7 @@ SCHEMA_STATUSES = {"unknown", "inferred", "declared", "validated"}
 CONFIDENCE_VALUES = {"high", "medium", "low"}
 VOLATILITY_VALUES = {"hot", "warm", "cold"}
 PERMISSION_DENIED_ERRNOS = {1, 13}
+WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^/?[A-Za-z]:[\\/]")
 ADAPTER_PROTOCOL = "llm-wiki-adapter/v1"
 ADAPTER_REGISTRY_SCHEMA = 1
 ADAPTER_MANIFEST_NAME = ".llm-wiki-adapter.json"
@@ -1104,6 +1105,9 @@ def is_local_markdown_link(link: str) -> bool:
 
 def resolve_link_target(base_dir: Path, link: str) -> Path:
     target = link.split("#", 1)[0]
+    windows_target = windows_absolute_path(target)
+    if windows_target is not None:
+        return windows_target
     if target.startswith("/"):
         return Path(target)
     return (base_dir / target).resolve()
@@ -1216,8 +1220,9 @@ def resolve_source_ref(ctx: LintContext, owner: Path, ref: str, wiki_source: boo
     if ref.startswith(("http://", "https://")):
         return None if wiki_source else Path(ref)
     candidates: list[Path] = []
-    ref_path = Path(ref)
-    if ref_path.is_absolute():
+    windows_ref = windows_absolute_path(ref)
+    ref_path = windows_ref or Path(ref)
+    if windows_ref is not None or ref_path.is_absolute():
         candidates.append(ref_path)
     elif ref.startswith(("../", "./")):
         candidates.append((owner.parent / ref).resolve())
@@ -1463,10 +1468,21 @@ def append_lint_log(ctx: LintContext) -> None:
 
 
 def expand_leading_tilde(value: str) -> Path:
+    windows_path = windows_absolute_path(value)
+    if windows_path is not None:
+        return windows_path
     if value == "~":
         return Path.home()
     if value.startswith("~/"):
         return Path.home() / value[2:]
+    return Path(value)
+
+
+def windows_absolute_path(value: str) -> Path | None:
+    if os.name != "nt" or not WINDOWS_ABSOLUTE_PATH_RE.match(value):
+        return None
+    if value.startswith("/") and len(value) >= 4 and value[2] == ":":
+        value = value[1:]
     return Path(value)
 
 
@@ -1521,6 +1537,100 @@ def resolve_registry_path(raw_path: str, hub: Path) -> Path:
     if path.is_absolute():
         return path
     return hub / path
+
+
+def check_hub_registry(ctx: LintContext) -> None:
+    registry = ctx.root / "wikis.json"
+    if not registry.exists():
+        return
+    try:
+        data = json.loads(registry.read_text(encoding="utf-8"))
+    except OSError as exc:
+        if is_permission_denied(exc):
+            ctx.issue("critical", permission_denied_message(registry, "read wiki registry", exc), registry)
+            return
+        ctx.issue("critical", f"Could not read wiki registry: {exc}", registry)
+        return
+    except json.JSONDecodeError as exc:
+        ctx.issue("critical", f"Invalid wiki registry: {exc}", registry)
+        return
+
+    changed = False
+    default_path = data.get("default")
+    if isinstance(default_path, str) and default_path not in {"<HUB>", "HUB", "."}:
+        resolved_default = resolve_registry_path(default_path, ctx.root)
+        if resolved_default.is_absolute():
+            if ctx.fix:
+                data["default"] = "<HUB>"
+                ctx.fixed("Rewrote hub registry default to <HUB>.")
+                changed = True
+            else:
+                ctx.issue(
+                    "suggestion",
+                    "Hub registry default should be portable: use <HUB> instead of an absolute path.",
+                    registry,
+                    fixable=True,
+                )
+
+    wikis = data.get("wikis")
+    if not isinstance(wikis, dict):
+        return
+    for slug, entry in sorted(wikis.items()):
+        if not isinstance(entry, dict):
+            continue
+        raw_path = entry.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            continue
+        if slug == "hub":
+            if raw_path not in {"<HUB>", "HUB", "."}:
+                if ctx.fix:
+                    entry["path"] = "<HUB>"
+                    ctx.fixed("Rewrote hub registry entry path to <HUB>.")
+                    changed = True
+                else:
+                    ctx.issue(
+                        "suggestion",
+                        "Hub registry entry should use portable path <HUB>.",
+                        registry,
+                        fixable=True,
+                    )
+            continue
+
+        relative_path = (
+            f"topics/.archive/{slug}" if is_archived_registry_entry(entry) else f"topics/{slug}"
+        )
+        hub_topic = ctx.root / relative_path
+        if initialized_wiki_root(hub_topic) and raw_path != relative_path:
+            if ctx.fix:
+                entry["path"] = relative_path
+                ctx.fixed(f"Rewrote hub-owned registry path for {slug} to {relative_path}.")
+                changed = True
+            else:
+                ctx.issue(
+                    "suggestion",
+                    f"Hub-owned wiki path should be portable: use {relative_path}.",
+                    registry,
+                    fixable=True,
+                )
+            continue
+
+        resolved = resolve_registry_path(raw_path, ctx.root)
+        if resolved.is_absolute() and not is_under(resolved, ctx.root):
+            if resolved.exists():
+                ctx.issue(
+                    "info",
+                    f"Registry path for {slug} is an external local absolute path that exists: {raw_path}.",
+                    registry,
+                )
+            else:
+                ctx.issue(
+                    "warning",
+                    f"Registry path for {slug} is an external local absolute path that does not exist: {raw_path}.",
+                    registry,
+                )
+
+    if changed:
+        write_registry(ctx.root, data)
 
 
 def is_archived_registry_entry(entry: dict[str, Any] | None) -> bool:
@@ -1657,6 +1767,7 @@ def run_lint(args: argparse.Namespace) -> int:
     check_unknown_files(ctx)
     if hub_root:
         check_specialist_library(ctx)
+        check_hub_registry(ctx)
         append_lint_log(ctx)
         if args.json:
             print_json_report(ctx)

--- a/scripts/llm-wiki
+++ b/scripts/llm-wiki
@@ -1532,11 +1532,26 @@ def expand_leading_tilde(value: str) -> Path:
 
 
 def windows_absolute_path(value: str) -> Path | None:
-    if os.name != "nt" or not WINDOWS_ABSOLUTE_PATH_RE.match(value):
+    normalized = normalize_windows_absolute_path(value)
+    if normalized is None:
         return None
-    if value.startswith("/") and len(value) >= 4 and value[2] == ":":
+    return Path(normalized)
+
+
+def normalize_windows_absolute_path(
+    value: str, platform: str | None = None
+) -> str | None:
+    """Return a canonical drive path only when Windows semantics apply.
+
+    Keeping recognition separate from ``Path`` construction makes the three
+    accepted spellings testable on every development platform. POSIX must not
+    reinterpret a valid filename such as ``C:\\notes`` as an absolute path.
+    """
+    if (platform or os.name) != "nt" or not WINDOWS_ABSOLUTE_PATH_RE.match(value):
+        return None
+    if value.startswith("/"):
         value = value[1:]
-    return Path(value)
+    return value.replace("\\", "/")
 
 
 def initialized_wiki_root(path: Path) -> bool:
@@ -1611,19 +1626,17 @@ def check_hub_registry(ctx: LintContext) -> None:
     changed = False
     default_path = data.get("default")
     if isinstance(default_path, str) and default_path not in {"<HUB>", "HUB", "."}:
-        resolved_default = resolve_registry_path(default_path, ctx.root)
-        if resolved_default.is_absolute():
-            if ctx.fix:
-                data["default"] = "<HUB>"
-                ctx.fixed("Rewrote hub registry default to <HUB>.")
-                changed = True
-            else:
-                ctx.issue(
-                    "suggestion",
-                    "Hub registry default should be portable: use <HUB> instead of an absolute path.",
-                    registry,
-                    fixable=True,
-                )
+        if ctx.fix:
+            data["default"] = "<HUB>"
+            ctx.fixed("Rewrote hub registry default to <HUB>.")
+            changed = True
+        else:
+            ctx.issue(
+                "suggestion",
+                "Hub registry default should use the portable <HUB> token.",
+                registry,
+                fixable=True,
+            )
 
     wikis = data.get("wikis")
     if not isinstance(wikis, dict):

--- a/scripts/llm-wiki
+++ b/scripts/llm-wiki
@@ -58,6 +58,7 @@ SCHEMA_STATUSES = {"unknown", "inferred", "declared", "validated"}
 CONFIDENCE_VALUES = {"high", "medium", "low"}
 VOLATILITY_VALUES = {"hot", "warm", "cold"}
 PERMISSION_DENIED_ERRNOS = {1, 13}
+WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^/?[A-Za-z]:[\\/]")
 ADAPTER_PROTOCOL = "llm-wiki-adapter/v1"
 ADAPTER_REGISTRY_SCHEMA = 1
 ADAPTER_MANIFEST_NAME = ".llm-wiki-adapter.json"
@@ -1104,6 +1105,9 @@ def is_local_markdown_link(link: str) -> bool:
 
 def resolve_link_target(base_dir: Path, link: str) -> Path:
     target = link.split("#", 1)[0]
+    windows_target = windows_absolute_path(target)
+    if windows_target is not None:
+        return windows_target
     if target.startswith("/"):
         return Path(target)
     return (base_dir / target).resolve()
@@ -1216,8 +1220,9 @@ def resolve_source_ref(ctx: LintContext, owner: Path, ref: str, wiki_source: boo
     if ref.startswith(("http://", "https://")):
         return None if wiki_source else Path(ref)
     candidates: list[Path] = []
-    ref_path = Path(ref)
-    if ref_path.is_absolute():
+    windows_ref = windows_absolute_path(ref)
+    ref_path = windows_ref or Path(ref)
+    if windows_ref is not None or ref_path.is_absolute():
         candidates.append(ref_path)
     elif ref.startswith(("../", "./")):
         candidates.append((owner.parent / ref).resolve())
@@ -1463,10 +1468,21 @@ def append_lint_log(ctx: LintContext) -> None:
 
 
 def expand_leading_tilde(value: str) -> Path:
+    windows_path = windows_absolute_path(value)
+    if windows_path is not None:
+        return windows_path
     if value == "~":
         return Path.home()
     if value.startswith("~/"):
         return Path.home() / value[2:]
+    return Path(value)
+
+
+def windows_absolute_path(value: str) -> Path | None:
+    if os.name != "nt" or not WINDOWS_ABSOLUTE_PATH_RE.match(value):
+        return None
+    if value.startswith("/") and len(value) >= 4 and value[2] == ":":
+        value = value[1:]
     return Path(value)
 
 
@@ -1521,6 +1537,100 @@ def resolve_registry_path(raw_path: str, hub: Path) -> Path:
     if path.is_absolute():
         return path
     return hub / path
+
+
+def check_hub_registry(ctx: LintContext) -> None:
+    registry = ctx.root / "wikis.json"
+    if not registry.exists():
+        return
+    try:
+        data = json.loads(registry.read_text(encoding="utf-8"))
+    except OSError as exc:
+        if is_permission_denied(exc):
+            ctx.issue("critical", permission_denied_message(registry, "read wiki registry", exc), registry)
+            return
+        ctx.issue("critical", f"Could not read wiki registry: {exc}", registry)
+        return
+    except json.JSONDecodeError as exc:
+        ctx.issue("critical", f"Invalid wiki registry: {exc}", registry)
+        return
+
+    changed = False
+    default_path = data.get("default")
+    if isinstance(default_path, str) and default_path not in {"<HUB>", "HUB", "."}:
+        resolved_default = resolve_registry_path(default_path, ctx.root)
+        if resolved_default.is_absolute():
+            if ctx.fix:
+                data["default"] = "<HUB>"
+                ctx.fixed("Rewrote hub registry default to <HUB>.")
+                changed = True
+            else:
+                ctx.issue(
+                    "suggestion",
+                    "Hub registry default should be portable: use <HUB> instead of an absolute path.",
+                    registry,
+                    fixable=True,
+                )
+
+    wikis = data.get("wikis")
+    if not isinstance(wikis, dict):
+        return
+    for slug, entry in sorted(wikis.items()):
+        if not isinstance(entry, dict):
+            continue
+        raw_path = entry.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            continue
+        if slug == "hub":
+            if raw_path not in {"<HUB>", "HUB", "."}:
+                if ctx.fix:
+                    entry["path"] = "<HUB>"
+                    ctx.fixed("Rewrote hub registry entry path to <HUB>.")
+                    changed = True
+                else:
+                    ctx.issue(
+                        "suggestion",
+                        "Hub registry entry should use portable path <HUB>.",
+                        registry,
+                        fixable=True,
+                    )
+            continue
+
+        relative_path = (
+            f"topics/.archive/{slug}" if is_archived_registry_entry(entry) else f"topics/{slug}"
+        )
+        hub_topic = ctx.root / relative_path
+        if initialized_wiki_root(hub_topic) and raw_path != relative_path:
+            if ctx.fix:
+                entry["path"] = relative_path
+                ctx.fixed(f"Rewrote hub-owned registry path for {slug} to {relative_path}.")
+                changed = True
+            else:
+                ctx.issue(
+                    "suggestion",
+                    f"Hub-owned wiki path should be portable: use {relative_path}.",
+                    registry,
+                    fixable=True,
+                )
+            continue
+
+        resolved = resolve_registry_path(raw_path, ctx.root)
+        if resolved.is_absolute() and not is_under(resolved, ctx.root):
+            if resolved.exists():
+                ctx.issue(
+                    "info",
+                    f"Registry path for {slug} is an external local absolute path that exists: {raw_path}.",
+                    registry,
+                )
+            else:
+                ctx.issue(
+                    "warning",
+                    f"Registry path for {slug} is an external local absolute path that does not exist: {raw_path}.",
+                    registry,
+                )
+
+    if changed:
+        write_registry(ctx.root, data)
 
 
 def is_archived_registry_entry(entry: dict[str, Any] | None) -> bool:
@@ -1657,6 +1767,7 @@ def run_lint(args: argparse.Namespace) -> int:
     check_unknown_files(ctx)
     if hub_root:
         check_specialist_library(ctx)
+        check_hub_registry(ctx)
         append_lint_log(ctx)
         if args.json:
             print_json_report(ctx)

--- a/tests/test-local-cli-lint.sh
+++ b/tests/test-local-cli-lint.sh
@@ -57,6 +57,19 @@ from pathlib import PureWindowsPath
 
 namespace = runpy.run_path(sys.argv[1])
 
+normalize_windows = namespace["normalize_windows_absolute_path"]
+assert normalize_windows(r"C:\Users\person\wiki", platform="nt") == (
+    "C:/Users/person/wiki"
+)
+assert normalize_windows("C:/Users/person/wiki", platform="nt") == (
+    "C:/Users/person/wiki"
+)
+assert normalize_windows("/C:/Users/person/wiki", platform="nt") == (
+    "C:/Users/person/wiki"
+)
+assert normalize_windows("topics/example", platform="nt") is None
+assert normalize_windows(r"C:\Users\person\wiki", platform="posix") is None
+
 # Exercise the link helper with Windows-native relpath output even when this
 # test suite runs on POSIX. PureWindowsPath makes as_posix() behavior
 # deterministic without requiring a Windows runner.
@@ -519,6 +532,82 @@ echo '{}' > "$hub_scope/.sessions/state/codex/example.json"
 expect_success \
   "hub lint allows operational .sessions layer" \
   "$CLI" lint "$hub_scope"
+
+registry_portability="$tmpdir/registry-portability"
+external_registry_wiki="$tmpdir/external-registry-wiki"
+missing_registry_wiki="$tmpdir/missing-registry-wiki"
+mkdir -p "$registry_portability/topics/portable-topic" "$external_registry_wiki"
+cp -R "$GOLDEN/." "$registry_portability/topics/portable-topic/"
+cp -R "$GOLDEN/." "$external_registry_wiki/"
+cat > "$registry_portability/_index.md" <<'EOF'
+# Hub Index
+EOF
+cat > "$registry_portability/log.md" <<'EOF'
+# Hub Log
+EOF
+cat > "$registry_portability/wikis.json" <<JSON
+{
+  "default": "$registry_portability",
+  "wikis": {
+    "hub": { "path": "$registry_portability", "description": "Hub" },
+    "portable-topic": {
+      "path": "$registry_portability/topics/portable-topic",
+      "description": "Portable topic"
+    },
+    "external-existing": {
+      "path": "$external_registry_wiki",
+      "description": "External existing wiki"
+    },
+    "external-missing": {
+      "path": "$missing_registry_wiki",
+      "description": "External missing wiki"
+    }
+  },
+  "local_wikis": []
+}
+JSON
+set +e
+registry_report="$("$CLI" lint "$registry_portability" --json 2>&1)"
+registry_report_rc=$?
+set -e
+if [ "$registry_report_rc" -ne 0 ] \
+  && python3 -c '
+import json, sys
+report = json.load(sys.stdin)
+messages = "\n".join(item["message"] for item in report["issues"])
+assert report["counts"] == {"critical": 0, "info": 1, "suggestion": 3, "warning": 1}
+assert "default should use the portable <HUB> token" in messages
+assert "Hub registry entry should use portable path <HUB>" in messages
+assert "Hub-owned wiki path should be portable: use topics/portable-topic" in messages
+assert "external local absolute path that exists" in messages
+assert "external local absolute path that does not exist" in messages
+' <<<"$registry_report"; then
+  log_pass "hub lint reports portable and external registry paths distinctly"
+else
+  log_fail "hub lint reports portable and external registry paths distinctly" "$registry_report"
+fi
+
+set +e
+registry_fix_report="$("$CLI" lint "$registry_portability" --fix --json 2>&1)"
+registry_fix_rc=$?
+set -e
+if [ "$registry_fix_rc" -ne 0 ] \
+  && python3 - "$registry_portability/wikis.json" "$external_registry_wiki" "$missing_registry_wiki" <<'PY'
+import json
+import sys
+
+registry = json.load(open(sys.argv[1], encoding="utf-8"))
+assert registry["default"] == "<HUB>"
+assert registry["wikis"]["hub"]["path"] == "<HUB>"
+assert registry["wikis"]["portable-topic"]["path"] == "topics/portable-topic"
+assert registry["wikis"]["external-existing"]["path"] == sys.argv[2]
+assert registry["wikis"]["external-missing"]["path"] == sys.argv[3]
+PY
+then
+  log_pass "--fix rewrites only hub-owned registry paths"
+else
+  log_fail "--fix rewrites only hub-owned registry paths" "$registry_fix_report"
+fi
 
 portable_home="$tmpdir/portable-home"
 portable_hub="$portable_home/Library/Mobile Documents/com~apple~CloudDocs/wiki"


### PR DESCRIPTION
Two related portability fixes:

1. resolve_link_target(), resolve_source_ref(), and expand_leading_tilde() didn't recognize Windows drive-letter absolute paths (C:\foo, C:/foo, /C:/foo). The leading-slash form in particular — /C:/foo, which some tools emit for markdown links — was mishandled: target.startswith('/') routed it through Path(target) unchanged, producing \C:\foo, which does not exist. Add windows_absolute_path() to recognize and normalize all three forms (gated on os.name == 'nt' so POSIX behavior is untouched), and use it at all three call sites.

2. wikis.json registry entries can hold host-specific absolute paths (default, per-wiki path) that make a hub non-portable across machines or checkouts. resolve_registry_path(), is_archived_registry_entry(), write_registry(), and is_under() already existed to support this, but nothing called them from lint. Add check_hub_registry(), wired into run_lint's hub branch, which flags (and under --fix, rewrites) absolute default/hub paths to <HUB>, absolute hub-owned topic paths to their portable topics/<slug> form, and reports non-hub-owned absolute paths as info/warning depending on whether they still resolve.

Verified both against minimal fixtures on Windows: a markdown link using the /C:/... form now resolves instead of reporting a false 'missing file'; an absolute wikis.json registry now gets the three expected portability suggestions instead of passing silently.