### PR TITLE
Check for rsync before destructive sync-plugin steps

### DIFF
--- a/scripts/sync-codex-plugin.sh
+++ b/scripts/sync-codex-plugin.sh
@@ -42,6 +42,11 @@ if [ ! -f "$LOCAL_HELPER" ]; then
   exit 1
 fi
 
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "Missing required tool: rsync" >&2
+  exit 1
+fi
+
 # The deterministic helper is shared by every runtime package. The public
 # script remains the source of truth; packaged copies make adapter management
 # available even when the plugin is installed without the full repository.

--- a/scripts/sync-opencode-plugin.sh
+++ b/scripts/sync-opencode-plugin.sh
@@ -30,6 +30,11 @@ if [ ! -f "$LOCAL_HELPER" ]; then
   exit 1
 fi
 
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "Missing required tool: rsync" >&2
+  exit 1
+fi
+
 mkdir -p "$ROOT/claude-plugin/bin" "$TARGET_PLUGIN/bin"
 cp "$LOCAL_HELPER" "$ROOT/claude-plugin/bin/llm-wiki"
 cp "$LOCAL_HELPER" "$TARGET_PLUGIN/bin/llm-wiki"

--- a/tests/test-codex-sync.sh
+++ b/tests/test-codex-sync.sh
@@ -13,6 +13,38 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+mkdir -p \
+  "$scratch/scripts" \
+  "$scratch/claude-plugin/skills/wiki-manager/references" \
+  "$scratch/claude-plugin/.claude-plugin" \
+  "$scratch/plugins/llm-wiki/.codex-plugin" \
+  "$scratch/plugins/llm-wiki/skills/wiki-query" \
+  "$scratch/fake-bin"
+cp scripts/sync-codex-plugin.sh "$scratch/scripts/"
+touch \
+  "$scratch/claude-plugin/skills/wiki-manager/references/query-lite.md" \
+  "$scratch/claude-plugin/.claude-plugin/plugin.json" \
+  "$scratch/plugins/llm-wiki/.codex-plugin/plugin.json" \
+  "$scratch/scripts/llm-wiki-session" \
+  "$scratch/scripts/llm-wiki" \
+  "$scratch/plugins/llm-wiki/skills/wiki-query/must-survive"
+ln -s "$(command -v dirname)" "$scratch/fake-bin/dirname"
+set +e
+missing_rsync_output="$(
+  PATH="$scratch/fake-bin" /bin/bash "$scratch/scripts/sync-codex-plugin.sh" 2>&1
+)"
+missing_rsync_rc=$?
+set -e
+if [ "$missing_rsync_rc" -eq 0 ] \
+  || ! grep -q "Missing required tool: rsync" <<<"$missing_rsync_output" \
+  || [ ! -f "$scratch/plugins/llm-wiki/skills/wiki-query/must-survive" ]; then
+  echo "FAIL: Codex sync must reject a missing rsync before changing the target." >&2
+  echo "$missing_rsync_output" >&2
+  exit 1
+fi
+
 ./scripts/sync-codex-plugin.sh >/dev/null
 
 if ! git diff --quiet HEAD -- plugins/; then
@@ -30,4 +62,4 @@ MSG
   exit 1
 fi
 
-echo "OK: Codex plugin mirror is in sync."
+echo "OK: Codex sync prerequisites are non-destructive and the plugin mirror is in sync."

--- a/tests/test-opencode-sync.sh
+++ b/tests/test-opencode-sync.sh
@@ -11,6 +11,35 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+mkdir -p \
+  "$scratch/scripts" \
+  "$scratch/claude-plugin/skills/wiki-manager/references" \
+  "$scratch/claude-plugin/.claude-plugin" \
+  "$scratch/plugins/llm-wiki-opencode/skills/wiki-query" \
+  "$scratch/fake-bin"
+cp scripts/sync-opencode-plugin.sh "$scratch/scripts/"
+touch \
+  "$scratch/claude-plugin/skills/wiki-manager/references/query-lite.md" \
+  "$scratch/claude-plugin/.claude-plugin/plugin.json" \
+  "$scratch/scripts/llm-wiki" \
+  "$scratch/plugins/llm-wiki-opencode/skills/wiki-query/must-survive"
+ln -s "$(command -v dirname)" "$scratch/fake-bin/dirname"
+set +e
+missing_rsync_output="$(
+  PATH="$scratch/fake-bin" /bin/bash "$scratch/scripts/sync-opencode-plugin.sh" 2>&1
+)"
+missing_rsync_rc=$?
+set -e
+if [ "$missing_rsync_rc" -eq 0 ] \
+  || ! grep -q "Missing required tool: rsync" <<<"$missing_rsync_output" \
+  || [ ! -f "$scratch/plugins/llm-wiki-opencode/skills/wiki-query/must-survive" ]; then
+  echo "FAIL: OpenCode sync must reject a missing rsync before changing the target." >&2
+  echo "$missing_rsync_output" >&2
+  exit 1
+fi
+
 ./scripts/sync-opencode-plugin.sh >/dev/null
 
 if ! git diff --quiet HEAD -- plugins/llm-wiki-opencode/; then
@@ -28,4 +57,4 @@ MSG
   exit 1
 fi
 
-echo "OK: OpenCode plugin mirror is in sync."
+echo "OK: OpenCode sync prerequisites are non-destructive and the plugin mirror is in sync."


### PR DESCRIPTION
sync-codex-plugin.sh runs `rm -rf` on `skills/wiki-manager` and `skills/wiki-query` **before** the `rsync` call that repopulates them. On a machine without rsync installed, `set -euo pipefail` means the script exits right after those deletions (`rsync: command not found`, exit 127), leaving the packaged Codex plugin skills deleted and never restored.

sync-opencode-plugin.sh doesn't have the same ordering bug (its `rm -rf` calls come after its `rsync` call, so `set -e` stops it first), but gets the same upfront check for a clearer error message and consistency with its sibling script.

**Fix:** add a `command -v rsync` prerequisite check alongside the existing missing-file checks in both scripts, before any destructive step runs.

**Tested:** on a machine without rsync installed — `sync-codex-plugin.sh` previously deleted `plugins/llm-wiki/skills/wiki-query` contents before aborting; with this check it now exits cleanly with `Missing required tool: rsync` and leaves the tree untouched. Both scripts pass `bash -n` syntax check. `tests/test-plugin-validate.sh` and `tests/test-docs-consistency.sh` pass at the same baseline counts as unmodified `master`.