### PR TITLE
Support explicit skill factory adapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,10 @@ provider steps stay private.
 packages live under `HUB/.skills/`, are explicitly enabled per active topic,
 and never grant tools, write authority, professional status, or permission to
 spawn agents. Select the minimum useful method and record its version/hash.
+17. **Named adapters can be explicit-only.** `wiki skill-factory <request>`
+selects the registered `skill-factory` adapter by name, runs doctor, and follows
+its adapter-owned guide. It has no ambient route; every generated candidate is
+disabled, and install/enable/commit/publication remain separate actions.
 
 ## File Formats
 
@@ -454,6 +458,13 @@ For an action plus URL, run `llm-wiki adapter route --intent <effect>
 --resource <url> --json` before ingestion. A match returns the adapter guide;
 read it and run `adapter doctor`. No-match resumes normal routing; ambiguity or
 drift fails closed.
+
+For an explicit `wiki skill-factory <request>` call, do not invent a URL.
+Resolve the registered `skill-factory` adapter with `adapter show`, run
+`adapter doctor skill-factory`, and read its adapter-owned guide. This named
+adapter has no ambient route. Its external output must remain disabled and may
+not be installed, enabled for a topic, committed, or published without separate
+explicit authorization.
 
 Use the bundled `bin/llm-wiki` from the installed plugin root, or
 `scripts/llm-wiki` in a source checkout:

--- a/claude-plugin/commands/wiki.md
+++ b/claude-plugin/commands/wiki.md
@@ -126,6 +126,7 @@ The user typed something that isn't a known keyword. Detect their intent and rou
 |----------|--------|----------------|----------|
 | 0 | **Retract** | "retract", "remove source", "remove this everywhere", "forget this data", "wipe references", "delete this from the wiki" | `Skill: wiki:retract` before loading semantic wiki context |
 | 0a | **External Adapter Route** | An action verb plus an external URL, especially edit, revise, update, proofread, replace, suggest, sync, publish, validate, transcribe, or analyze | `Skill: wiki:adapter`; normalize the effect, run `adapter route`, and on a match read the returned adapter-owned guide before acting; a no-match returns to normal routing |
+| 0a.0b | **Skill Factory Adapter** | Starts with `wiki skill-factory`, `skill-factory`, or explicitly says "use the skill-factory adapter" | `Skill: wiki:adapter` with explicit named adapter `skill-factory`; run show/doctor, read its guide, and keep every generated candidate disabled |
 | 0a.1 | **Private Adapter** | "private adapter", "registered adapter", "adapter add", "adapter list", "adapter doctor", "adapter run", "use the <name> adapter", or an explicit request to register/invoke an external local llm-wiki adapter; do not match `ingest-collection --adapter` | `Skill: wiki:adapter` with the management/run arguments |
 | 0a.1b | **Personal Specialist** | "specialist skill", "specialist agent", "expert reviewer", "expert lens", "personal skill", "local skill", "specialist create/list/show/validate/enable/disable/suggest/apply", or a request to use a named specialist method | `Skill: wiki:specialist` with the management, suggestion, or apply arguments |
 | 0a.2 | **Collection Ingest** | Words: "import wiki", "mirror wiki", "bulk ingest", "ingest collection", "import collection", "ingest repo", "import repo"; or a URL/path plus collection signals: `dump.xml`, `.xml.bz2`, `.xml.gz`, `api.php`, `MediaWiki`, `github.com/*/*` with "all", "repo", "docs", "BIPs", or "collection" | `Skill: wiki:ingest-collection` with the source and filters |
@@ -191,6 +192,11 @@ The user typed something that isn't a known keyword. Detect their intent and rou
   closed. A URL without a concrete action is not authorization to invent a
   write, and every remote write still uses the generic approved-plan,
   revision-lock, idempotency, private-receipt, and read-back controls.
+- `wiki skill-factory` is an explicit named-adapter call, not a reason to make
+  skill generation ambient. Resolve the registered `skill-factory` adapter,
+  run doctor, and follow its own guide without inventing a URL route. Its output
+  is a disabled external candidate. Never install, enable, commit, or publish a
+  generated package as part of the factory run.
 - Collect signals outrank plain inventory and research when the user asks to
   discover many objects before tracking them. For example, "collect and
   inventory all bitcoin memes" routes to collect, which writes a bounded

--- a/claude-plugin/skills/wiki-manager/SKILL.md
+++ b/claude-plugin/skills/wiki-manager/SKILL.md
@@ -7,7 +7,8 @@ description: >
   outputs. Activates for /wiki commands; wiki or knowledge-base work; ingest,
   collect, catalog, compile, query, audit, librarian, inventory, idea,
   portfolio, business ideas, projects, datasets, archives, sessions, feedback,
-  private adapters, adapter routing, personal specialist skills, expert review,
+  private adapters, adapter routing, explicit wiki skill-factory requests,
+  personal specialist skills, expert review,
   specialist selection, provenance, external resource actions, or questions in a directory
   with .wiki/ or a configured hub.
 tools:
@@ -116,6 +117,11 @@ For an action plus URL, run `adapter route --intent <effect> --resource <url>
 --json` before ingestion. On a match, read its adapter-owned guide; provider
 steps live there. A URL alone is not write authorization. See
 [references/adapters.md](references/adapters.md).
+
+Explicit `wiki skill-factory <request>` selects the registered named adapter;
+do not invent a URL route. Run show/doctor and read its guide. It never
+activates ambiently, and its external candidates remain disabled; installation,
+topic enablement, commit, and publication are separate actions.
 
 ## Ambient Behavior
 

--- a/claude-plugin/skills/wiki-manager/references/adapters.md
+++ b/claude-plugin/skills/wiki-manager/references/adapters.md
@@ -98,6 +98,32 @@ effect is not write authorization, and a bounded instruction authorizes only a
 faithful plan. All generic remote-write controls below still apply regardless
 of provider.
 
+## Explicit named adapter invocation
+
+A registered adapter with no URL routes may be deliberately explicit-only.
+Use it only when the user names the adapter in declarative wiki syntax. The
+initial supported case is:
+
+```text
+wiki skill-factory <skill request>
+```
+
+For this syntax, do not call `adapter route` with a fabricated resource. Use
+`adapter show skill-factory` to resolve the machine-local registration,
+run `adapter doctor skill-factory`, and read the adapter-owned workflow guide
+from its registered root. Stop if the adapter is missing, its manifest has
+drifted, or the guide is missing. A normal request to create, review, or discuss
+a skill is not enough to select the adapter; the declarative name or an equally
+explicit “use the skill-factory adapter” instruction is required.
+
+Explicit-only availability is not ambient enablement. The adapter has no route,
+receives no automatic wiki context, and gains no tool or write authority. The
+`skill-factory` adapter must keep `writes_wiki: false`, use registered external
+input/output roots, and emit candidates in disabled state. A successful run may
+not install a package, edit `HUB/.skills/registry.json`, enable a topic, commit,
+or publish. Those remain separate authorized actions after evaluation and
+human acceptance.
+
 ## Adapter manifest
 
 Every adapter root contains `.llm-wiki-adapter.json`:

--- a/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
+++ b/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
@@ -10,7 +10,7 @@ description: >
   candidate list, watch list, backlog, dataset, large data, data registry,
   dataset manifest, compilation, querying, linting, audit, research, librarian,
   scan quality, article quality, content review, output drift, provenance,
-  archive wiki, archive topic, restore wiki, private adapter, adapter registry,
+  archive wiki, archive topic, restore wiki, private adapter, adapter registry, skill-factory,
   personal specialist, specialist skill, specialist reviewer, expert lens,
   adapter route, adapter doctor, adapter run, edit an external resource, session capture, capture context, rehydrate,
   resume from session, lessons learned, implementation plan, or uses
@@ -121,6 +121,11 @@ For an action plus URL, run `adapter route --intent <effect> --resource <url>
 --json` before ingestion. On a match, read its adapter-owned guide; provider
 steps live there. A URL alone is not write authorization. See
 [references/adapters.md](references/adapters.md).
+
+Explicit `wiki skill-factory <request>` selects the registered named adapter;
+do not invent a URL route. Run show/doctor and read its guide. It never
+activates ambiently, and its external candidates remain disabled; installation,
+topic enablement, commit, and publication are separate actions.
 
 ## Ambient Behavior
 

--- a/plugins/llm-wiki/.codex-plugin/plugin.json
+++ b/plugins/llm-wiki/.codex-plugin/plugin.json
@@ -33,7 +33,8 @@
     "adapters",
     "private-adapters",
     "specialists",
-    "personal-skills"
+    "personal-skills",
+    "skill-factory"
   ],
   "skills": "./skills/",
   "interface": {

--- a/plugins/llm-wiki/skills/wiki/SKILL.md
+++ b/plugins/llm-wiki/skills/wiki/SKILL.md
@@ -10,7 +10,7 @@ description: >
   candidate list, watch list, backlog, dataset, large data, data registry,
   dataset manifest, compilation, querying, linting, audit, research, librarian,
   scan quality, article quality, content review, output drift, provenance,
-  archive wiki, archive topic, restore wiki, private adapter, adapter registry,
+  archive wiki, archive topic, restore wiki, private adapter, adapter registry, skill-factory,
   personal specialist, specialist skill, specialist reviewer, expert lens,
   adapter route, adapter doctor, adapter run, edit an external resource, session capture, capture context, rehydrate,
   resume from session, implementation plan, or uses
@@ -116,6 +116,11 @@ For an action plus URL, run `adapter route --intent <effect> --resource <url>
 --json` before ingestion. On a match, read its adapter-owned guide; provider
 steps live there. A URL alone is not write authorization. See
 [references/adapters.md](references/adapters.md).
+
+Explicit `wiki skill-factory <request>` selects the registered named adapter;
+do not invent a URL route. Run show/doctor and read its guide. It never
+activates ambiently, and its external candidates remain disabled; installation,
+topic enablement, commit, and publication are separate actions.
 
 ## Ambient Behavior
 

--- a/plugins/llm-wiki/skills/wiki/references/adapters.md
+++ b/plugins/llm-wiki/skills/wiki/references/adapters.md
@@ -98,6 +98,32 @@ effect is not write authorization, and a bounded instruction authorizes only a
 faithful plan. All generic remote-write controls below still apply regardless
 of provider.
 
+## Explicit named adapter invocation
+
+A registered adapter with no URL routes may be deliberately explicit-only.
+Use it only when the user names the adapter in declarative wiki syntax. The
+initial supported case is:
+
+```text
+wiki skill-factory <skill request>
+```
+
+For this syntax, do not call `adapter route` with a fabricated resource. Use
+`adapter show skill-factory` to resolve the machine-local registration,
+run `adapter doctor skill-factory`, and read the adapter-owned workflow guide
+from its registered root. Stop if the adapter is missing, its manifest has
+drifted, or the guide is missing. A normal request to create, review, or discuss
+a skill is not enough to select the adapter; the declarative name or an equally
+explicit “use the skill-factory adapter” instruction is required.
+
+Explicit-only availability is not ambient enablement. The adapter has no route,
+receives no automatic wiki context, and gains no tool or write authority. The
+`skill-factory` adapter must keep `writes_wiki: false`, use registered external
+input/output roots, and emit candidates in disabled state. A successful run may
+not install a package, edit `HUB/.skills/registry.json`, enable a topic, commit,
+or publish. Those remain separate authorized actions after evaluation and
+human acceptance.
+
 ## Adapter manifest
 
 Every adapter root contains `.llm-wiki-adapter.json`:

--- a/scripts/sync-codex-plugin.sh
+++ b/scripts/sync-codex-plugin.sh
@@ -236,7 +236,7 @@ description: >
   candidate list, watch list, backlog, dataset, large data, data registry,
   dataset manifest, compilation, querying, linting, audit, research, librarian,
   scan quality, article quality, content review, output drift, provenance,
-  archive wiki, archive topic, restore wiki, private adapter, adapter registry,
+  archive wiki, archive topic, restore wiki, private adapter, adapter registry, skill-factory,
   personal specialist, specialist skill, specialist reviewer, expert lens,
   adapter route, adapter doctor, adapter run, edit an external resource, session capture, capture context, rehydrate,
   resume from session, implementation plan, or uses
@@ -420,7 +420,7 @@ keywords = [
     for keyword in codex.get("keywords", [])
     if not (keyword.startswith("private") and keyword.endswith("-skills"))
 ]
-for keyword in ["ideas", "projects", "specialists", "personal-skills"]:
+for keyword in ["ideas", "projects", "specialists", "personal-skills", "skill-factory"]:
     if keyword not in keywords:
         keywords.append(keyword)
 codex["keywords"] = keywords

--- a/scripts/sync-opencode-plugin.sh
+++ b/scripts/sync-opencode-plugin.sh
@@ -84,7 +84,7 @@ description: >
   candidate list, watch list, backlog, dataset, large data, data registry,
   dataset manifest, compilation, querying, linting, audit, research, librarian,
   scan quality, article quality, content review, output drift, provenance,
-  archive wiki, archive topic, restore wiki, private adapter, adapter registry,
+  archive wiki, archive topic, restore wiki, private adapter, adapter registry, skill-factory,
   personal specialist, specialist skill, specialist reviewer, expert lens,
   adapter route, adapter doctor, adapter run, edit an external resource, session capture, capture context, rehydrate,
   resume from session, lessons learned, implementation plan, or uses

--- a/tests/promptfooconfig.yaml
+++ b/tests/promptfooconfig.yaml
@@ -131,6 +131,30 @@ tests:
       - type: cost
         threshold: 0.50
 
+  - description: "Router: declarative skill-factory call is explicit-only and disabled-by-default"
+    vars:
+      prompt: "wiki skill-factory create a UniFi network operations reviewer"
+    assert:
+      - type: skill-used
+        value: wiki
+      - type: llm-rubric
+        value: "Agent treats this as an explicit named skill-factory adapter invocation, resolves the machine-local registration without fabricating a URL route, runs adapter doctor, reads the adapter-owned guide, uses wiki research to prepare the external factory input, and keeps the generated candidate disabled. It does not install, enable, commit, publish, or make live UniFi changes."
+        threshold: 0.75
+      - type: cost
+        threshold: 0.50
+
+  - description: "Router: ordinary skill discussion does not ambiently invoke skill-factory"
+    vars:
+      prompt: "What makes a good SKILL.md description?"
+    assert:
+      - type: skill-used
+        value: wiki
+      - type: llm-rubric
+        value: "Agent answers from relevant wiki knowledge or normal skill guidance and does not invoke the skill-factory adapter because the user did not use the declarative name or explicitly ask to use that adapter."
+        threshold: 0.75
+      - type: cost
+        threshold: 0.50
+
   - description: "Router: collect intent routes to collect before inventory or research"
     vars:
       prompt: "Find, collect, and inventory all the memes you can find for bitcoin"

--- a/tests/test-plugin-validate.sh
+++ b/tests/test-plugin-validate.sh
@@ -90,6 +90,10 @@ if grep -q '## Adapter Routing' "$PLUGIN_DIR/skills/wiki-manager/SKILL.md" \
   && grep -q '## Intent routing' "$ADAPTER_REFERENCE" \
   && grep -q 'adapter-owned workflow' "$ADAPTER_REFERENCE" \
   && grep -q '"routes"' "$ADAPTER_REFERENCE" \
+  && grep -q '## Explicit named adapter invocation' "$ADAPTER_REFERENCE" \
+  && grep -q 'wiki skill-factory' "$PLUGIN_DIR/skills/wiki-manager/SKILL.md" \
+  && grep -q 'Skill Factory Adapter' "$PLUGIN_DIR/commands/wiki.md" \
+  && grep -q 'wiki skill-factory' "$PROJECT_ROOT/AGENTS.md" \
   && grep -q 'External Adapter Route' "$PLUGIN_DIR/commands/wiki.md" \
   && grep -q '## Declarative intent routing' "$PLUGIN_DIR/commands/adapter.md" \
   && grep -q 'Route external actions before ingestion' "$PROJECT_ROOT/AGENTS.md" \
@@ -244,6 +248,11 @@ if [ -f "$CODEX_SKILL/SKILL.md" ]; then
     log_pass "Codex implicit skill metadata advertises external adapter routing"
   else
     log_fail "Codex adapter invocation metadata missing" "expected external resource in frontmatter"
+  fi
+  if sed -n '2,/^---$/p' "$CODEX_SKILL/SKILL.md" | grep -q 'skill-factory'; then
+    log_pass "Codex implicit skill metadata advertises declarative skill factory"
+  else
+    log_fail "Codex skill factory metadata missing" "expected skill factory in frontmatter"
   fi
 else
   log_fail "Codex SKILL.md not found" "missing file"


### PR DESCRIPTION
## Summary

- recognize `wiki skill-factory <request>` as an explicit named-adapter invocation
- preserve zero ambient routing and disabled-by-default candidate output
- synchronize Claude, Codex, OpenCode, portable instructions, and adapter documentation
- add positive and negative routing eval cases plus deterministic validation coverage

## Validation

- plugin validation: 129/129
- structure validation: 170/170
- local CLI lint/adapters/specialists: 30/30, 16/16, 21/21
- session capture/concurrency: 19/19, 10/10
- token, query-lite, mirror-sync, and clean-home Codex runtime tests: pass
- static token budgets: pass
- Promptfoo configuration parses with 28 cases; live Promptfoo eval not run because `ANTHROPIC_API_KEY` is not configured

The factory run does not install, enable, commit, publish, or execute generated skills.