### PR TITLE
Release v0.24.0: privacy-sealed project knowledge checkpoints

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "llm-wiki",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "LLM-compiled knowledge base plugin with privacy-sealed Project Knowledge Checkpoints, personal specialist skills, trusted adapters, Idea-to-Project workflows, compact queries, inventory, datasets, audits, sessions, research, and outputs.",
   "owner": {
     "name": "nvk"
@@ -10,7 +10,7 @@
     {
       "name": "wiki",
       "description": "LLM-compiled knowledge base with privacy-sealed project handoffs, personal specialist skills, trusted adapters, Idea shaping and Project promotion, compact queries, ingestion, inventory, datasets, audits, sessions, and outputs.",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "author": {
         "name": "nvk"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,14 +2,14 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "llm-wiki",
   "version": "0.23.0",
-  "description": "LLM-compiled knowledge base plugin with personal specialist skills, trusted adapters, a fuzzy Concept-to-Idea-to-Project workflow, compact queries, inventory, datasets, audits, sessions, research, and outputs.",
+  "description": "LLM-compiled knowledge base plugin with privacy-sealed Project Knowledge Checkpoints, personal specialist skills, trusted adapters, Idea-to-Project workflows, compact queries, inventory, datasets, audits, sessions, research, and outputs.",
   "owner": {
     "name": "nvk"
   },
   "plugins": [
     {
       "name": "wiki",
-      "description": "LLM-compiled knowledge base with personal specialist skills, explicitly trusted private adapters, fuzzy Idea shaping and Project promotion, compact queries, ingestion, inventory, datasets, audits, sessions, and outputs.",
+      "description": "LLM-compiled knowledge base with privacy-sealed project handoffs, personal specialist skills, trusted adapters, Idea shaping and Project promotion, compact queries, ingestion, inventory, datasets, audits, sessions, and outputs.",
       "version": "0.23.0",
       "author": {
         "name": "nvk"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,9 @@ spawn agents. Select the minimum useful method and record its version/hash.
 selects the registered `skill-factory` adapter by name, runs doctor, and follows
 its adapter-owned guide. It has no ambient route; every generated candidate is
 disabled, and install/enable/commit/publication remain separate actions.
+18. **Project checkpoints are privacy-sealed handoffs.** Curate across topics,
+never dump raw/sessions. Create/refresh are dry-run first; minimization,
+seal/verify, and exact override attestation are mandatory.
 
 ## File Formats
 
@@ -960,6 +963,18 @@ lineage while the Project owns delivery truth.
 Projects are a lightweight overlay — they don't move or copy wiki content.
 Project archive is separate from topic archive: it moves one folder under
 `output/projects/.archive/` inside the selected topic wiki.
+
+### Project Knowledge Checkpoint
+
+Bundle `index.md`, `project-knowledge.md`, `sources.md`, `checkpoint.json`, and
+generated `privacy-report.json` under `docs/knowledge/<slug>/`. Preview
+scope/privacy/diffs before `--apply`; verify hashes/attestation; import only
+pinned evidence.
+
+Audience is `private|team|public`; unknown access fails. Exclude raw/session/
+prompt data, secrets, identities, and private/personal/confidential records.
+Stage, seal, copy only passed/overridden output, then reverify. Scans cannot be
+disabled; exact overrides stay attested and permissions remain separate.
 
 ### Feedback
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,9 +146,9 @@ spawn agents. Select the minimum useful method and record its version/hash.
 selects the registered `skill-factory` adapter by name, runs doctor, and follows
 its adapter-owned guide. It has no ambient route; every generated candidate is
 disabled, and install/enable/commit/publication remain separate actions.
-18. **Project checkpoints are privacy-sealed handoffs.** Curate across topics,
-never dump raw/sessions. Create/refresh are dry-run first; minimization,
-seal/verify, and exact override attestation are mandatory.
+18. **Project checkpoints are comprehensive and privacy-sealed.** Never dump
+raw/sessions or summarize scope away; require coverage, a detail floor, seal,
+and exact overrides.
 
 ## File Formats
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ git -C ~/.claude/plugins/marketplaces/llm-wiki remote set-url origin https://git
 ./tests/test-local-cli-retract.sh  # local secret-safe retract + verification helper
 ./tests/test-local-cli-adapters.sh # private-adapter registry + v1 execution boundary
 ./tests/test-local-cli-specialists.sh # personal specialist library + topic allowlists
+./tests/test-local-cli-checkpoint.sh # project handoff integrity + mandatory privacy seal/overrides
 ./tests/test-session-capture.sh    # deterministic session capture helper
 ./tests/test-session-concurrency.sh # concurrent session-state regression
 ./tests/test-codex-sync.sh         # Codex plugin mirror matches Claude source

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ LLM-compiled knowledge bases for any AI agent. Capture rough Ideas, research and
 
 ## Changelog
 
+**v0.24.0** — **Privacy-sealed Project Knowledge Checkpoints.** Adds
+comprehensive, cross-topic project handoffs under `docs/knowledge/<slug>/` with
+dry-run-first create and refresh, read-only verification and bounded import,
+exact source and section coverage, explicit omissions, semantic privacy
+minimization, deterministic sealing, attested overrides, and a thin-output
+guard. Checkpoint writes never authorize commit, publication, or import.
+
 **v0.23.0** — **Personal specialist framework.** Adds optional user-owned,
 instruction-only `SKILL.md` review methods under the user's local wiki hub,
 explicit per-topic allowlists, deterministic validation and management, and research
@@ -431,7 +438,7 @@ Check your installed version:
 /wiki:audit --project gut-brain-playbook          # Truth-seeking audit across outputs + wiki + fresh research
 /wiki:output report --topic gut-brain             # Generate a report
 /wiki:output slides --retardmax                   # Ship a rough slide deck NOW
-/wiki:checkpoint create my-project --repo . --audience team  # Preview a cross-topic, privacy-sealed project handoff
+/wiki:checkpoint create my-project --repo . --audience team  # Preview a comprehensive cross-topic, privacy-sealed project handoff
 /wiki:checkpoint create my-project --repo . --audience team --apply  # Stage, seal, verify, then write; never commit/push
 /wiki:checkpoint verify docs/knowledge/my-project # Recheck hashes and the privacy attestation
 /wiki:assess /path/to/my-app --wiki nutrition     # Gap analysis: repo vs wiki vs market
@@ -473,10 +480,11 @@ checks without an agent:
 
 This local helper covers structural checks and safe migrations that do not
 require an LLM. Checkpoint sealing is mandatory for generated project
-handoffs: it hashes the bundle, scans for sensitive information without
-printing matched values, and writes `privacy-report.json`. There is no no-scan
-option; intentional exceptions name exact finding IDs and remain visibly
-attested as `overridden`. The agentic `/wiki:lint` workflow remains the full protocol for
+handoffs: it enforces comprehensive input-to-section coverage and a
+deterministic thin-output floor, hashes the bundle, scans for sensitive
+information without printing matched values, and writes `privacy-report.json`.
+There is no no-scan option; intentional exceptions name exact finding IDs and
+remain visibly attested as `overridden`. The agentic `/wiki:lint` workflow remains the full protocol for
 editorial and deep verification passes. The local schema helper creates only a
 starter advisory topic guide (`schema.md`); run librarian conventions advice
 for established wikis before adopting topic-specific vocabulary. The local archive helper
@@ -623,7 +631,7 @@ for the storage layout, privacy defaults, capture modes, and adapter contract.
 | `/wiki:refresh [<article-path>|--due]` | Re-check article sources for changed facts and offer human-gated updates |
 | `/wiki:output <type>` | Generate: summary, report, study-guide, slides, timeline, glossary, comparison |
 | `/wiki:output <type> --retardmax` | Ship it now — rough but comprehensive, iterate later |
-| `/wiki:checkpoint create [<slug>] --repo <path> --audience private\|team\|public` | Preview a cross-topic Project Knowledge Checkpoint with source-access, coverage, privacy, and gap review |
+| `/wiki:checkpoint create [<slug>] --repo <path> --audience private\|team\|public` | Preview a comprehensive cross-topic checkpoint with source access, section coverage, detail-floor, privacy, and gap review |
 | `/wiki:checkpoint create ... --apply` | Stage, synthesize, deterministically privacy-seal, verify, and write a five-file repo handoff without committing or pushing |
 | `/wiki:checkpoint refresh <bundle> [--apply]` | Re-run stored scope and review source/claim/privacy differences before replacing generated files |
 | `/wiki:checkpoint verify <bundle>` | Recheck structure, checkpoint/file hashes, privacy findings, and exact recorded overrides |

--- a/README.md
+++ b/README.md
@@ -431,6 +431,9 @@ Check your installed version:
 /wiki:audit --project gut-brain-playbook          # Truth-seeking audit across outputs + wiki + fresh research
 /wiki:output report --topic gut-brain             # Generate a report
 /wiki:output slides --retardmax                   # Ship a rough slide deck NOW
+/wiki:checkpoint create my-project --repo . --audience team  # Preview a cross-topic, privacy-sealed project handoff
+/wiki:checkpoint create my-project --repo . --audience team --apply  # Stage, seal, verify, then write; never commit/push
+/wiki:checkpoint verify docs/knowledge/my-project # Recheck hashes and the privacy attestation
 /wiki:assess /path/to/my-app --wiki nutrition     # Gap analysis: repo vs wiki vs market
 /wiki:lint --fix                                  # Clean up inconsistencies
 ```
@@ -464,10 +467,16 @@ checks without an agent:
 ./scripts/llm-wiki specialist validate
 ./scripts/llm-wiki specialist enable research-methodologist --wiki nutrition
 ./scripts/llm-wiki specialist list --wiki nutrition --json
+./scripts/llm-wiki checkpoint seal docs/knowledge/my-project --audience team --json
+./scripts/llm-wiki checkpoint verify docs/knowledge/my-project --json
 ```
 
 This local helper covers structural checks and safe migrations that do not
-require an LLM. The agentic `/wiki:lint` workflow remains the full protocol for
+require an LLM. Checkpoint sealing is mandatory for generated project
+handoffs: it hashes the bundle, scans for sensitive information without
+printing matched values, and writes `privacy-report.json`. There is no no-scan
+option; intentional exceptions name exact finding IDs and remain visibly
+attested as `overridden`. The agentic `/wiki:lint` workflow remains the full protocol for
 editorial and deep verification passes. The local schema helper creates only a
 starter advisory topic guide (`schema.md`); run librarian conventions advice
 for established wikis before adopting topic-specific vocabulary. The local archive helper
@@ -614,6 +623,11 @@ for the storage layout, privacy defaults, capture modes, and adapter contract.
 | `/wiki:refresh [<article-path>|--due]` | Re-check article sources for changed facts and offer human-gated updates |
 | `/wiki:output <type>` | Generate: summary, report, study-guide, slides, timeline, glossary, comparison |
 | `/wiki:output <type> --retardmax` | Ship it now — rough but comprehensive, iterate later |
+| `/wiki:checkpoint create [<slug>] --repo <path> --audience private\|team\|public` | Preview a cross-topic Project Knowledge Checkpoint with source-access, coverage, privacy, and gap review |
+| `/wiki:checkpoint create ... --apply` | Stage, synthesize, deterministically privacy-seal, verify, and write a five-file repo handoff without committing or pushing |
+| `/wiki:checkpoint refresh <bundle> [--apply]` | Re-run stored scope and review source/claim/privacy differences before replacing generated files |
+| `/wiki:checkpoint verify <bundle>` | Recheck structure, checkpoint/file hashes, privacy findings, and exact recorded overrides |
+| `/wiki:checkpoint import <bundle\|repo> --wiki <name>` | Verify and ingest a pinned checkpoint as bounded source evidence, never canonical truth |
 | `/wiki:project new <slug> "goal"` | Group related outputs under `output/projects/<slug>/` with a plain `WHY.md` rationale |
 | `/wiki:project list\|show\|add\|archive` | Manage output project folders without duplicating project state into frontmatter |
 | `/wiki:retract [<source-path>]` | User-authoritative removal of a source and its downstream wiki references, including selected archives and sessions |

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki",
-  "description": "LLM-compiled knowledge base with personal specialist skills, trusted adapters, fuzzy Concept-to-Idea-to-Project workflows, compact queries, inventory, datasets, ingestion, audits, sessions, research, and outputs.",
+  "description": "LLM-compiled knowledge base with privacy-sealed Project Knowledge Checkpoints, personal specialist skills, trusted adapters, Idea-to-Project workflows, compact queries, inventory, datasets, ingestion, audits, sessions, research, and outputs.",
   "version": "0.23.0",
   "author": {
     "name": "nvk"
@@ -23,6 +23,8 @@
     "inventory",
     "ideas",
     "projects",
+    "checkpoints",
+    "knowledge-handoff",
     "adapters",
     "private-adapters",
     "specialists",

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wiki",
   "description": "LLM-compiled knowledge base with privacy-sealed Project Knowledge Checkpoints, personal specialist skills, trusted adapters, Idea-to-Project workflows, compact queries, inventory, datasets, ingestion, audits, sessions, research, and outputs.",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "author": {
     "name": "nvk"
   },

--- a/claude-plugin/bin/llm-wiki
+++ b/claude-plugin/bin/llm-wiki
@@ -80,6 +80,18 @@ SPECIALIST_REQUIRED_SECTIONS = [
     "Evaluation cases",
     "Provenance and maintenance",
 ]
+CHECKPOINT_SCHEMA = "llm-wiki/project-knowledge-checkpoint/v1"
+CHECKPOINT_PRIVACY_SCHEMA = "llm-wiki/checkpoint-privacy-report/v1"
+CHECKPOINT_SCANNER_VERSION = 1
+CHECKPOINT_AUDIENCES = {"private", "team", "public"}
+CHECKPOINT_REQUIRED_FILES = {
+    "index.md",
+    "project-knowledge.md",
+    "sources.md",
+    "checkpoint.json",
+}
+CHECKPOINT_REPORT_NAME = "privacy-report.json"
+CHECKPOINT_MAX_FILE_BYTES = 10 * 1024 * 1024
 
 ROOT_ALLOWED = {
     "_index.md",
@@ -149,6 +161,16 @@ class Document:
     path: Path
     frontmatter: dict[str, Any]
     body: str
+
+
+@dataclass(frozen=True)
+class CheckpointFinding:
+    finding_id: str
+    category: str
+    severity: str
+    path: str
+    line: int
+    message: str
 
 
 class LintContext:
@@ -4228,6 +4250,695 @@ def run_adapter(args: argparse.Namespace) -> int:
     return handlers[args.adapter_command](args)
 
 
+def checkpoint_pattern_specs() -> list[tuple[str, str, str, re.Pattern[str]]]:
+    flags = re.IGNORECASE | re.MULTILINE
+    return [
+        (
+            "secret-private-key",
+            "critical",
+            "Possible private-key material.",
+            re.compile(
+                r"-----BEGIN (?:(?:[A-Z0-9 ]+ )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----",
+                flags,
+            ),
+        ),
+        (
+            "secret-known-token",
+            "critical",
+            "Possible service credential or bearer token.",
+            re.compile(
+                r"(?:\bAKIA[0-9A-Z]{16}\b|\bgh[pousr]_[A-Za-z0-9]{20,}\b|"
+                r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b|\bsk-[A-Za-z0-9_-]{16,}\b|"
+                r"\bAIza[0-9A-Za-z_-]{25,}\b|\bBearer\s+[A-Za-z0-9._~+/=-]{12,}|"
+                r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b)",
+                flags,
+            ),
+        ),
+        (
+            "secret-assignment",
+            "critical",
+            "Possible credential assigned to a sensitive field.",
+            re.compile(
+                r"\b(?:api[_-]?key|private[_-]?key|(?:access|auth|api|refresh)?[_-]?token|"
+                r"client[_-]?secret|password|passwd|secret|session[_-]?cookie)\b"
+                r"\s*[\"']?\s*[:=]\s*"
+                r"[\"']?[A-Za-z0-9_./+=$~-]{8,}",
+                flags,
+            ),
+        ),
+        (
+            "secret-url-credentials",
+            "critical",
+            "Possible username/password embedded in a URL.",
+            re.compile(r"\b[a-z][a-z0-9+.-]*://[^\s/@:]+:[^\s/@]+@", flags),
+        ),
+        (
+            "personal-email",
+            "warning",
+            "Email address may identify a person or private account.",
+            re.compile(r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
+        ),
+        (
+            "personal-account-field",
+            "warning",
+            "Account or username field may expose an identity.",
+            re.compile(
+                r"^[ \t]*[\"']?(?:user(?:name)?|login|account(?:[_-]?name)?|handle)"
+                r"[\"']?[ \t]*[:=][ \t]*[\"']?@?[A-Za-z0-9_.-]{2,}",
+                flags,
+            ),
+        ),
+        (
+            "local-home-path",
+            "critical",
+            "Machine-local home directory path.",
+            re.compile(
+                r"(?:(?<![:A-Za-z0-9])/Users/[A-Za-z0-9._-]+(?:/|\b)|"
+                r"(?<![:A-Za-z0-9])/home/[A-Za-z0-9._-]+(?:/|\b)|"
+                r"(?<![:A-Za-z0-9])/root(?:/|\b)|[A-Za-z]:\\Users\\[A-Za-z0-9._ -]+(?:\\|\b))",
+                flags,
+            ),
+        ),
+        (
+            "local-machine-path",
+            "critical",
+            "Machine-local volume, temporary, or file URL path.",
+            re.compile(
+                r"(?:file://|(?:~|\$HOME|\$\{HOME\})/|(?<![:A-Za-z0-9])/Volumes/[^\s/]+(?:/|\b)|"
+                r"(?<![:A-Za-z0-9])/private/var/folders/|(?<![:A-Za-z0-9])/(?:tmp|var|etc|opt|srv|mnt|media|workspace|Applications|Library)/[^\s`\"']+)",
+                flags,
+            ),
+        ),
+        (
+            "remote-login-identity",
+            "warning",
+            "Remote-login syntax may expose a username or private host.",
+            re.compile(r"\b(?:ssh|scp|sftp|rsync)\b[^\n]*\b[A-Za-z0-9._-]+@[A-Za-z0-9._-]+", flags),
+        ),
+        (
+            "local-network-address",
+            "warning",
+            "Private-network address may reveal local infrastructure.",
+            re.compile(
+                r"\b(?:10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|"
+                r"172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2})\b"
+            ),
+        ),
+        (
+            "local-hostname",
+            "warning",
+            "Local hostname may reveal private infrastructure.",
+            re.compile(
+                r"(?:\b[A-Za-z0-9][A-Za-z0-9-]{0,62}\.local\b|"
+                r"\b[A-Za-z0-9][A-Za-z0-9.-]{0,126}\.(?:lan|internal)\b|"
+                r"^[ \t]*[\"']?hostname[\"']?[ \t]*[:=][ \t]*[\"']?[^\s\"']+)",
+                flags,
+            ),
+        ),
+        (
+            "session-transcript",
+            "critical",
+            "Session or transcript metadata must not enter a checkpoint.",
+            re.compile(
+                r"(?:transcript[_-]?path|rollout-[^\s]+\.jsonl|\.sessions/(?:digests|feedback)/|"
+                r"\b(?:codex|claude):[0-9a-f]{8}-[0-9a-f-]{27,}\b|UserPromptSubmit|PreCompact|PostCompact)",
+                flags,
+            ),
+        ),
+        (
+            "prompt-conversation-role",
+            "warning",
+            "Conversation-role content may be copied prompt or transcript text.",
+            re.compile(
+                r"(?:^[ \t]*(?:system|developer|assistant|user)[ \t]*:[ \t]+\S|"
+                r"[\"']role[\"'][ \t]*:[ \t]*[\"'](?:system|developer|assistant|user)[\"'])",
+                flags,
+            ),
+        ),
+        (
+            "prompt-instruction-marker",
+            "warning",
+            "Prompt/instruction marker may expose agent instructions.",
+            re.compile(
+                r"(?:<\|(?:system|user|assistant)\|>|\[INST\]|</?system>|"
+                r"AGENTS\.md instructions for|(?:system|developer) prompt[ \t]*:)",
+                flags,
+            ),
+        ),
+    ]
+
+
+def checkpoint_finding(
+    category: str,
+    severity: str,
+    path: str,
+    line: int,
+    message: str,
+    evidence: str,
+) -> CheckpointFinding:
+    digest = hashlib.sha256(
+        "\0".join([category, path, str(line), evidence]).encode("utf-8")
+    ).hexdigest()[:16]
+    return CheckpointFinding(
+        finding_id=f"privacy-{digest}",
+        category=category,
+        severity=severity,
+        path=path,
+        line=line,
+        message=message,
+    )
+
+
+def scan_checkpoint_text(text: str, rel: str) -> list[CheckpointFinding]:
+    findings: list[CheckpointFinding] = []
+    for category, severity, message, pattern in checkpoint_pattern_specs():
+        for match in pattern.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            findings.append(
+                checkpoint_finding(
+                    category,
+                    severity,
+                    rel,
+                    line,
+                    message,
+                    match.group(0),
+                )
+            )
+    return findings
+
+
+def checkpoint_file_paths(root: Path, include_report: bool = False) -> list[Path]:
+    names = set(CHECKPOINT_REQUIRED_FILES)
+    if include_report:
+        names.add(CHECKPOINT_REPORT_NAME)
+    return [root / name for name in sorted(names) if (root / name).exists() or (root / name).is_symlink()]
+
+
+def checkpoint_source_key(item: dict[str, Any]) -> str:
+    return f"{item.get('wiki', '')}:{item.get('path', '')}"
+
+
+def checkpoint_source_access_findings(
+    manifest: dict[str, Any], audience: str
+) -> list[CheckpointFinding]:
+    inputs = manifest.get("inputs")
+    if not isinstance(inputs, list):
+        return [
+            checkpoint_finding(
+                "structure-inputs",
+                "critical",
+                "checkpoint.json",
+                1,
+                "Manifest inputs must be an array.",
+                "inputs-not-array",
+            )
+        ]
+    source_overrides = manifest.get("source_overrides", [])
+    override_keys = {
+        entry.get("source")
+        for entry in source_overrides
+        if isinstance(entry, dict)
+        and isinstance(entry.get("source"), str)
+        and isinstance(entry.get("reason"), str)
+        and entry.get("reason", "").strip()
+    }
+    allowed = {
+        "private": {"public", "team", "private"},
+        "team": {"public", "team"},
+        "public": {"public"},
+    }[audience]
+    findings: list[CheckpointFinding] = []
+    for index, item in enumerate(inputs):
+        if not isinstance(item, dict):
+            findings.append(
+                checkpoint_finding(
+                    "structure-input",
+                    "critical",
+                    "checkpoint.json",
+                    1,
+                    f"Input {index + 1} must be an object.",
+                    f"input-{index}-not-object",
+                )
+            )
+            continue
+        access = item.get("access")
+        key = checkpoint_source_key(item)
+        if access not in {"public", "team", "private", "unknown"}:
+            message = f"Input {index + 1} has no valid access classification."
+        elif access not in allowed:
+            message = f"Input {index + 1} exceeds the declared {audience} audience."
+        else:
+            continue
+        if key in override_keys:
+            continue
+        findings.append(
+            checkpoint_finding(
+                "source-access",
+                "critical",
+                "checkpoint.json",
+                1,
+                message,
+                f"{index}:{key}:{access}:{audience}",
+            )
+        )
+    return findings
+
+
+def scan_checkpoint_bundle(root: Path, audience: str) -> tuple[list[CheckpointFinding], list[dict[str, str]]]:
+    findings: list[CheckpointFinding] = []
+    files: list[dict[str, str]] = []
+    allowed_names = CHECKPOINT_REQUIRED_FILES | {CHECKPOINT_REPORT_NAME}
+    for path in sorted(root.iterdir(), key=lambda item: item.name):
+        if path.name in allowed_names:
+            continue
+        opaque_path = "unexpected-" + hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:12]
+        findings.append(
+            checkpoint_finding(
+                "structure-unexpected-entry",
+                "critical",
+                opaque_path,
+                0,
+                "Checkpoint v1 contains an unexpected file or directory; its name is redacted.",
+                path.name,
+            )
+        )
+    for required in sorted(CHECKPOINT_REQUIRED_FILES):
+        if not (root / required).is_file():
+            findings.append(
+                checkpoint_finding(
+                    "structure-required-file",
+                    "critical",
+                    required,
+                    0,
+                    "Required checkpoint file is missing.",
+                    required,
+                )
+            )
+    for path in checkpoint_file_paths(root):
+        rel = path.relative_to(root).as_posix()
+        findings.extend(scan_checkpoint_text(rel, rel))
+        if path.is_symlink():
+            findings.append(
+                checkpoint_finding(
+                    "structure-symlink",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint bundles may not contain symbolic links.",
+                    rel,
+                )
+            )
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError as exc:
+            findings.append(
+                checkpoint_finding(
+                    "structure-unreadable",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint file could not be inspected.",
+                    f"{rel}:{type(exc).__name__}",
+                )
+            )
+            continue
+        if size > CHECKPOINT_MAX_FILE_BYTES:
+            findings.append(
+                checkpoint_finding(
+                    "structure-file-size",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint file exceeds the 10 MiB safety limit.",
+                    f"{rel}:{size}",
+                )
+            )
+            continue
+        if path.suffix.lower() not in {".md", ".json"}:
+            findings.append(
+                checkpoint_finding(
+                    "structure-file-type",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint contains a non-Markdown/non-JSON file.",
+                    rel,
+                )
+            )
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            findings.append(
+                checkpoint_finding(
+                    "structure-non-text",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint file is unreadable or not UTF-8 text.",
+                    f"{rel}:{type(exc).__name__}",
+                )
+            )
+            continue
+        files.append({"path": rel, "sha256": file_sha256(path)})
+        findings.extend(scan_checkpoint_text(text, rel))
+
+    manifest_path = root / "checkpoint.json"
+    if manifest_path.is_file() and not manifest_path.is_symlink():
+        try:
+            manifest = load_json_object(manifest_path, "checkpoint manifest")
+        except SystemExit as exc:
+            findings.append(
+                checkpoint_finding(
+                    "structure-manifest-json",
+                    "critical",
+                    "checkpoint.json",
+                    1,
+                    "Checkpoint manifest is not a valid JSON object.",
+                    str(exc),
+                )
+            )
+        else:
+            findings.extend(checkpoint_source_access_findings(manifest, audience))
+    unique = {finding.finding_id: finding for finding in findings}
+    return (
+        sorted(unique.values(), key=lambda item: (item.path, item.line, item.category, item.finding_id)),
+        sorted(files, key=lambda item: item["path"]),
+    )
+
+
+def validate_checkpoint_manifest(manifest: dict[str, Any], audience: str) -> None:
+    if manifest.get("schema") != CHECKPOINT_SCHEMA:
+        raise SystemExit(f"checkpoint.json schema must be {CHECKPOINT_SCHEMA!r}")
+    if audience not in CHECKPOINT_AUDIENCES:
+        raise SystemExit("checkpoint audience must be private, team, or public")
+    project = manifest.get("project")
+    if not isinstance(project, dict) or not isinstance(project.get("slug"), str) or not project.get("slug"):
+        raise SystemExit("checkpoint.json project.slug must be a non-empty string")
+    if not SPECIALIST_NAME_RE.fullmatch(project["slug"]):
+        raise SystemExit("checkpoint.json project.slug must be lowercase hyphenated text")
+    if not isinstance(manifest.get("created_at"), str) or not manifest["created_at"].strip():
+        raise SystemExit("checkpoint.json created_at must be a non-empty string")
+    if not isinstance(manifest.get("scope"), dict):
+        raise SystemExit("checkpoint.json scope must be an object")
+    if not isinstance(manifest.get("inputs"), list):
+        raise SystemExit("checkpoint.json inputs must be an array")
+    if not isinstance(manifest.get("gaps"), list):
+        raise SystemExit("checkpoint.json gaps must be an array")
+    for index, item in enumerate(manifest["inputs"]):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json input {index + 1} must be an object")
+        for field in ("wiki", "path", "sha256", "reason", "access"):
+            if not isinstance(item.get(field), str) or not item[field].strip():
+                raise SystemExit(f"checkpoint.json input {index + 1} requires {field}")
+        if not re.fullmatch(r"[0-9a-f]{64}", item["sha256"]):
+            raise SystemExit(f"checkpoint.json input {index + 1} sha256 must be 64 lowercase hex characters")
+        source_path = item["path"]
+        if Path(source_path).is_absolute() or ".." in Path(source_path).parts:
+            raise SystemExit(f"checkpoint.json input {index + 1} path must be wiki-relative")
+    source_overrides = manifest.get("source_overrides", [])
+    if not isinstance(source_overrides, list):
+        raise SystemExit("checkpoint.json source_overrides must be an array")
+    input_keys = {checkpoint_source_key(item) for item in manifest["inputs"]}
+    for index, item in enumerate(source_overrides):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json source override {index + 1} must be an object")
+        if item.get("source") not in input_keys:
+            raise SystemExit(f"checkpoint.json source override {index + 1} names an unknown input")
+        if not isinstance(item.get("reason"), str) or not item["reason"].strip():
+            raise SystemExit(f"checkpoint.json source override {index + 1} requires a reason")
+
+
+def checkpoint_content_file_hashes(root: Path) -> list[dict[str, str]]:
+    values: list[dict[str, str]] = []
+    for path in checkpoint_file_paths(root):
+        rel = path.relative_to(root).as_posix()
+        if rel in {"checkpoint.json", CHECKPOINT_REPORT_NAME}:
+            continue
+        if path.is_symlink() or not path.is_file():
+            continue
+        values.append({"path": rel, "sha256": file_sha256(path)})
+    return sorted(values, key=lambda item: item["path"])
+
+
+def checkpoint_manifest_id(manifest: dict[str, Any]) -> str:
+    payload = dict(manifest)
+    payload.pop("checkpoint_id", None)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def checkpoint_report_id(report: dict[str, Any]) -> str:
+    payload = dict(report)
+    payload.pop("report_id", None)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def checkpoint_timestamp() -> str:
+    override = os.environ.get("LLM_WIKI_NOW")
+    if override:
+        return override
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def write_checkpoint_json(path: Path, value: dict[str, Any]) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o644)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def checkpoint_finding_json(finding: CheckpointFinding, allowed: bool) -> dict[str, Any]:
+    return {
+        "id": finding.finding_id,
+        "category": finding.category,
+        "severity": finding.severity,
+        "path": finding.path,
+        "line": finding.line,
+        "message": finding.message,
+        "status": "allowed" if allowed else "blocking",
+    }
+
+
+def validate_override_reason(reason: str | None) -> str:
+    value = (reason or "").strip()
+    if not value:
+        raise SystemExit("--override-reason is required when allowing a source or finding")
+    if len(value) > 240 or "\n" in value or "\r" in value:
+        raise SystemExit("--override-reason must be one line and no more than 240 characters")
+    if scan_checkpoint_text(value, CHECKPOINT_REPORT_NAME):
+        raise SystemExit("--override-reason itself matches a sensitive-information pattern")
+    return value
+
+
+def checkpoint_seal(args: argparse.Namespace) -> int:
+    root = Path(args.path).expanduser().resolve(strict=False)
+    if not root.is_dir():
+        raise SystemExit("checkpoint seal path must be an existing directory")
+    for name in CHECKPOINT_REQUIRED_FILES | {CHECKPOINT_REPORT_NAME}:
+        if (root / name).is_symlink():
+            raise SystemExit("checkpoint seal refuses symbolic links in the fixed bundle")
+    manifest_path = root / "checkpoint.json"
+    manifest = load_json_object(manifest_path, "checkpoint manifest")
+    validate_checkpoint_manifest(manifest, args.audience)
+
+    allowed_findings = set(args.allow_finding or [])
+    allowed_sources = set(args.allow_source or [])
+    reason: str | None = None
+    if allowed_findings or allowed_sources:
+        reason = validate_override_reason(args.override_reason)
+
+    input_keys = {
+        checkpoint_source_key(item)
+        for item in manifest.get("inputs", [])
+        if isinstance(item, dict)
+    }
+    unknown_sources = sorted(allowed_sources - input_keys)
+    if unknown_sources:
+        raise SystemExit("--allow-source names an input not present in checkpoint.json")
+    # A new seal never trusts hand-written or stale source overrides. The
+    # caller must re-authorize every retained above-audience input by exact key.
+    manifest["source_overrides"] = [
+        {"source": key, "reason": reason} for key in sorted(allowed_sources)
+    ]
+
+    manifest["audience"] = args.audience
+    manifest["files"] = checkpoint_content_file_hashes(root)
+    manifest["checkpoint_id"] = checkpoint_manifest_id(manifest)
+    write_checkpoint_json(manifest_path, manifest)
+
+    findings, scanned_files = scan_checkpoint_bundle(root, args.audience)
+    finding_ids = {finding.finding_id for finding in findings}
+    unknown_findings = sorted(allowed_findings - finding_ids)
+    if unknown_findings:
+        raise SystemExit("--allow-finding contains an unknown or stale finding ID")
+    blocking = [finding for finding in findings if finding.finding_id not in allowed_findings]
+    source_override_count = len(manifest.get("source_overrides", []))
+    status = "blocked" if blocking else (
+        "overridden" if findings or source_override_count else "passed"
+    )
+    overrides = [
+        {"finding_id": finding_id, "reason": reason}
+        for finding_id in sorted(allowed_findings)
+    ]
+    report: dict[str, Any] = {
+        "schema": CHECKPOINT_PRIVACY_SCHEMA,
+        "scanner_version": CHECKPOINT_SCANNER_VERSION,
+        "checkpoint_id": manifest["checkpoint_id"],
+        "audience": args.audience,
+        "scanned_at": checkpoint_timestamp(),
+        "status": status,
+        "files": scanned_files,
+        "findings": [
+            checkpoint_finding_json(finding, finding.finding_id in allowed_findings)
+            for finding in findings
+        ],
+        "overrides": overrides,
+        "source_override_count": source_override_count,
+    }
+    report["report_id"] = checkpoint_report_id(report)
+    write_checkpoint_json(root / CHECKPOINT_REPORT_NAME, report)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            f"Checkpoint seal: {status} ({len(scanned_files)} files, "
+            f"{len(findings)} findings, {len(overrides)} overrides)"
+        )
+        for finding in findings:
+            print(
+                f"- {finding.finding_id} {finding.category} "
+                f"{finding.path}:{finding.line} - {finding.message}"
+            )
+    return 2 if blocking else 0
+
+
+def checkpoint_verify(args: argparse.Namespace) -> int:
+    root = Path(args.path).expanduser().resolve(strict=False)
+    errors: list[str] = []
+    if not root.is_dir():
+        raise SystemExit("checkpoint verify path must be an existing directory")
+    for name in CHECKPOINT_REQUIRED_FILES | {CHECKPOINT_REPORT_NAME}:
+        if (root / name).is_symlink():
+            result = {
+                "status": "invalid",
+                "errors": ["checkpoint verify refuses symbolic links in the fixed bundle"],
+            }
+            print(json.dumps(result, indent=2, sort_keys=True) if args.json else result["errors"][0])
+            return 2
+    try:
+        manifest = load_json_object(root / "checkpoint.json", "checkpoint manifest")
+        report = load_json_object(root / CHECKPOINT_REPORT_NAME, "checkpoint privacy report")
+    except SystemExit as exc:
+        result = {"status": "invalid", "errors": [str(exc)]}
+        print(json.dumps(result, indent=2, sort_keys=True) if args.json else str(exc))
+        return 2
+    audience = manifest.get("audience")
+    try:
+        validate_checkpoint_manifest(manifest, audience)
+    except SystemExit as exc:
+        errors.append(str(exc))
+    if report.get("schema") != CHECKPOINT_PRIVACY_SCHEMA:
+        errors.append("privacy-report.json has an unsupported schema")
+    if report.get("scanner_version") != CHECKPOINT_SCANNER_VERSION:
+        errors.append("privacy-report.json scanner version is unsupported")
+    if report.get("report_id") != checkpoint_report_id(report):
+        errors.append("privacy-report.json report_id does not match its content")
+    expected_checkpoint_id = checkpoint_manifest_id(manifest)
+    if manifest.get("checkpoint_id") != expected_checkpoint_id:
+        errors.append("checkpoint.json checkpoint_id does not match its content")
+    if report.get("checkpoint_id") != manifest.get("checkpoint_id"):
+        errors.append("privacy report checkpoint_id does not match checkpoint.json")
+    if report.get("audience") != audience:
+        errors.append("privacy report audience does not match checkpoint.json")
+
+    actual_content_files = checkpoint_content_file_hashes(root)
+    if manifest.get("files") != actual_content_files:
+        errors.append("checkpoint.json generated-file hashes do not match the bundle")
+    findings, scanned_files = scan_checkpoint_bundle(root, audience) if audience in CHECKPOINT_AUDIENCES else ([], [])
+    if report.get("files") != scanned_files:
+        errors.append("privacy report file hashes do not match the bundle")
+    report_finding_ids = {
+        item.get("id") for item in report.get("findings", []) if isinstance(item, dict)
+    }
+    actual_finding_ids = {finding.finding_id for finding in findings}
+    if report_finding_ids != actual_finding_ids:
+        errors.append("privacy findings do not match a fresh scan")
+    override_rows = report.get("overrides")
+    if not isinstance(override_rows, list):
+        errors.append("privacy report overrides must be an array")
+        override_rows = []
+    override_ids: set[str] = set()
+    for index, item in enumerate(override_rows):
+        if not isinstance(item, dict) or not isinstance(item.get("finding_id"), str):
+            errors.append(f"privacy report override {index + 1} is invalid")
+            continue
+        try:
+            validate_override_reason(item.get("reason"))
+        except SystemExit:
+            errors.append(f"privacy report override {index + 1} has an invalid reason")
+            continue
+        override_ids.add(item["finding_id"])
+    if len(override_ids) != len(override_rows):
+        errors.append("privacy report overrides contain duplicate or invalid finding IDs")
+    if not override_ids.issubset(actual_finding_ids):
+        errors.append("privacy report contains an unknown or stale override")
+    expected_finding_records = [
+        checkpoint_finding_json(finding, finding.finding_id in override_ids)
+        for finding in findings
+    ]
+    if report.get("findings") != expected_finding_records:
+        errors.append("privacy report finding metadata does not match a fresh scan")
+    blocking_ids = actual_finding_ids - override_ids
+    source_override_count = len(manifest.get("source_overrides", []))
+    if report.get("source_override_count") != source_override_count:
+        errors.append("privacy report source override count does not match checkpoint.json")
+    expected_status = "blocked" if blocking_ids else (
+        "overridden" if actual_finding_ids or source_override_count else "passed"
+    )
+    if report.get("status") != expected_status:
+        errors.append("privacy report status does not match the current findings")
+    result = {
+        "schema": CHECKPOINT_PRIVACY_SCHEMA,
+        "status": "invalid" if errors else expected_status,
+        "checkpoint_id": manifest.get("checkpoint_id"),
+        "audience": audience,
+        "file_count": len(scanned_files),
+        "finding_count": len(findings),
+        "override_count": len(override_ids),
+        "source_override_count": source_override_count,
+        "finding_categories": sorted({finding.category for finding in findings}),
+        "errors": errors,
+    }
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            f"Checkpoint verify: {result['status']} ({result['file_count']} files, "
+            f"{result['finding_count']} findings, {result['override_count']} overrides)"
+        )
+        for error in errors:
+            print(f"- {error}")
+    return 2 if errors or expected_status == "blocked" else 0
+
+
+def run_checkpoint(args: argparse.Namespace) -> int:
+    handlers = {"seal": checkpoint_seal, "verify": checkpoint_verify}
+    return handlers[args.checkpoint_command](args)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="llm-wiki",
@@ -4586,6 +5297,52 @@ def build_parser() -> argparse.ArgumentParser:
     adapter_remove_parser.add_argument("--json", action="store_true", help="Print JSON.")
 
     adapter.set_defaults(func=run_adapter)
+
+    checkpoint = subparsers.add_parser(
+        "checkpoint",
+        help="Seal and verify portable Project Knowledge Checkpoints.",
+        description=(
+            "Deterministically validate, hash, privacy-scan, seal, and verify a "
+            "Project Knowledge Checkpoint generated by the agentic wiki workflow."
+        ),
+    )
+    checkpoint_sub = checkpoint.add_subparsers(dest="checkpoint_command", required=True)
+
+    checkpoint_seal_parser = checkpoint_sub.add_parser(
+        "seal", help="Finalize hashes and run the mandatory privacy scan."
+    )
+    checkpoint_seal_parser.add_argument("path", help="Checkpoint bundle directory.")
+    checkpoint_seal_parser.add_argument(
+        "--audience",
+        required=True,
+        choices=sorted(CHECKPOINT_AUDIENCES),
+        help="Declared recipient boundary for source-access validation.",
+    )
+    checkpoint_seal_parser.add_argument(
+        "--allow-finding",
+        action="append",
+        default=[],
+        help="Explicitly acknowledge one exact finding ID; repeatable.",
+    )
+    checkpoint_seal_parser.add_argument(
+        "--allow-source",
+        action="append",
+        default=[],
+        help="Explicitly retain one exact wiki:path input above the audience; repeatable.",
+    )
+    checkpoint_seal_parser.add_argument(
+        "--override-reason",
+        help="One-line reason required for any source or finding override.",
+    )
+    checkpoint_seal_parser.add_argument("--json", action="store_true", help="Print JSON.")
+
+    checkpoint_verify_parser = checkpoint_sub.add_parser(
+        "verify", help="Recheck bundle structure, hashes, and privacy attestation."
+    )
+    checkpoint_verify_parser.add_argument("path", help="Checkpoint bundle directory.")
+    checkpoint_verify_parser.add_argument("--json", action="store_true", help="Print JSON.")
+
+    checkpoint.set_defaults(func=run_checkpoint)
 
     return parser
 

--- a/claude-plugin/bin/llm-wiki
+++ b/claude-plugin/bin/llm-wiki
@@ -13,6 +13,7 @@ import datetime as dt
 import getpass
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
@@ -92,6 +93,7 @@ CHECKPOINT_REQUIRED_FILES = {
 }
 CHECKPOINT_REPORT_NAME = "privacy-report.json"
 CHECKPOINT_MAX_FILE_BYTES = 10 * 1024 * 1024
+CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO = 0.20
 
 ROOT_ALLOWED = {
     "_index.md",
@@ -4438,6 +4440,50 @@ def checkpoint_source_key(item: dict[str, Any]) -> str:
     return f"{item.get('wiki', '')}:{item.get('path', '')}"
 
 
+def checkpoint_word_count(text: str) -> int:
+    return len(re.findall(r"\b[\w][\w'-]*\b", text, flags=re.UNICODE))
+
+
+def checkpoint_coverage_metrics(root: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    inputs = manifest.get("inputs", [])
+    source_word_count = sum(
+        item.get("words", 0) for item in inputs if isinstance(item, dict)
+    )
+    knowledge_path = root / "project-knowledge.md"
+    try:
+        knowledge_text = knowledge_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        knowledge_text = ""
+    knowledge_word_count = checkpoint_word_count(knowledge_text)
+    retention_ratio = (
+        knowledge_word_count / source_word_count if source_word_count else 0.0
+    )
+    return {
+        "source_word_count": source_word_count,
+        "knowledge_word_count": knowledge_word_count,
+        "retention_ratio": round(retention_ratio, 4),
+        "minimum_retention_ratio": CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO,
+    }
+
+
+def apply_checkpoint_coverage_metrics(root: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    metrics = checkpoint_coverage_metrics(root, manifest)
+    if metrics["retention_ratio"] < CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO:
+        required_words = math.ceil(
+            metrics["source_word_count"] * CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO
+        )
+        raise SystemExit(
+            "project-knowledge.md is too thin for comprehensive mode: "
+            f"{metrics['knowledge_word_count']} words for "
+            f"{metrics['source_word_count']} selected-source words; "
+            f"write at least {required_words} words or reduce the selected scope"
+        )
+    coverage = manifest["coverage"]
+    for key, value in metrics.items():
+        coverage[key] = value
+    return metrics
+
+
 def checkpoint_source_access_findings(
     manifest: dict[str, Any], audience: str
 ) -> list[CheckpointFinding]:
@@ -4642,7 +4688,7 @@ def validate_checkpoint_manifest(manifest: dict[str, Any], audience: str) -> Non
         raise SystemExit("checkpoint.json created_at must be a non-empty string")
     if not isinstance(manifest.get("scope"), dict):
         raise SystemExit("checkpoint.json scope must be an object")
-    if not isinstance(manifest.get("inputs"), list):
+    if not isinstance(manifest.get("inputs"), list) or not manifest["inputs"]:
         raise SystemExit("checkpoint.json inputs must be an array")
     if not isinstance(manifest.get("gaps"), list):
         raise SystemExit("checkpoint.json gaps must be an array")
@@ -4652,15 +4698,59 @@ def validate_checkpoint_manifest(manifest: dict[str, Any], audience: str) -> Non
         for field in ("wiki", "path", "sha256", "reason", "access"):
             if not isinstance(item.get(field), str) or not item[field].strip():
                 raise SystemExit(f"checkpoint.json input {index + 1} requires {field}")
+        if not isinstance(item.get("words"), int) or item["words"] <= 0:
+            raise SystemExit(f"checkpoint.json input {index + 1} words must be a positive integer")
         if not re.fullmatch(r"[0-9a-f]{64}", item["sha256"]):
             raise SystemExit(f"checkpoint.json input {index + 1} sha256 must be 64 lowercase hex characters")
         source_path = item["path"]
         if Path(source_path).is_absolute() or ".." in Path(source_path).parts:
             raise SystemExit(f"checkpoint.json input {index + 1} path must be wiki-relative")
+    input_keys = [checkpoint_source_key(item) for item in manifest["inputs"]]
+    if len(set(input_keys)) != len(input_keys):
+        raise SystemExit("checkpoint.json inputs must have unique wiki:path keys")
+
+    coverage = manifest.get("coverage")
+    if not isinstance(coverage, dict):
+        raise SystemExit("checkpoint.json coverage must be an object")
+    if coverage.get("mode") != "comprehensive":
+        raise SystemExit("checkpoint.json coverage.mode must be 'comprehensive'")
+    source_word_count = sum(item["words"] for item in manifest["inputs"])
+    if coverage.get("source_word_count") != source_word_count:
+        raise SystemExit("checkpoint.json coverage.source_word_count must equal input words")
+    section_map = coverage.get("section_map")
+    if not isinstance(section_map, list) or not section_map:
+        raise SystemExit("checkpoint.json coverage.section_map must be a non-empty array")
+    mapped_sources: set[str] = set()
+    valid_input_keys = set(input_keys)
+    for index, item in enumerate(section_map):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} must be an object")
+        if not isinstance(item.get("section"), str) or not item["section"].strip():
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} requires section")
+        sources = item.get("sources")
+        if not isinstance(sources, list) or not sources:
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} requires sources")
+        if any(not isinstance(source, str) or source not in valid_input_keys for source in sources):
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} names an unknown input")
+        mapped_sources.update(sources)
+    if mapped_sources != valid_input_keys:
+        raise SystemExit("checkpoint.json coverage.section_map must account for every input")
+    omissions = coverage.get("omissions")
+    if not isinstance(omissions, list):
+        raise SystemExit("checkpoint.json coverage.omissions must be an array")
+    for index, item in enumerate(omissions):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json coverage omission {index + 1} must be an object")
+        if item.get("source") not in valid_input_keys:
+            raise SystemExit(f"checkpoint.json coverage omission {index + 1} names an unknown input")
+        for field in ("section", "reason"):
+            if not isinstance(item.get(field), str) or not item[field].strip():
+                raise SystemExit(f"checkpoint.json coverage omission {index + 1} requires {field}")
+
     source_overrides = manifest.get("source_overrides", [])
     if not isinstance(source_overrides, list):
         raise SystemExit("checkpoint.json source_overrides must be an array")
-    input_keys = {checkpoint_source_key(item) for item in manifest["inputs"]}
+    input_keys = set(input_keys)
     for index, item in enumerate(source_overrides):
         if not isinstance(item, dict):
             raise SystemExit(f"checkpoint.json source override {index + 1} must be an object")
@@ -4775,6 +4865,7 @@ def checkpoint_seal(args: argparse.Namespace) -> int:
     ]
 
     manifest["audience"] = args.audience
+    coverage_metrics = apply_checkpoint_coverage_metrics(root, manifest)
     manifest["files"] = checkpoint_content_file_hashes(root)
     manifest["checkpoint_id"] = checkpoint_manifest_id(manifest)
     write_checkpoint_json(manifest_path, manifest)
@@ -4807,6 +4898,7 @@ def checkpoint_seal(args: argparse.Namespace) -> int:
         ],
         "overrides": overrides,
         "source_override_count": source_override_count,
+        "coverage": coverage_metrics,
     }
     report["report_id"] = checkpoint_report_id(report)
     write_checkpoint_json(root / CHECKPOINT_REPORT_NAME, report)
@@ -4864,6 +4956,16 @@ def checkpoint_verify(args: argparse.Namespace) -> int:
     if report.get("audience") != audience:
         errors.append("privacy report audience does not match checkpoint.json")
 
+    coverage_metrics = checkpoint_coverage_metrics(root, manifest)
+    coverage = manifest.get("coverage", {})
+    for key, value in coverage_metrics.items():
+        if coverage.get(key) != value:
+            errors.append(f"checkpoint.json coverage {key} does not match the bundle")
+    if coverage_metrics["retention_ratio"] < CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO:
+        errors.append("project-knowledge.md is too thin for comprehensive mode")
+    if report.get("coverage") != coverage_metrics:
+        errors.append("privacy report coverage metrics do not match the bundle")
+
     actual_content_files = checkpoint_content_file_hashes(root)
     if manifest.get("files") != actual_content_files:
         errors.append("checkpoint.json generated-file hashes do not match the bundle")
@@ -4919,6 +5021,7 @@ def checkpoint_verify(args: argparse.Namespace) -> int:
         "finding_count": len(findings),
         "override_count": len(override_ids),
         "source_override_count": source_override_count,
+        "coverage": coverage_metrics,
         "finding_categories": sorted({finding.category for finding in findings}),
         "errors": errors,
     }

--- a/claude-plugin/commands/checkpoint.md
+++ b/claude-plugin/commands/checkpoint.md
@@ -41,15 +41,23 @@ Read bounded repo context: README, supplied `WHY.md`/`BRIEF.md`, ADRs,
 architecture/operations/security docs, manifests, and explicit seeds. Exclude
 `.git`, dependencies, builds, caches, env files, and arbitrary user folders.
 
-Read every active topic root and compiled-wiki index. Shortlist by goal,
-aliases, tags, entities, project references, decisions, and constraints; then
-read only selected compiled articles. Follow one support hop when a material
-claim/conflict/risk/decision requires it. Archives require
-`--include-archived`; raw bodies are not export content.
+Read active topic roots/indexes; select compiled articles and material Ideas,
+Projects, plans, and outputs by goal, aliases, decisions, and constraints.
+Follow one needed support hop. Archives require `--include-archived`; raw is not
+export content.
 
 For each input record topic, wiki-relative path, SHA-256, inclusion reason,
 confidence, `public|team|private|unknown` access, and reuse note. Record
 material exclusions and gaps.
+
+### Mandatory comprehensive coverage
+
+Default to comprehensive, not executive-summary-only. After orientation retain
+tables, requirements, alternatives, phases, operations, risks, validation, and
+gaps. Record input words; comprehensive `coverage` needs their total, every
+input mapped to a section, and reasoned omissions. Seal rejects knowledge below
+20% of selected words. This catches thinness, not quality: deduplicate or reduce
+scope rather than over-compress.
 
 ### Mandatory semantic privacy minimization
 
@@ -67,8 +75,9 @@ source or scanner override from general approval.
 
 Show exact `docs/knowledge/<slug>/` destination, audience and repo visibility,
 project packet/question, selected articles with reasons, source access,
-exclusions, gaps, coverage matrix, planned five files, and overrides. Without
-`--apply`, stop. This is the complete workflow preview, not a reduced pilot.
+input/expected handoff word counts, exclusions, gaps, section coverage matrix,
+planned five files, and overrides. Without `--apply`, stop. This is the complete
+workflow preview, not a reduced sample.
 
 Public repos require explicit `public` audience. A local/untracked or
 authoritatively private target may default to `private`; unknown visibility
@@ -83,8 +92,9 @@ destination:
 - `project-knowledge.md`: coherent synthesis in the reference's stable order;
 - `sources.md`: stable IDs and portable provenance—never absolute producer paths;
 - `checkpoint.json`: schema `llm-wiki/project-knowledge-checkpoint/v1`,
-  `checkpoint_id: pending`, created time, audience, project, scope, inputs,
-  exclusions, empty source overrides/files, and gaps.
+  `checkpoint_id: pending`, created time, audience, project, scope, inputs with
+  exact word counts, comprehensive section coverage/omissions, exclusions,
+  empty source overrides/files, and gaps.
 
 Do not hand-write `privacy-report.json`. Resolve the bundled helper and run:
 
@@ -143,6 +153,7 @@ For a repo/path, pin the exact revision and isolate one
 ## Report
 
 Report operation, absolute destination, checkpoint ID, audience, privacy and
-verification status, override count, source-topic count, and whether files
-changed. State separately that no commit, push, publication, or import occurred
-unless that distinct action was explicitly requested.
+verification status, override count, source-topic count, source words, handoff
+words, retention ratio, and whether files changed. State separately that no
+commit, push, publication, or import occurred unless that distinct action was
+explicitly requested.

--- a/claude-plugin/commands/checkpoint.md
+++ b/claude-plugin/commands/checkpoint.md
@@ -1,0 +1,148 @@
+---
+description: "Create, refresh, verify, or import a privacy-sealed cross-topic Project Knowledge Checkpoint for a repository."
+argument-hint: "create [<slug>] [--repo <path>] [--audience private|team|public] [--apply] | refresh <bundle> [--apply] | verify <bundle> | import <bundle|repo> --wiki <name>"
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(gh:*), Bash(ls:*), Bash(mkdir:*), Bash(mktemp:*), Bash(cp:*), Bash(mv:*), Bash(rm:*), Bash(date:*), Bash(python3:*), Bash(*llm-wiki:*)
+---
+
+## Your task
+
+Manage a Project Knowledge Checkpoint: a portable, privacy-sealed project
+handoff synthesized from relevant compiled knowledge across topic wikis. Read
+`skills/wiki-manager/references/checkpoints.md` before acting.
+
+This is not a topic export, raw/session dump, or Git publication command.
+`create` and `refresh` are dry-run by default. `--apply` authorizes only the
+previewed file write—not commit, push, publication, release, or import.
+
+## Resolve and parse
+
+1. Resolve HUB from `$HOME/.config/llm-wiki/config.json` using normal
+   `hub_path`/fallback rules; read `HUB/_index.md` and `HUB/wikis.json`.
+2. Parse `create`, `refresh`, `verify`, or `import`; natural “checkpoint/dump
+   this project's wiki knowledge into the repo” means `create`.
+3. For create, resolve `--repo` or `git rev-parse --show-toplevel`, symlinks,
+   revision, remote, and authoritative visibility. Never guess visibility or
+   write outside the resolved repository.
+4. Resolve the lowercase slug from an explicit value, selected wiki Project,
+   or repo name. Ask only if ambiguity changes scope.
+
+Useful flags: `--project <slug>`, primary `--wiki`, repeatable `--with <wiki>`,
+`--audience private|team|public`, `--include-archived`, repeatable
+`--allow-source <wiki:path>`, repeatable `--allow-finding <id>`, required
+`--override-reason "..."` for overrides, and `--apply`.
+
+There is no option to disable privacy scanning.
+
+## Create
+
+### Project packet and selection
+
+Read bounded repo context: README, supplied `WHY.md`/`BRIEF.md`, ADRs,
+architecture/operations/security docs, manifests, and explicit seeds. Exclude
+`.git`, dependencies, builds, caches, env files, and arbitrary user folders.
+
+Read every active topic root and compiled-wiki index. Shortlist by goal,
+aliases, tags, entities, project references, decisions, and constraints; then
+read only selected compiled articles. Follow one support hop when a material
+claim/conflict/risk/decision requires it. Archives require
+`--include-archived`; raw bodies are not export content.
+
+For each input record topic, wiki-relative path, SHA-256, inclusion reason,
+confidence, `public|team|private|unknown` access, and reuse note. Record
+material exclusions and gaps.
+
+### Mandatory semantic privacy minimization
+
+Classify every input before synthesis; unknown or above-audience inputs fail
+closed. Exclude raw bodies, sessions/transcripts/events/prompts/feedback,
+credentials/cookies/tokens/keys, home paths/usernames/hosts/IPs/temp paths,
+adapter artifacts/data-plane locators, personal records, and confidential
+repo/organization detail outside the audience. Summarize only what recipients
+need; the deterministic scanner cannot detect every confidential decision.
+
+`--allow-source` must name the exact source and include a reason. Never infer a
+source or scanner override from general approval.
+
+### Preview
+
+Show exact `docs/knowledge/<slug>/` destination, audience and repo visibility,
+project packet/question, selected articles with reasons, source access,
+exclusions, gaps, coverage matrix, planned five files, and overrides. Without
+`--apply`, stop. This is the complete workflow preview, not a reduced pilot.
+
+Public repos require explicit `public` audience. A local/untracked or
+authoritatively private target may default to `private`; unknown visibility
+must stop before final copy.
+
+### Stage, seal, and copy
+
+With `--apply`, generate in a private temporary directory outside the tracked
+destination:
+
+- `index.md`: entry point, audience, trust, revision, verification/import use;
+- `project-knowledge.md`: coherent synthesis in the reference's stable order;
+- `sources.md`: stable IDs and portable provenance—never absolute producer paths;
+- `checkpoint.json`: schema `llm-wiki/project-knowledge-checkpoint/v1`,
+  `checkpoint_id: pending`, created time, audience, project, scope, inputs,
+  exclusions, empty source overrides/files, and gaps.
+
+Do not hand-write `privacy-report.json`. Resolve the bundled helper and run:
+
+```bash
+llm-wiki checkpoint seal <staging> --audience <audience> --json
+llm-wiki checkpoint verify <staging> --json
+```
+
+Forward explicit source/finding overrides and reason to `seal`. It validates
+the fixed bundle, hashes files, writes checkpoint ID and
+`privacy-report.json`, and scans filenames/content for credentials, identities,
+local paths/network data, session metadata, and prompt markers without
+printing matches.
+
+On findings, show only category, opaque/relative path, line, message, and ID;
+stop before final copy. The user may remove the value or name each exact
+finding plus a reason. Seal reruns and records `overridden`, never `passed`.
+There is no blanket or stale-ID bypass.
+
+After successful staging verification:
+
+1. Refuse an existing destination unless refresh/replacement was previewed.
+2. Copy all five files to the exact destination.
+3. Verify the destination again.
+4. On failure, remove the new copy or restore the backup.
+5. Append a content-free operation entry to the selected topic log, otherwise
+   the hub log. Never log source paths or findings.
+
+## Refresh
+
+Verify first. Re-run stored scope and show sources/claims/decisions/gaps/privacy
+added, removed, or changed. Detect human edits from attested hashes and never
+silently overwrite them; offer staged regeneration, manual merge, or a new
+destination. Preserve stable source IDs, then use the same seal/copy/verify
+sequence. Without `--apply`, stop after the diff.
+
+## Verify
+
+Run `llm-wiki checkpoint verify <bundle> --json` read-only. Report checkpoint
+ID, audience, integrity, `passed|overridden|blocked`, file count, categories,
+and override counts—never matched values.
+
+## Import
+
+For a repo/path, pin the exact revision and isolate one
+`docs/knowledge/<slug>/` bundle. Verify before reading:
+
+- reject invalid hashes, missing attestation, or `blocked`;
+- show `overridden` categories/IDs and require recipient acceptance;
+- ingest the five files through bounded collection provenance;
+- preserve checkpoint ID, audience, source IDs, trust, and staleness;
+- dedupe by checkpoint ID, then path/content hash; and
+- treat imports as source evidence, never overwrite/promote local articles,
+  Projects, or prior snapshots automatically.
+
+## Report
+
+Report operation, absolute destination, checkpoint ID, audience, privacy and
+verification status, override count, source-topic count, and whether files
+changed. State separately that no commit, push, publication, or import occurred
+unless that distinct action was explicitly requested.

--- a/claude-plugin/commands/wiki.md
+++ b/claude-plugin/commands/wiki.md
@@ -129,6 +129,7 @@ The user typed something that isn't a known keyword. Detect their intent and rou
 | 0a.0b | **Skill Factory Adapter** | Starts with `wiki skill-factory`, `skill-factory`, or explicitly says "use the skill-factory adapter" | `Skill: wiki:adapter` with explicit named adapter `skill-factory`; run show/doctor, read its guide, and keep every generated candidate disabled |
 | 0a.1 | **Private Adapter** | "private adapter", "registered adapter", "adapter add", "adapter list", "adapter doctor", "adapter run", "use the <name> adapter", or an explicit request to register/invoke an external local llm-wiki adapter; do not match `ingest-collection --adapter` | `Skill: wiki:adapter` with the management/run arguments |
 | 0a.1b | **Personal Specialist** | "specialist skill", "specialist agent", "expert reviewer", "expert lens", "personal skill", "local skill", "specialist create/list/show/validate/enable/disable/suggest/apply", or a request to use a named specialist method | `Skill: wiki:specialist` with the management, suggestion, or apply arguments |
+| 0a.1c | **Project Knowledge Checkpoint** | "project knowledge checkpoint", "knowledge checkpoint", "knowledge handoff", "export project knowledge", "dump wiki knowledge into the repo", "checkpoint this project", "refresh checkpoint", "verify checkpoint", or "import checkpoint" | `Skill: wiki:checkpoint`; create/refresh are dry-run by default and always use the mandatory semantic privacy review plus deterministic seal/verify gate |
 | 0a.2 | **Collection Ingest** | Words: "import wiki", "mirror wiki", "bulk ingest", "ingest collection", "import collection", "ingest repo", "import repo"; or a URL/path plus collection signals: `dump.xml`, `.xml.bz2`, `.xml.gz`, `api.php`, `MediaWiki`, `github.com/*/*` with "all", "repo", "docs", "BIPs", or "collection" | `Skill: wiki:ingest-collection` with the source and filters |
 | 0b | **Collect** | "collect", "collector", "catalog", "curate", "gather examples", "find all", "make a list of", "inventory all", "find and inventory", "collect and inventory"; especially with object words like "memes", "tools", "projects", "examples", "companies", "people", "quotes", "assets", "images", "videos", "screenshots" | `Skill: wiki:collect` |
 | 0c | **Idea (promote)** | "turn this idea into a project", "make this a project", "promote this idea", "approve the brief", "commit to this idea", "use the narrow/minimal/selected version" plus "project/build/ship" | `Skill: wiki:idea` with `promote` and the approved choice |
@@ -197,6 +198,12 @@ The user typed something that isn't a known keyword. Detect their intent and rou
   run doctor, and follow its own guide without inventing a URL route. Its output
   is a disabled external candidate. Never install, enable, commit, or publish a
   generated package as part of the factory run.
+- Project Knowledge Checkpoint signals outrank generic output, project, and
+  collection-ingest signals. A checkpoint is a cross-topic, project-shaped
+  handoff, not a report in one wiki. `create` and `refresh` preview by default;
+  writing requires `--apply`, every written bundle must be sealed and verified,
+  and no request can disable the privacy scan. A general approval never implies
+  a sensitive-source or scanner-finding override.
 - Collect signals outrank plain inventory and research when the user asks to
   discover many objects before tracking them. For example, "collect and
   inventory all bitcoin memes" routes to collect, which writes a bounded

--- a/claude-plugin/skills/wiki-manager/SKILL.md
+++ b/claude-plugin/skills/wiki-manager/SKILL.md
@@ -7,6 +7,7 @@ description: >
   outputs. Activates for /wiki commands; wiki or knowledge-base work; ingest,
   collect, catalog, compile, query, audit, librarian, inventory, idea,
   portfolio, business ideas, projects, datasets, archives, sessions, feedback,
+  checkpoints,
   private adapters, adapter routing, explicit wiki skill-factory requests,
   personal specialist skills, expert review,
   specialist selection, provenance, external resource actions, or questions in a directory
@@ -110,6 +111,10 @@ enabled per active topic. Loading one never grants tools, write access, professi
 authority, or permission to spawn agents. Select the minimum useful method,
 preserve disagreement, and record its version/hash. See
 [references/specialists.md](references/specialists.md).
+
+15. **Project checkpoints are privacy-sealed.** Never dump raw/sessions; seal
+and exact overrides are required. See
+[references/checkpoints.md](references/checkpoints.md).
 
 ## Adapter Routing
 

--- a/claude-plugin/skills/wiki-manager/SKILL.md
+++ b/claude-plugin/skills/wiki-manager/SKILL.md
@@ -112,8 +112,7 @@ authority, or permission to spawn agents. Select the minimum useful method,
 preserve disagreement, and record its version/hash. See
 [references/specialists.md](references/specialists.md).
 
-15. **Project checkpoints are privacy-sealed.** Never dump raw/sessions; seal
-and exact overrides are required. See
+15. **Project checkpoints need comprehensive coverage and a privacy seal.** See
 [references/checkpoints.md](references/checkpoints.md).
 
 ## Adapter Routing

--- a/claude-plugin/skills/wiki-manager/references/checkpoints.md
+++ b/claude-plugin/skills/wiki-manager/references/checkpoints.md
@@ -16,7 +16,7 @@ docs/knowledge/<project-slug>/
 ```
 
 - `index.md`: portable entry point and import/verification guidance.
-- `project-knowledge.md`: coherent new synthesis.
+- `project-knowledge.md`: full synthesis.
 - `sources.md`: readable evidence ledger with stable source IDs.
 - `checkpoint.json`: scope, project revision, selected inputs/reasons/hashes,
   exclusions, gaps, audience, generated hashes, and checkpoint identity.
@@ -36,15 +36,17 @@ question, aliases, README, supplied `WHY.md`/`BRIEF.md`, ADRs, architecture and
 operations/security docs, and explicit seeds. Do not scan `.git`, dependencies,
 builds, caches, env files, or arbitrary user directories.
 
-Read HUB index/registry, then every active topic root and `wiki/_index.md`.
-Shortlist by goal, titles, summaries, aliases, tags, entities, decisions,
-constraints, and project references. Read only selected compiled articles;
-follow one supporting hop when an important claim, conflict, risk, or decision
-needs it. Archives require explicit inclusion. Raw bodies are not export data.
+Read HUB/indexes and selected compiled/Idea/Project/plan/output material; one
+support hop is allowed. Archives are explicit; raw is excluded. Record
+topic/path/hash/words, reason, confidence, access/reuse, exclusions/gaps.
 
-Record for every input: origin topic, wiki-relative path, SHA-256, selection
-reason, confidence, `public|team|private|unknown` access, and reuse note. Record
-material exclusions and gaps so “most relevant” stays auditable.
+## Comprehensive coverage contract
+
+Default to comprehensive, not executive-summary-only. Retain tables,
+requirements, alternatives, phases, workflows, rights, risks, and gaps. Every
+input needs positive `words` and a mapped section; `coverage` stores the total
+and omissions. Seal rejects knowledge below 20% of selected
+words. The floor is not a quality score.
 
 `project-knowledge.md` keeps this order:
 
@@ -126,7 +128,7 @@ explicit `public`; unknown visibility stops before final copy.
 
 `checkpoint.json` uses `llm-wiki/project-knowledge-checkpoint/v1`: sealer ID,
 files/hashes, time/audience, project/revision, scope/policy, inputs with
-topic/path/hash/reason/access, exact overrides, exclusions, and gaps.
+topic/path/hash/words/reason/access, coverage, overrides, exclusions, and gaps.
 
 Paths are bundle-, repo-, or wiki-relative. Never serialize a hub/home root,
 transcript pointer, adapter root, or temporary path.

--- a/claude-plugin/skills/wiki-manager/references/checkpoints.md
+++ b/claude-plugin/skills/wiki-manager/references/checkpoints.md
@@ -1,0 +1,154 @@
+# Project Knowledge Checkpoints
+
+A checkpoint is a portable snapshot of what a teammate needs to understand,
+build, operate, or import one project. It is a curated materialized view across
+active topic wikis—not a topic, raw-source, or session dump.
+
+## Bundle and operations
+
+```text
+docs/knowledge/<project-slug>/
+├── index.md
+├── project-knowledge.md
+├── sources.md
+├── checkpoint.json
+└── privacy-report.json
+```
+
+- `index.md`: portable entry point and import/verification guidance.
+- `project-knowledge.md`: coherent new synthesis.
+- `sources.md`: readable evidence ledger with stable source IDs.
+- `checkpoint.json`: scope, project revision, selected inputs/reasons/hashes,
+  exclusions, gaps, audience, generated hashes, and checkpoint identity.
+- `privacy-report.json`: deterministic file-hash and privacy attestation. The
+  agent never hand-writes it, and it never contains matched excerpts.
+
+Operations are `create` (discover/synthesize), `refresh` (review diffs),
+`verify` (read-only checks), and `import` (pinned evidence, not truth).
+
+Create/refresh are dry-run first. `--apply` grants only the previewed file
+write; commit, push, publication, release, and import remain separate.
+
+## Selection and synthesis
+
+Start from a bounded project packet: exact repo/revision, goal, audience,
+question, aliases, README, supplied `WHY.md`/`BRIEF.md`, ADRs, architecture and
+operations/security docs, and explicit seeds. Do not scan `.git`, dependencies,
+builds, caches, env files, or arbitrary user directories.
+
+Read HUB index/registry, then every active topic root and `wiki/_index.md`.
+Shortlist by goal, titles, summaries, aliases, tags, entities, decisions,
+constraints, and project references. Read only selected compiled articles;
+follow one supporting hop when an important claim, conflict, risk, or decision
+needs it. Archives require explicit inclusion. Raw bodies are not export data.
+
+Record for every input: origin topic, wiki-relative path, SHA-256, selection
+reason, confidence, `public|team|private|unknown` access, and reuse note. Record
+material exclusions and gaps so “most relevant” stays auditable.
+
+`project-knowledge.md` keeps this order:
+
+1. purpose, audience, current state;
+2. project/system map;
+3. decisions and rejected alternatives;
+4. facts, assumptions, and evidence strength;
+5. requirements, constraints, non-goals;
+6. development and operating workflows;
+7. risks, failure modes, privacy/security boundaries;
+8. terminology and important entities;
+9. disagreement, unknowns, gaps;
+10. next experiments/actions; and
+11. scope, trust, refresh instructions.
+
+Use stable source IDs for material claims. Distinguish source facts, user
+decisions, hypotheses, and recommendations. Never concatenate articles or
+promise completeness beyond the selection method.
+
+## Mandatory privacy gate
+
+Privacy has two layers; neither may be skipped.
+
+### Semantic minimization
+
+Classify every input before synthesis. `unknown` fails closed; an input above
+the declared audience requires explicit exact-source approval. Exclude by
+default:
+
+- raw bodies, copied paywalled/licensed text, and unverified private evidence;
+- sessions, transcripts, event logs, prompts, feedback, and chat text;
+- home paths, usernames, hostnames, local IPs, mounts, and temp paths;
+- credentials, keys, tokens, cookies, connection strings, and secrets;
+- private-adapter code, requests, receipts, artifacts, and data-plane paths;
+- customer, health, legal, financial, or other personal records; and
+- internal URLs, repos, issues, organization detail, or identifiers outside
+  the audience.
+
+Summarize only what recipients need. A scanner cannot recognize every
+confidential decision, so semantic review remains mandatory even after a pass.
+
+### Deterministic seal
+
+Generate in private staging, then run the bundled helper:
+
+```bash
+llm-wiki checkpoint seal <bundle> --audience private|team|public --json
+llm-wiki checkpoint verify <bundle> --json
+```
+
+Seal enforces the fixed UTF-8 Markdown/JSON bundle, computes file hashes and
+checkpoint ID, scans names/content, and writes `privacy-report.json`. It covers
+likely secrets, credentials, identities, local paths/network data,
+session/transcript metadata, and prompt/conversation markers. Reports contain
+only category, safe/opaque relative path, line, message, and stable finding ID.
+
+There is no `--no-scan` or global bypass. Intentional retention requires every
+exact current finding/source ID plus a one-line reason:
+
+```bash
+llm-wiki checkpoint seal <bundle> --audience team \
+  --allow-finding privacy-<id> \
+  --override-reason "Public attribution handle"
+```
+
+The scan reruns and reports `overridden`, not `passed`. Never infer an override
+from general approval. IDs are content/line-bound; changed or stale values need
+review again. Source overrides are likewise exact and attested.
+
+Blocked staging must not reach the final repo. After a passed/overridden seal,
+copy the complete five files and verify the destination. On failure remove the
+new copy or restore its backup. Never commit staging.
+
+## Audience and manifest
+
+Audience is `private`, `team`, or `public`. Default `private` only for
+local/untracked or authoritatively private destinations. Public repos require
+explicit `public`; unknown visibility stops before final copy.
+
+`checkpoint.json` uses `llm-wiki/project-knowledge-checkpoint/v1`: sealer ID,
+files/hashes, time/audience, project/revision, scope/policy, inputs with
+topic/path/hash/reason/access, exact overrides, exclusions, and gaps.
+
+Paths are bundle-, repo-, or wiki-relative. Never serialize a hub/home root,
+transcript pointer, adapter root, or temporary path.
+
+## Refresh
+
+Verify first, rerun stored scope, preserve logical source IDs, and show:
+
+- sources/claims added, removed, or changed;
+- decisions/constraints changed;
+- gaps opened/closed; and
+- privacy findings/overrides changed.
+
+Attested hash differences reveal human edits. Never overwrite silently; offer
+staged regeneration, manual merge, or a new path, then seal and verify again.
+
+## Import
+
+Verify before reading/importing. Reject invalid hashes, missing attestation, or
+`blocked`; show `overridden` IDs/categories and require recipient acceptance.
+For repos, isolate the bundle at the exact producing revision.
+
+Ingest all five files as one bounded collection; preserve checkpoint ID,
+audience, source IDs, trust, and staleness; dedupe by ID then path/hash.
+Imported synthesis never overwrites Projects, articles, or prior snapshots.

--- a/claude-plugin/skills/wiki-manager/references/projects.md
+++ b/claude-plugin/skills/wiki-manager/references/projects.md
@@ -7,6 +7,12 @@ shaped Idea in `inventory/ideas/`. See [ideas.md](ideas.md). Direct Projects
 remain appropriate for maintenance, migrations, incident response, and other
 work that does not benefit from an incubation step.
 
+A Project folder is not a portable knowledge export. When teammates need the
+relevant knowledge from multiple topic wikis inside a working repository, use
+the privacy-sealed [Project Knowledge Checkpoint](checkpoints.md) workflow. The
+Project keeps delivery truth; the checkpoint is a reviewable snapshot for
+handoff/import and never becomes a second live Project state store.
+
 The read-only [Portfolio workflow](portfolio.md) lists Projects across active
 topic wikis and distinguishes explicitly promoted Projects from direct ones.
 

--- a/plugins/llm-wiki-opencode/bin/llm-wiki
+++ b/plugins/llm-wiki-opencode/bin/llm-wiki
@@ -80,6 +80,18 @@ SPECIALIST_REQUIRED_SECTIONS = [
     "Evaluation cases",
     "Provenance and maintenance",
 ]
+CHECKPOINT_SCHEMA = "llm-wiki/project-knowledge-checkpoint/v1"
+CHECKPOINT_PRIVACY_SCHEMA = "llm-wiki/checkpoint-privacy-report/v1"
+CHECKPOINT_SCANNER_VERSION = 1
+CHECKPOINT_AUDIENCES = {"private", "team", "public"}
+CHECKPOINT_REQUIRED_FILES = {
+    "index.md",
+    "project-knowledge.md",
+    "sources.md",
+    "checkpoint.json",
+}
+CHECKPOINT_REPORT_NAME = "privacy-report.json"
+CHECKPOINT_MAX_FILE_BYTES = 10 * 1024 * 1024
 
 ROOT_ALLOWED = {
     "_index.md",
@@ -149,6 +161,16 @@ class Document:
     path: Path
     frontmatter: dict[str, Any]
     body: str
+
+
+@dataclass(frozen=True)
+class CheckpointFinding:
+    finding_id: str
+    category: str
+    severity: str
+    path: str
+    line: int
+    message: str
 
 
 class LintContext:
@@ -4228,6 +4250,695 @@ def run_adapter(args: argparse.Namespace) -> int:
     return handlers[args.adapter_command](args)
 
 
+def checkpoint_pattern_specs() -> list[tuple[str, str, str, re.Pattern[str]]]:
+    flags = re.IGNORECASE | re.MULTILINE
+    return [
+        (
+            "secret-private-key",
+            "critical",
+            "Possible private-key material.",
+            re.compile(
+                r"-----BEGIN (?:(?:[A-Z0-9 ]+ )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----",
+                flags,
+            ),
+        ),
+        (
+            "secret-known-token",
+            "critical",
+            "Possible service credential or bearer token.",
+            re.compile(
+                r"(?:\bAKIA[0-9A-Z]{16}\b|\bgh[pousr]_[A-Za-z0-9]{20,}\b|"
+                r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b|\bsk-[A-Za-z0-9_-]{16,}\b|"
+                r"\bAIza[0-9A-Za-z_-]{25,}\b|\bBearer\s+[A-Za-z0-9._~+/=-]{12,}|"
+                r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b)",
+                flags,
+            ),
+        ),
+        (
+            "secret-assignment",
+            "critical",
+            "Possible credential assigned to a sensitive field.",
+            re.compile(
+                r"\b(?:api[_-]?key|private[_-]?key|(?:access|auth|api|refresh)?[_-]?token|"
+                r"client[_-]?secret|password|passwd|secret|session[_-]?cookie)\b"
+                r"\s*[\"']?\s*[:=]\s*"
+                r"[\"']?[A-Za-z0-9_./+=$~-]{8,}",
+                flags,
+            ),
+        ),
+        (
+            "secret-url-credentials",
+            "critical",
+            "Possible username/password embedded in a URL.",
+            re.compile(r"\b[a-z][a-z0-9+.-]*://[^\s/@:]+:[^\s/@]+@", flags),
+        ),
+        (
+            "personal-email",
+            "warning",
+            "Email address may identify a person or private account.",
+            re.compile(r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
+        ),
+        (
+            "personal-account-field",
+            "warning",
+            "Account or username field may expose an identity.",
+            re.compile(
+                r"^[ \t]*[\"']?(?:user(?:name)?|login|account(?:[_-]?name)?|handle)"
+                r"[\"']?[ \t]*[:=][ \t]*[\"']?@?[A-Za-z0-9_.-]{2,}",
+                flags,
+            ),
+        ),
+        (
+            "local-home-path",
+            "critical",
+            "Machine-local home directory path.",
+            re.compile(
+                r"(?:(?<![:A-Za-z0-9])/Users/[A-Za-z0-9._-]+(?:/|\b)|"
+                r"(?<![:A-Za-z0-9])/home/[A-Za-z0-9._-]+(?:/|\b)|"
+                r"(?<![:A-Za-z0-9])/root(?:/|\b)|[A-Za-z]:\\Users\\[A-Za-z0-9._ -]+(?:\\|\b))",
+                flags,
+            ),
+        ),
+        (
+            "local-machine-path",
+            "critical",
+            "Machine-local volume, temporary, or file URL path.",
+            re.compile(
+                r"(?:file://|(?:~|\$HOME|\$\{HOME\})/|(?<![:A-Za-z0-9])/Volumes/[^\s/]+(?:/|\b)|"
+                r"(?<![:A-Za-z0-9])/private/var/folders/|(?<![:A-Za-z0-9])/(?:tmp|var|etc|opt|srv|mnt|media|workspace|Applications|Library)/[^\s`\"']+)",
+                flags,
+            ),
+        ),
+        (
+            "remote-login-identity",
+            "warning",
+            "Remote-login syntax may expose a username or private host.",
+            re.compile(r"\b(?:ssh|scp|sftp|rsync)\b[^\n]*\b[A-Za-z0-9._-]+@[A-Za-z0-9._-]+", flags),
+        ),
+        (
+            "local-network-address",
+            "warning",
+            "Private-network address may reveal local infrastructure.",
+            re.compile(
+                r"\b(?:10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|"
+                r"172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2})\b"
+            ),
+        ),
+        (
+            "local-hostname",
+            "warning",
+            "Local hostname may reveal private infrastructure.",
+            re.compile(
+                r"(?:\b[A-Za-z0-9][A-Za-z0-9-]{0,62}\.local\b|"
+                r"\b[A-Za-z0-9][A-Za-z0-9.-]{0,126}\.(?:lan|internal)\b|"
+                r"^[ \t]*[\"']?hostname[\"']?[ \t]*[:=][ \t]*[\"']?[^\s\"']+)",
+                flags,
+            ),
+        ),
+        (
+            "session-transcript",
+            "critical",
+            "Session or transcript metadata must not enter a checkpoint.",
+            re.compile(
+                r"(?:transcript[_-]?path|rollout-[^\s]+\.jsonl|\.sessions/(?:digests|feedback)/|"
+                r"\b(?:codex|claude):[0-9a-f]{8}-[0-9a-f-]{27,}\b|UserPromptSubmit|PreCompact|PostCompact)",
+                flags,
+            ),
+        ),
+        (
+            "prompt-conversation-role",
+            "warning",
+            "Conversation-role content may be copied prompt or transcript text.",
+            re.compile(
+                r"(?:^[ \t]*(?:system|developer|assistant|user)[ \t]*:[ \t]+\S|"
+                r"[\"']role[\"'][ \t]*:[ \t]*[\"'](?:system|developer|assistant|user)[\"'])",
+                flags,
+            ),
+        ),
+        (
+            "prompt-instruction-marker",
+            "warning",
+            "Prompt/instruction marker may expose agent instructions.",
+            re.compile(
+                r"(?:<\|(?:system|user|assistant)\|>|\[INST\]|</?system>|"
+                r"AGENTS\.md instructions for|(?:system|developer) prompt[ \t]*:)",
+                flags,
+            ),
+        ),
+    ]
+
+
+def checkpoint_finding(
+    category: str,
+    severity: str,
+    path: str,
+    line: int,
+    message: str,
+    evidence: str,
+) -> CheckpointFinding:
+    digest = hashlib.sha256(
+        "\0".join([category, path, str(line), evidence]).encode("utf-8")
+    ).hexdigest()[:16]
+    return CheckpointFinding(
+        finding_id=f"privacy-{digest}",
+        category=category,
+        severity=severity,
+        path=path,
+        line=line,
+        message=message,
+    )
+
+
+def scan_checkpoint_text(text: str, rel: str) -> list[CheckpointFinding]:
+    findings: list[CheckpointFinding] = []
+    for category, severity, message, pattern in checkpoint_pattern_specs():
+        for match in pattern.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            findings.append(
+                checkpoint_finding(
+                    category,
+                    severity,
+                    rel,
+                    line,
+                    message,
+                    match.group(0),
+                )
+            )
+    return findings
+
+
+def checkpoint_file_paths(root: Path, include_report: bool = False) -> list[Path]:
+    names = set(CHECKPOINT_REQUIRED_FILES)
+    if include_report:
+        names.add(CHECKPOINT_REPORT_NAME)
+    return [root / name for name in sorted(names) if (root / name).exists() or (root / name).is_symlink()]
+
+
+def checkpoint_source_key(item: dict[str, Any]) -> str:
+    return f"{item.get('wiki', '')}:{item.get('path', '')}"
+
+
+def checkpoint_source_access_findings(
+    manifest: dict[str, Any], audience: str
+) -> list[CheckpointFinding]:
+    inputs = manifest.get("inputs")
+    if not isinstance(inputs, list):
+        return [
+            checkpoint_finding(
+                "structure-inputs",
+                "critical",
+                "checkpoint.json",
+                1,
+                "Manifest inputs must be an array.",
+                "inputs-not-array",
+            )
+        ]
+    source_overrides = manifest.get("source_overrides", [])
+    override_keys = {
+        entry.get("source")
+        for entry in source_overrides
+        if isinstance(entry, dict)
+        and isinstance(entry.get("source"), str)
+        and isinstance(entry.get("reason"), str)
+        and entry.get("reason", "").strip()
+    }
+    allowed = {
+        "private": {"public", "team", "private"},
+        "team": {"public", "team"},
+        "public": {"public"},
+    }[audience]
+    findings: list[CheckpointFinding] = []
+    for index, item in enumerate(inputs):
+        if not isinstance(item, dict):
+            findings.append(
+                checkpoint_finding(
+                    "structure-input",
+                    "critical",
+                    "checkpoint.json",
+                    1,
+                    f"Input {index + 1} must be an object.",
+                    f"input-{index}-not-object",
+                )
+            )
+            continue
+        access = item.get("access")
+        key = checkpoint_source_key(item)
+        if access not in {"public", "team", "private", "unknown"}:
+            message = f"Input {index + 1} has no valid access classification."
+        elif access not in allowed:
+            message = f"Input {index + 1} exceeds the declared {audience} audience."
+        else:
+            continue
+        if key in override_keys:
+            continue
+        findings.append(
+            checkpoint_finding(
+                "source-access",
+                "critical",
+                "checkpoint.json",
+                1,
+                message,
+                f"{index}:{key}:{access}:{audience}",
+            )
+        )
+    return findings
+
+
+def scan_checkpoint_bundle(root: Path, audience: str) -> tuple[list[CheckpointFinding], list[dict[str, str]]]:
+    findings: list[CheckpointFinding] = []
+    files: list[dict[str, str]] = []
+    allowed_names = CHECKPOINT_REQUIRED_FILES | {CHECKPOINT_REPORT_NAME}
+    for path in sorted(root.iterdir(), key=lambda item: item.name):
+        if path.name in allowed_names:
+            continue
+        opaque_path = "unexpected-" + hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:12]
+        findings.append(
+            checkpoint_finding(
+                "structure-unexpected-entry",
+                "critical",
+                opaque_path,
+                0,
+                "Checkpoint v1 contains an unexpected file or directory; its name is redacted.",
+                path.name,
+            )
+        )
+    for required in sorted(CHECKPOINT_REQUIRED_FILES):
+        if not (root / required).is_file():
+            findings.append(
+                checkpoint_finding(
+                    "structure-required-file",
+                    "critical",
+                    required,
+                    0,
+                    "Required checkpoint file is missing.",
+                    required,
+                )
+            )
+    for path in checkpoint_file_paths(root):
+        rel = path.relative_to(root).as_posix()
+        findings.extend(scan_checkpoint_text(rel, rel))
+        if path.is_symlink():
+            findings.append(
+                checkpoint_finding(
+                    "structure-symlink",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint bundles may not contain symbolic links.",
+                    rel,
+                )
+            )
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError as exc:
+            findings.append(
+                checkpoint_finding(
+                    "structure-unreadable",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint file could not be inspected.",
+                    f"{rel}:{type(exc).__name__}",
+                )
+            )
+            continue
+        if size > CHECKPOINT_MAX_FILE_BYTES:
+            findings.append(
+                checkpoint_finding(
+                    "structure-file-size",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint file exceeds the 10 MiB safety limit.",
+                    f"{rel}:{size}",
+                )
+            )
+            continue
+        if path.suffix.lower() not in {".md", ".json"}:
+            findings.append(
+                checkpoint_finding(
+                    "structure-file-type",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint contains a non-Markdown/non-JSON file.",
+                    rel,
+                )
+            )
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            findings.append(
+                checkpoint_finding(
+                    "structure-non-text",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint file is unreadable or not UTF-8 text.",
+                    f"{rel}:{type(exc).__name__}",
+                )
+            )
+            continue
+        files.append({"path": rel, "sha256": file_sha256(path)})
+        findings.extend(scan_checkpoint_text(text, rel))
+
+    manifest_path = root / "checkpoint.json"
+    if manifest_path.is_file() and not manifest_path.is_symlink():
+        try:
+            manifest = load_json_object(manifest_path, "checkpoint manifest")
+        except SystemExit as exc:
+            findings.append(
+                checkpoint_finding(
+                    "structure-manifest-json",
+                    "critical",
+                    "checkpoint.json",
+                    1,
+                    "Checkpoint manifest is not a valid JSON object.",
+                    str(exc),
+                )
+            )
+        else:
+            findings.extend(checkpoint_source_access_findings(manifest, audience))
+    unique = {finding.finding_id: finding for finding in findings}
+    return (
+        sorted(unique.values(), key=lambda item: (item.path, item.line, item.category, item.finding_id)),
+        sorted(files, key=lambda item: item["path"]),
+    )
+
+
+def validate_checkpoint_manifest(manifest: dict[str, Any], audience: str) -> None:
+    if manifest.get("schema") != CHECKPOINT_SCHEMA:
+        raise SystemExit(f"checkpoint.json schema must be {CHECKPOINT_SCHEMA!r}")
+    if audience not in CHECKPOINT_AUDIENCES:
+        raise SystemExit("checkpoint audience must be private, team, or public")
+    project = manifest.get("project")
+    if not isinstance(project, dict) or not isinstance(project.get("slug"), str) or not project.get("slug"):
+        raise SystemExit("checkpoint.json project.slug must be a non-empty string")
+    if not SPECIALIST_NAME_RE.fullmatch(project["slug"]):
+        raise SystemExit("checkpoint.json project.slug must be lowercase hyphenated text")
+    if not isinstance(manifest.get("created_at"), str) or not manifest["created_at"].strip():
+        raise SystemExit("checkpoint.json created_at must be a non-empty string")
+    if not isinstance(manifest.get("scope"), dict):
+        raise SystemExit("checkpoint.json scope must be an object")
+    if not isinstance(manifest.get("inputs"), list):
+        raise SystemExit("checkpoint.json inputs must be an array")
+    if not isinstance(manifest.get("gaps"), list):
+        raise SystemExit("checkpoint.json gaps must be an array")
+    for index, item in enumerate(manifest["inputs"]):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json input {index + 1} must be an object")
+        for field in ("wiki", "path", "sha256", "reason", "access"):
+            if not isinstance(item.get(field), str) or not item[field].strip():
+                raise SystemExit(f"checkpoint.json input {index + 1} requires {field}")
+        if not re.fullmatch(r"[0-9a-f]{64}", item["sha256"]):
+            raise SystemExit(f"checkpoint.json input {index + 1} sha256 must be 64 lowercase hex characters")
+        source_path = item["path"]
+        if Path(source_path).is_absolute() or ".." in Path(source_path).parts:
+            raise SystemExit(f"checkpoint.json input {index + 1} path must be wiki-relative")
+    source_overrides = manifest.get("source_overrides", [])
+    if not isinstance(source_overrides, list):
+        raise SystemExit("checkpoint.json source_overrides must be an array")
+    input_keys = {checkpoint_source_key(item) for item in manifest["inputs"]}
+    for index, item in enumerate(source_overrides):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json source override {index + 1} must be an object")
+        if item.get("source") not in input_keys:
+            raise SystemExit(f"checkpoint.json source override {index + 1} names an unknown input")
+        if not isinstance(item.get("reason"), str) or not item["reason"].strip():
+            raise SystemExit(f"checkpoint.json source override {index + 1} requires a reason")
+
+
+def checkpoint_content_file_hashes(root: Path) -> list[dict[str, str]]:
+    values: list[dict[str, str]] = []
+    for path in checkpoint_file_paths(root):
+        rel = path.relative_to(root).as_posix()
+        if rel in {"checkpoint.json", CHECKPOINT_REPORT_NAME}:
+            continue
+        if path.is_symlink() or not path.is_file():
+            continue
+        values.append({"path": rel, "sha256": file_sha256(path)})
+    return sorted(values, key=lambda item: item["path"])
+
+
+def checkpoint_manifest_id(manifest: dict[str, Any]) -> str:
+    payload = dict(manifest)
+    payload.pop("checkpoint_id", None)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def checkpoint_report_id(report: dict[str, Any]) -> str:
+    payload = dict(report)
+    payload.pop("report_id", None)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def checkpoint_timestamp() -> str:
+    override = os.environ.get("LLM_WIKI_NOW")
+    if override:
+        return override
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def write_checkpoint_json(path: Path, value: dict[str, Any]) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o644)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def checkpoint_finding_json(finding: CheckpointFinding, allowed: bool) -> dict[str, Any]:
+    return {
+        "id": finding.finding_id,
+        "category": finding.category,
+        "severity": finding.severity,
+        "path": finding.path,
+        "line": finding.line,
+        "message": finding.message,
+        "status": "allowed" if allowed else "blocking",
+    }
+
+
+def validate_override_reason(reason: str | None) -> str:
+    value = (reason or "").strip()
+    if not value:
+        raise SystemExit("--override-reason is required when allowing a source or finding")
+    if len(value) > 240 or "\n" in value or "\r" in value:
+        raise SystemExit("--override-reason must be one line and no more than 240 characters")
+    if scan_checkpoint_text(value, CHECKPOINT_REPORT_NAME):
+        raise SystemExit("--override-reason itself matches a sensitive-information pattern")
+    return value
+
+
+def checkpoint_seal(args: argparse.Namespace) -> int:
+    root = Path(args.path).expanduser().resolve(strict=False)
+    if not root.is_dir():
+        raise SystemExit("checkpoint seal path must be an existing directory")
+    for name in CHECKPOINT_REQUIRED_FILES | {CHECKPOINT_REPORT_NAME}:
+        if (root / name).is_symlink():
+            raise SystemExit("checkpoint seal refuses symbolic links in the fixed bundle")
+    manifest_path = root / "checkpoint.json"
+    manifest = load_json_object(manifest_path, "checkpoint manifest")
+    validate_checkpoint_manifest(manifest, args.audience)
+
+    allowed_findings = set(args.allow_finding or [])
+    allowed_sources = set(args.allow_source or [])
+    reason: str | None = None
+    if allowed_findings or allowed_sources:
+        reason = validate_override_reason(args.override_reason)
+
+    input_keys = {
+        checkpoint_source_key(item)
+        for item in manifest.get("inputs", [])
+        if isinstance(item, dict)
+    }
+    unknown_sources = sorted(allowed_sources - input_keys)
+    if unknown_sources:
+        raise SystemExit("--allow-source names an input not present in checkpoint.json")
+    # A new seal never trusts hand-written or stale source overrides. The
+    # caller must re-authorize every retained above-audience input by exact key.
+    manifest["source_overrides"] = [
+        {"source": key, "reason": reason} for key in sorted(allowed_sources)
+    ]
+
+    manifest["audience"] = args.audience
+    manifest["files"] = checkpoint_content_file_hashes(root)
+    manifest["checkpoint_id"] = checkpoint_manifest_id(manifest)
+    write_checkpoint_json(manifest_path, manifest)
+
+    findings, scanned_files = scan_checkpoint_bundle(root, args.audience)
+    finding_ids = {finding.finding_id for finding in findings}
+    unknown_findings = sorted(allowed_findings - finding_ids)
+    if unknown_findings:
+        raise SystemExit("--allow-finding contains an unknown or stale finding ID")
+    blocking = [finding for finding in findings if finding.finding_id not in allowed_findings]
+    source_override_count = len(manifest.get("source_overrides", []))
+    status = "blocked" if blocking else (
+        "overridden" if findings or source_override_count else "passed"
+    )
+    overrides = [
+        {"finding_id": finding_id, "reason": reason}
+        for finding_id in sorted(allowed_findings)
+    ]
+    report: dict[str, Any] = {
+        "schema": CHECKPOINT_PRIVACY_SCHEMA,
+        "scanner_version": CHECKPOINT_SCANNER_VERSION,
+        "checkpoint_id": manifest["checkpoint_id"],
+        "audience": args.audience,
+        "scanned_at": checkpoint_timestamp(),
+        "status": status,
+        "files": scanned_files,
+        "findings": [
+            checkpoint_finding_json(finding, finding.finding_id in allowed_findings)
+            for finding in findings
+        ],
+        "overrides": overrides,
+        "source_override_count": source_override_count,
+    }
+    report["report_id"] = checkpoint_report_id(report)
+    write_checkpoint_json(root / CHECKPOINT_REPORT_NAME, report)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            f"Checkpoint seal: {status} ({len(scanned_files)} files, "
+            f"{len(findings)} findings, {len(overrides)} overrides)"
+        )
+        for finding in findings:
+            print(
+                f"- {finding.finding_id} {finding.category} "
+                f"{finding.path}:{finding.line} - {finding.message}"
+            )
+    return 2 if blocking else 0
+
+
+def checkpoint_verify(args: argparse.Namespace) -> int:
+    root = Path(args.path).expanduser().resolve(strict=False)
+    errors: list[str] = []
+    if not root.is_dir():
+        raise SystemExit("checkpoint verify path must be an existing directory")
+    for name in CHECKPOINT_REQUIRED_FILES | {CHECKPOINT_REPORT_NAME}:
+        if (root / name).is_symlink():
+            result = {
+                "status": "invalid",
+                "errors": ["checkpoint verify refuses symbolic links in the fixed bundle"],
+            }
+            print(json.dumps(result, indent=2, sort_keys=True) if args.json else result["errors"][0])
+            return 2
+    try:
+        manifest = load_json_object(root / "checkpoint.json", "checkpoint manifest")
+        report = load_json_object(root / CHECKPOINT_REPORT_NAME, "checkpoint privacy report")
+    except SystemExit as exc:
+        result = {"status": "invalid", "errors": [str(exc)]}
+        print(json.dumps(result, indent=2, sort_keys=True) if args.json else str(exc))
+        return 2
+    audience = manifest.get("audience")
+    try:
+        validate_checkpoint_manifest(manifest, audience)
+    except SystemExit as exc:
+        errors.append(str(exc))
+    if report.get("schema") != CHECKPOINT_PRIVACY_SCHEMA:
+        errors.append("privacy-report.json has an unsupported schema")
+    if report.get("scanner_version") != CHECKPOINT_SCANNER_VERSION:
+        errors.append("privacy-report.json scanner version is unsupported")
+    if report.get("report_id") != checkpoint_report_id(report):
+        errors.append("privacy-report.json report_id does not match its content")
+    expected_checkpoint_id = checkpoint_manifest_id(manifest)
+    if manifest.get("checkpoint_id") != expected_checkpoint_id:
+        errors.append("checkpoint.json checkpoint_id does not match its content")
+    if report.get("checkpoint_id") != manifest.get("checkpoint_id"):
+        errors.append("privacy report checkpoint_id does not match checkpoint.json")
+    if report.get("audience") != audience:
+        errors.append("privacy report audience does not match checkpoint.json")
+
+    actual_content_files = checkpoint_content_file_hashes(root)
+    if manifest.get("files") != actual_content_files:
+        errors.append("checkpoint.json generated-file hashes do not match the bundle")
+    findings, scanned_files = scan_checkpoint_bundle(root, audience) if audience in CHECKPOINT_AUDIENCES else ([], [])
+    if report.get("files") != scanned_files:
+        errors.append("privacy report file hashes do not match the bundle")
+    report_finding_ids = {
+        item.get("id") for item in report.get("findings", []) if isinstance(item, dict)
+    }
+    actual_finding_ids = {finding.finding_id for finding in findings}
+    if report_finding_ids != actual_finding_ids:
+        errors.append("privacy findings do not match a fresh scan")
+    override_rows = report.get("overrides")
+    if not isinstance(override_rows, list):
+        errors.append("privacy report overrides must be an array")
+        override_rows = []
+    override_ids: set[str] = set()
+    for index, item in enumerate(override_rows):
+        if not isinstance(item, dict) or not isinstance(item.get("finding_id"), str):
+            errors.append(f"privacy report override {index + 1} is invalid")
+            continue
+        try:
+            validate_override_reason(item.get("reason"))
+        except SystemExit:
+            errors.append(f"privacy report override {index + 1} has an invalid reason")
+            continue
+        override_ids.add(item["finding_id"])
+    if len(override_ids) != len(override_rows):
+        errors.append("privacy report overrides contain duplicate or invalid finding IDs")
+    if not override_ids.issubset(actual_finding_ids):
+        errors.append("privacy report contains an unknown or stale override")
+    expected_finding_records = [
+        checkpoint_finding_json(finding, finding.finding_id in override_ids)
+        for finding in findings
+    ]
+    if report.get("findings") != expected_finding_records:
+        errors.append("privacy report finding metadata does not match a fresh scan")
+    blocking_ids = actual_finding_ids - override_ids
+    source_override_count = len(manifest.get("source_overrides", []))
+    if report.get("source_override_count") != source_override_count:
+        errors.append("privacy report source override count does not match checkpoint.json")
+    expected_status = "blocked" if blocking_ids else (
+        "overridden" if actual_finding_ids or source_override_count else "passed"
+    )
+    if report.get("status") != expected_status:
+        errors.append("privacy report status does not match the current findings")
+    result = {
+        "schema": CHECKPOINT_PRIVACY_SCHEMA,
+        "status": "invalid" if errors else expected_status,
+        "checkpoint_id": manifest.get("checkpoint_id"),
+        "audience": audience,
+        "file_count": len(scanned_files),
+        "finding_count": len(findings),
+        "override_count": len(override_ids),
+        "source_override_count": source_override_count,
+        "finding_categories": sorted({finding.category for finding in findings}),
+        "errors": errors,
+    }
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            f"Checkpoint verify: {result['status']} ({result['file_count']} files, "
+            f"{result['finding_count']} findings, {result['override_count']} overrides)"
+        )
+        for error in errors:
+            print(f"- {error}")
+    return 2 if errors or expected_status == "blocked" else 0
+
+
+def run_checkpoint(args: argparse.Namespace) -> int:
+    handlers = {"seal": checkpoint_seal, "verify": checkpoint_verify}
+    return handlers[args.checkpoint_command](args)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="llm-wiki",
@@ -4586,6 +5297,52 @@ def build_parser() -> argparse.ArgumentParser:
     adapter_remove_parser.add_argument("--json", action="store_true", help="Print JSON.")
 
     adapter.set_defaults(func=run_adapter)
+
+    checkpoint = subparsers.add_parser(
+        "checkpoint",
+        help="Seal and verify portable Project Knowledge Checkpoints.",
+        description=(
+            "Deterministically validate, hash, privacy-scan, seal, and verify a "
+            "Project Knowledge Checkpoint generated by the agentic wiki workflow."
+        ),
+    )
+    checkpoint_sub = checkpoint.add_subparsers(dest="checkpoint_command", required=True)
+
+    checkpoint_seal_parser = checkpoint_sub.add_parser(
+        "seal", help="Finalize hashes and run the mandatory privacy scan."
+    )
+    checkpoint_seal_parser.add_argument("path", help="Checkpoint bundle directory.")
+    checkpoint_seal_parser.add_argument(
+        "--audience",
+        required=True,
+        choices=sorted(CHECKPOINT_AUDIENCES),
+        help="Declared recipient boundary for source-access validation.",
+    )
+    checkpoint_seal_parser.add_argument(
+        "--allow-finding",
+        action="append",
+        default=[],
+        help="Explicitly acknowledge one exact finding ID; repeatable.",
+    )
+    checkpoint_seal_parser.add_argument(
+        "--allow-source",
+        action="append",
+        default=[],
+        help="Explicitly retain one exact wiki:path input above the audience; repeatable.",
+    )
+    checkpoint_seal_parser.add_argument(
+        "--override-reason",
+        help="One-line reason required for any source or finding override.",
+    )
+    checkpoint_seal_parser.add_argument("--json", action="store_true", help="Print JSON.")
+
+    checkpoint_verify_parser = checkpoint_sub.add_parser(
+        "verify", help="Recheck bundle structure, hashes, and privacy attestation."
+    )
+    checkpoint_verify_parser.add_argument("path", help="Checkpoint bundle directory.")
+    checkpoint_verify_parser.add_argument("--json", action="store_true", help="Print JSON.")
+
+    checkpoint.set_defaults(func=run_checkpoint)
 
     return parser
 

--- a/plugins/llm-wiki-opencode/bin/llm-wiki
+++ b/plugins/llm-wiki-opencode/bin/llm-wiki
@@ -13,6 +13,7 @@ import datetime as dt
 import getpass
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
@@ -92,6 +93,7 @@ CHECKPOINT_REQUIRED_FILES = {
 }
 CHECKPOINT_REPORT_NAME = "privacy-report.json"
 CHECKPOINT_MAX_FILE_BYTES = 10 * 1024 * 1024
+CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO = 0.20
 
 ROOT_ALLOWED = {
     "_index.md",
@@ -4438,6 +4440,50 @@ def checkpoint_source_key(item: dict[str, Any]) -> str:
     return f"{item.get('wiki', '')}:{item.get('path', '')}"
 
 
+def checkpoint_word_count(text: str) -> int:
+    return len(re.findall(r"\b[\w][\w'-]*\b", text, flags=re.UNICODE))
+
+
+def checkpoint_coverage_metrics(root: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    inputs = manifest.get("inputs", [])
+    source_word_count = sum(
+        item.get("words", 0) for item in inputs if isinstance(item, dict)
+    )
+    knowledge_path = root / "project-knowledge.md"
+    try:
+        knowledge_text = knowledge_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        knowledge_text = ""
+    knowledge_word_count = checkpoint_word_count(knowledge_text)
+    retention_ratio = (
+        knowledge_word_count / source_word_count if source_word_count else 0.0
+    )
+    return {
+        "source_word_count": source_word_count,
+        "knowledge_word_count": knowledge_word_count,
+        "retention_ratio": round(retention_ratio, 4),
+        "minimum_retention_ratio": CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO,
+    }
+
+
+def apply_checkpoint_coverage_metrics(root: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    metrics = checkpoint_coverage_metrics(root, manifest)
+    if metrics["retention_ratio"] < CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO:
+        required_words = math.ceil(
+            metrics["source_word_count"] * CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO
+        )
+        raise SystemExit(
+            "project-knowledge.md is too thin for comprehensive mode: "
+            f"{metrics['knowledge_word_count']} words for "
+            f"{metrics['source_word_count']} selected-source words; "
+            f"write at least {required_words} words or reduce the selected scope"
+        )
+    coverage = manifest["coverage"]
+    for key, value in metrics.items():
+        coverage[key] = value
+    return metrics
+
+
 def checkpoint_source_access_findings(
     manifest: dict[str, Any], audience: str
 ) -> list[CheckpointFinding]:
@@ -4642,7 +4688,7 @@ def validate_checkpoint_manifest(manifest: dict[str, Any], audience: str) -> Non
         raise SystemExit("checkpoint.json created_at must be a non-empty string")
     if not isinstance(manifest.get("scope"), dict):
         raise SystemExit("checkpoint.json scope must be an object")
-    if not isinstance(manifest.get("inputs"), list):
+    if not isinstance(manifest.get("inputs"), list) or not manifest["inputs"]:
         raise SystemExit("checkpoint.json inputs must be an array")
     if not isinstance(manifest.get("gaps"), list):
         raise SystemExit("checkpoint.json gaps must be an array")
@@ -4652,15 +4698,59 @@ def validate_checkpoint_manifest(manifest: dict[str, Any], audience: str) -> Non
         for field in ("wiki", "path", "sha256", "reason", "access"):
             if not isinstance(item.get(field), str) or not item[field].strip():
                 raise SystemExit(f"checkpoint.json input {index + 1} requires {field}")
+        if not isinstance(item.get("words"), int) or item["words"] <= 0:
+            raise SystemExit(f"checkpoint.json input {index + 1} words must be a positive integer")
         if not re.fullmatch(r"[0-9a-f]{64}", item["sha256"]):
             raise SystemExit(f"checkpoint.json input {index + 1} sha256 must be 64 lowercase hex characters")
         source_path = item["path"]
         if Path(source_path).is_absolute() or ".." in Path(source_path).parts:
             raise SystemExit(f"checkpoint.json input {index + 1} path must be wiki-relative")
+    input_keys = [checkpoint_source_key(item) for item in manifest["inputs"]]
+    if len(set(input_keys)) != len(input_keys):
+        raise SystemExit("checkpoint.json inputs must have unique wiki:path keys")
+
+    coverage = manifest.get("coverage")
+    if not isinstance(coverage, dict):
+        raise SystemExit("checkpoint.json coverage must be an object")
+    if coverage.get("mode") != "comprehensive":
+        raise SystemExit("checkpoint.json coverage.mode must be 'comprehensive'")
+    source_word_count = sum(item["words"] for item in manifest["inputs"])
+    if coverage.get("source_word_count") != source_word_count:
+        raise SystemExit("checkpoint.json coverage.source_word_count must equal input words")
+    section_map = coverage.get("section_map")
+    if not isinstance(section_map, list) or not section_map:
+        raise SystemExit("checkpoint.json coverage.section_map must be a non-empty array")
+    mapped_sources: set[str] = set()
+    valid_input_keys = set(input_keys)
+    for index, item in enumerate(section_map):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} must be an object")
+        if not isinstance(item.get("section"), str) or not item["section"].strip():
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} requires section")
+        sources = item.get("sources")
+        if not isinstance(sources, list) or not sources:
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} requires sources")
+        if any(not isinstance(source, str) or source not in valid_input_keys for source in sources):
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} names an unknown input")
+        mapped_sources.update(sources)
+    if mapped_sources != valid_input_keys:
+        raise SystemExit("checkpoint.json coverage.section_map must account for every input")
+    omissions = coverage.get("omissions")
+    if not isinstance(omissions, list):
+        raise SystemExit("checkpoint.json coverage.omissions must be an array")
+    for index, item in enumerate(omissions):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json coverage omission {index + 1} must be an object")
+        if item.get("source") not in valid_input_keys:
+            raise SystemExit(f"checkpoint.json coverage omission {index + 1} names an unknown input")
+        for field in ("section", "reason"):
+            if not isinstance(item.get(field), str) or not item[field].strip():
+                raise SystemExit(f"checkpoint.json coverage omission {index + 1} requires {field}")
+
     source_overrides = manifest.get("source_overrides", [])
     if not isinstance(source_overrides, list):
         raise SystemExit("checkpoint.json source_overrides must be an array")
-    input_keys = {checkpoint_source_key(item) for item in manifest["inputs"]}
+    input_keys = set(input_keys)
     for index, item in enumerate(source_overrides):
         if not isinstance(item, dict):
             raise SystemExit(f"checkpoint.json source override {index + 1} must be an object")
@@ -4775,6 +4865,7 @@ def checkpoint_seal(args: argparse.Namespace) -> int:
     ]
 
     manifest["audience"] = args.audience
+    coverage_metrics = apply_checkpoint_coverage_metrics(root, manifest)
     manifest["files"] = checkpoint_content_file_hashes(root)
     manifest["checkpoint_id"] = checkpoint_manifest_id(manifest)
     write_checkpoint_json(manifest_path, manifest)
@@ -4807,6 +4898,7 @@ def checkpoint_seal(args: argparse.Namespace) -> int:
         ],
         "overrides": overrides,
         "source_override_count": source_override_count,
+        "coverage": coverage_metrics,
     }
     report["report_id"] = checkpoint_report_id(report)
     write_checkpoint_json(root / CHECKPOINT_REPORT_NAME, report)
@@ -4864,6 +4956,16 @@ def checkpoint_verify(args: argparse.Namespace) -> int:
     if report.get("audience") != audience:
         errors.append("privacy report audience does not match checkpoint.json")
 
+    coverage_metrics = checkpoint_coverage_metrics(root, manifest)
+    coverage = manifest.get("coverage", {})
+    for key, value in coverage_metrics.items():
+        if coverage.get(key) != value:
+            errors.append(f"checkpoint.json coverage {key} does not match the bundle")
+    if coverage_metrics["retention_ratio"] < CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO:
+        errors.append("project-knowledge.md is too thin for comprehensive mode")
+    if report.get("coverage") != coverage_metrics:
+        errors.append("privacy report coverage metrics do not match the bundle")
+
     actual_content_files = checkpoint_content_file_hashes(root)
     if manifest.get("files") != actual_content_files:
         errors.append("checkpoint.json generated-file hashes do not match the bundle")
@@ -4919,6 +5021,7 @@ def checkpoint_verify(args: argparse.Namespace) -> int:
         "finding_count": len(findings),
         "override_count": len(override_ids),
         "source_override_count": source_override_count,
+        "coverage": coverage_metrics,
         "finding_categories": sorted({finding.category for finding in findings}),
         "errors": errors,
     }

--- a/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
+++ b/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
@@ -11,6 +11,7 @@ description: >
   dataset manifest, compilation, querying, linting, audit, research, librarian,
   scan quality, article quality, content review, output drift, provenance,
   archive wiki, archive topic, restore wiki, private adapter, adapter registry, skill-factory,
+  checkpoints,
   personal specialist, specialist skill, specialist reviewer, expert lens,
   adapter route, adapter doctor, adapter run, edit an external resource, session capture, capture context, rehydrate,
   resume from session, lessons learned, implementation plan, or uses
@@ -114,6 +115,10 @@ enabled per active topic. Loading one never grants tools, write access, professi
 authority, or permission to spawn agents. Select the minimum useful method,
 preserve disagreement, and record its version/hash. See
 [references/specialists.md](references/specialists.md).
+
+15. **Project checkpoints are privacy-sealed.** Never dump raw/sessions; seal
+and exact overrides are required. See
+[references/checkpoints.md](references/checkpoints.md).
 
 ## Adapter Routing
 

--- a/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
+++ b/plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md
@@ -116,8 +116,7 @@ authority, or permission to spawn agents. Select the minimum useful method,
 preserve disagreement, and record its version/hash. See
 [references/specialists.md](references/specialists.md).
 
-15. **Project checkpoints are privacy-sealed.** Never dump raw/sessions; seal
-and exact overrides are required. See
+15. **Project checkpoints need comprehensive coverage and a privacy seal.** See
 [references/checkpoints.md](references/checkpoints.md).
 
 ## Adapter Routing

--- a/plugins/llm-wiki/.codex-plugin/plugin.json
+++ b/plugins/llm-wiki/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wiki",
   "version": "0.23.0",
-  "description": "LLM-compiled knowledge bases for Codex with personal specialist skills, fuzzy Idea capture, research, shaping, and explicit Project promotion, plus inventory, datasets, source ingestion, compilation, audits, sessions, and artifact generation.",
+  "description": "LLM-compiled knowledge bases for Codex with personal specialist skills, fuzzy Idea capture, research, shaping, and explicit Project promotion, plus inventory, datasets, source ingestion, compilation, audits, sessions, privacy-sealed project checkpoints, and artifact generation.",
   "author": {
     "name": "nvk",
     "url": "https://github.com/nvk"
@@ -34,13 +34,15 @@
     "private-adapters",
     "specialists",
     "personal-skills",
-    "skill-factory"
+    "skill-factory",
+    "checkpoints",
+    "knowledge-handoff"
   ],
   "skills": "./skills/",
   "interface": {
     "displayName": "LLM Wiki",
-    "shortDescription": "Use personal specialists, shape Ideas, and maintain research wikis",
-    "longDescription": "Bundle the llm-wiki workflow for Codex: apply personal specialist methods, capture rough Ideas, research and shape them, explicitly promote approved briefs into Projects, and maintain topic-scoped sources, compiled knowledge, inventory, datasets, sessions, audits, plans, and generated artifacts.",
+    "shortDescription": "Research, shape Ideas, and create privacy-sealed project handoffs",
+    "longDescription": "Bundle the llm-wiki workflow for Codex: apply personal specialist methods, capture rough Ideas, research and shape them, explicitly promote approved briefs into Projects, and maintain topic-scoped sources, compiled knowledge, inventory, datasets, sessions, audits, plans, privacy-sealed Project Knowledge Checkpoints, and generated artifacts.",
     "developerName": "nvk",
     "category": "Productivity",
     "capabilities": [
@@ -49,6 +51,7 @@
     ],
     "websiteURL": "https://github.com/nvk/llm-wiki",
     "defaultPrompt": [
+      "Create a privacy-sealed Project Knowledge Checkpoint from relevant research across my topic wikis.",
       "Capture this rough Idea, research it, shape alternatives, and wait for approval before creating a Project.",
       "Run a registered private adapter and review only its wiki-safe evidence candidates.",
       "Research a new topic and compile it into a wiki.",

--- a/plugins/llm-wiki/.codex-plugin/plugin.json
+++ b/plugins/llm-wiki/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "LLM-compiled knowledge bases for Codex with personal specialist skills, fuzzy Idea capture, research, shaping, and explicit Project promotion, plus inventory, datasets, source ingestion, compilation, audits, sessions, privacy-sealed project checkpoints, and artifact generation.",
   "author": {
     "name": "nvk",

--- a/plugins/llm-wiki/bin/llm-wiki
+++ b/plugins/llm-wiki/bin/llm-wiki
@@ -80,6 +80,18 @@ SPECIALIST_REQUIRED_SECTIONS = [
     "Evaluation cases",
     "Provenance and maintenance",
 ]
+CHECKPOINT_SCHEMA = "llm-wiki/project-knowledge-checkpoint/v1"
+CHECKPOINT_PRIVACY_SCHEMA = "llm-wiki/checkpoint-privacy-report/v1"
+CHECKPOINT_SCANNER_VERSION = 1
+CHECKPOINT_AUDIENCES = {"private", "team", "public"}
+CHECKPOINT_REQUIRED_FILES = {
+    "index.md",
+    "project-knowledge.md",
+    "sources.md",
+    "checkpoint.json",
+}
+CHECKPOINT_REPORT_NAME = "privacy-report.json"
+CHECKPOINT_MAX_FILE_BYTES = 10 * 1024 * 1024
 
 ROOT_ALLOWED = {
     "_index.md",
@@ -149,6 +161,16 @@ class Document:
     path: Path
     frontmatter: dict[str, Any]
     body: str
+
+
+@dataclass(frozen=True)
+class CheckpointFinding:
+    finding_id: str
+    category: str
+    severity: str
+    path: str
+    line: int
+    message: str
 
 
 class LintContext:
@@ -4228,6 +4250,695 @@ def run_adapter(args: argparse.Namespace) -> int:
     return handlers[args.adapter_command](args)
 
 
+def checkpoint_pattern_specs() -> list[tuple[str, str, str, re.Pattern[str]]]:
+    flags = re.IGNORECASE | re.MULTILINE
+    return [
+        (
+            "secret-private-key",
+            "critical",
+            "Possible private-key material.",
+            re.compile(
+                r"-----BEGIN (?:(?:[A-Z0-9 ]+ )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----",
+                flags,
+            ),
+        ),
+        (
+            "secret-known-token",
+            "critical",
+            "Possible service credential or bearer token.",
+            re.compile(
+                r"(?:\bAKIA[0-9A-Z]{16}\b|\bgh[pousr]_[A-Za-z0-9]{20,}\b|"
+                r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b|\bsk-[A-Za-z0-9_-]{16,}\b|"
+                r"\bAIza[0-9A-Za-z_-]{25,}\b|\bBearer\s+[A-Za-z0-9._~+/=-]{12,}|"
+                r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b)",
+                flags,
+            ),
+        ),
+        (
+            "secret-assignment",
+            "critical",
+            "Possible credential assigned to a sensitive field.",
+            re.compile(
+                r"\b(?:api[_-]?key|private[_-]?key|(?:access|auth|api|refresh)?[_-]?token|"
+                r"client[_-]?secret|password|passwd|secret|session[_-]?cookie)\b"
+                r"\s*[\"']?\s*[:=]\s*"
+                r"[\"']?[A-Za-z0-9_./+=$~-]{8,}",
+                flags,
+            ),
+        ),
+        (
+            "secret-url-credentials",
+            "critical",
+            "Possible username/password embedded in a URL.",
+            re.compile(r"\b[a-z][a-z0-9+.-]*://[^\s/@:]+:[^\s/@]+@", flags),
+        ),
+        (
+            "personal-email",
+            "warning",
+            "Email address may identify a person or private account.",
+            re.compile(r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
+        ),
+        (
+            "personal-account-field",
+            "warning",
+            "Account or username field may expose an identity.",
+            re.compile(
+                r"^[ \t]*[\"']?(?:user(?:name)?|login|account(?:[_-]?name)?|handle)"
+                r"[\"']?[ \t]*[:=][ \t]*[\"']?@?[A-Za-z0-9_.-]{2,}",
+                flags,
+            ),
+        ),
+        (
+            "local-home-path",
+            "critical",
+            "Machine-local home directory path.",
+            re.compile(
+                r"(?:(?<![:A-Za-z0-9])/Users/[A-Za-z0-9._-]+(?:/|\b)|"
+                r"(?<![:A-Za-z0-9])/home/[A-Za-z0-9._-]+(?:/|\b)|"
+                r"(?<![:A-Za-z0-9])/root(?:/|\b)|[A-Za-z]:\\Users\\[A-Za-z0-9._ -]+(?:\\|\b))",
+                flags,
+            ),
+        ),
+        (
+            "local-machine-path",
+            "critical",
+            "Machine-local volume, temporary, or file URL path.",
+            re.compile(
+                r"(?:file://|(?:~|\$HOME|\$\{HOME\})/|(?<![:A-Za-z0-9])/Volumes/[^\s/]+(?:/|\b)|"
+                r"(?<![:A-Za-z0-9])/private/var/folders/|(?<![:A-Za-z0-9])/(?:tmp|var|etc|opt|srv|mnt|media|workspace|Applications|Library)/[^\s`\"']+)",
+                flags,
+            ),
+        ),
+        (
+            "remote-login-identity",
+            "warning",
+            "Remote-login syntax may expose a username or private host.",
+            re.compile(r"\b(?:ssh|scp|sftp|rsync)\b[^\n]*\b[A-Za-z0-9._-]+@[A-Za-z0-9._-]+", flags),
+        ),
+        (
+            "local-network-address",
+            "warning",
+            "Private-network address may reveal local infrastructure.",
+            re.compile(
+                r"\b(?:10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|"
+                r"172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2})\b"
+            ),
+        ),
+        (
+            "local-hostname",
+            "warning",
+            "Local hostname may reveal private infrastructure.",
+            re.compile(
+                r"(?:\b[A-Za-z0-9][A-Za-z0-9-]{0,62}\.local\b|"
+                r"\b[A-Za-z0-9][A-Za-z0-9.-]{0,126}\.(?:lan|internal)\b|"
+                r"^[ \t]*[\"']?hostname[\"']?[ \t]*[:=][ \t]*[\"']?[^\s\"']+)",
+                flags,
+            ),
+        ),
+        (
+            "session-transcript",
+            "critical",
+            "Session or transcript metadata must not enter a checkpoint.",
+            re.compile(
+                r"(?:transcript[_-]?path|rollout-[^\s]+\.jsonl|\.sessions/(?:digests|feedback)/|"
+                r"\b(?:codex|claude):[0-9a-f]{8}-[0-9a-f-]{27,}\b|UserPromptSubmit|PreCompact|PostCompact)",
+                flags,
+            ),
+        ),
+        (
+            "prompt-conversation-role",
+            "warning",
+            "Conversation-role content may be copied prompt or transcript text.",
+            re.compile(
+                r"(?:^[ \t]*(?:system|developer|assistant|user)[ \t]*:[ \t]+\S|"
+                r"[\"']role[\"'][ \t]*:[ \t]*[\"'](?:system|developer|assistant|user)[\"'])",
+                flags,
+            ),
+        ),
+        (
+            "prompt-instruction-marker",
+            "warning",
+            "Prompt/instruction marker may expose agent instructions.",
+            re.compile(
+                r"(?:<\|(?:system|user|assistant)\|>|\[INST\]|</?system>|"
+                r"AGENTS\.md instructions for|(?:system|developer) prompt[ \t]*:)",
+                flags,
+            ),
+        ),
+    ]
+
+
+def checkpoint_finding(
+    category: str,
+    severity: str,
+    path: str,
+    line: int,
+    message: str,
+    evidence: str,
+) -> CheckpointFinding:
+    digest = hashlib.sha256(
+        "\0".join([category, path, str(line), evidence]).encode("utf-8")
+    ).hexdigest()[:16]
+    return CheckpointFinding(
+        finding_id=f"privacy-{digest}",
+        category=category,
+        severity=severity,
+        path=path,
+        line=line,
+        message=message,
+    )
+
+
+def scan_checkpoint_text(text: str, rel: str) -> list[CheckpointFinding]:
+    findings: list[CheckpointFinding] = []
+    for category, severity, message, pattern in checkpoint_pattern_specs():
+        for match in pattern.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            findings.append(
+                checkpoint_finding(
+                    category,
+                    severity,
+                    rel,
+                    line,
+                    message,
+                    match.group(0),
+                )
+            )
+    return findings
+
+
+def checkpoint_file_paths(root: Path, include_report: bool = False) -> list[Path]:
+    names = set(CHECKPOINT_REQUIRED_FILES)
+    if include_report:
+        names.add(CHECKPOINT_REPORT_NAME)
+    return [root / name for name in sorted(names) if (root / name).exists() or (root / name).is_symlink()]
+
+
+def checkpoint_source_key(item: dict[str, Any]) -> str:
+    return f"{item.get('wiki', '')}:{item.get('path', '')}"
+
+
+def checkpoint_source_access_findings(
+    manifest: dict[str, Any], audience: str
+) -> list[CheckpointFinding]:
+    inputs = manifest.get("inputs")
+    if not isinstance(inputs, list):
+        return [
+            checkpoint_finding(
+                "structure-inputs",
+                "critical",
+                "checkpoint.json",
+                1,
+                "Manifest inputs must be an array.",
+                "inputs-not-array",
+            )
+        ]
+    source_overrides = manifest.get("source_overrides", [])
+    override_keys = {
+        entry.get("source")
+        for entry in source_overrides
+        if isinstance(entry, dict)
+        and isinstance(entry.get("source"), str)
+        and isinstance(entry.get("reason"), str)
+        and entry.get("reason", "").strip()
+    }
+    allowed = {
+        "private": {"public", "team", "private"},
+        "team": {"public", "team"},
+        "public": {"public"},
+    }[audience]
+    findings: list[CheckpointFinding] = []
+    for index, item in enumerate(inputs):
+        if not isinstance(item, dict):
+            findings.append(
+                checkpoint_finding(
+                    "structure-input",
+                    "critical",
+                    "checkpoint.json",
+                    1,
+                    f"Input {index + 1} must be an object.",
+                    f"input-{index}-not-object",
+                )
+            )
+            continue
+        access = item.get("access")
+        key = checkpoint_source_key(item)
+        if access not in {"public", "team", "private", "unknown"}:
+            message = f"Input {index + 1} has no valid access classification."
+        elif access not in allowed:
+            message = f"Input {index + 1} exceeds the declared {audience} audience."
+        else:
+            continue
+        if key in override_keys:
+            continue
+        findings.append(
+            checkpoint_finding(
+                "source-access",
+                "critical",
+                "checkpoint.json",
+                1,
+                message,
+                f"{index}:{key}:{access}:{audience}",
+            )
+        )
+    return findings
+
+
+def scan_checkpoint_bundle(root: Path, audience: str) -> tuple[list[CheckpointFinding], list[dict[str, str]]]:
+    findings: list[CheckpointFinding] = []
+    files: list[dict[str, str]] = []
+    allowed_names = CHECKPOINT_REQUIRED_FILES | {CHECKPOINT_REPORT_NAME}
+    for path in sorted(root.iterdir(), key=lambda item: item.name):
+        if path.name in allowed_names:
+            continue
+        opaque_path = "unexpected-" + hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:12]
+        findings.append(
+            checkpoint_finding(
+                "structure-unexpected-entry",
+                "critical",
+                opaque_path,
+                0,
+                "Checkpoint v1 contains an unexpected file or directory; its name is redacted.",
+                path.name,
+            )
+        )
+    for required in sorted(CHECKPOINT_REQUIRED_FILES):
+        if not (root / required).is_file():
+            findings.append(
+                checkpoint_finding(
+                    "structure-required-file",
+                    "critical",
+                    required,
+                    0,
+                    "Required checkpoint file is missing.",
+                    required,
+                )
+            )
+    for path in checkpoint_file_paths(root):
+        rel = path.relative_to(root).as_posix()
+        findings.extend(scan_checkpoint_text(rel, rel))
+        if path.is_symlink():
+            findings.append(
+                checkpoint_finding(
+                    "structure-symlink",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint bundles may not contain symbolic links.",
+                    rel,
+                )
+            )
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError as exc:
+            findings.append(
+                checkpoint_finding(
+                    "structure-unreadable",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint file could not be inspected.",
+                    f"{rel}:{type(exc).__name__}",
+                )
+            )
+            continue
+        if size > CHECKPOINT_MAX_FILE_BYTES:
+            findings.append(
+                checkpoint_finding(
+                    "structure-file-size",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint file exceeds the 10 MiB safety limit.",
+                    f"{rel}:{size}",
+                )
+            )
+            continue
+        if path.suffix.lower() not in {".md", ".json"}:
+            findings.append(
+                checkpoint_finding(
+                    "structure-file-type",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint contains a non-Markdown/non-JSON file.",
+                    rel,
+                )
+            )
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            findings.append(
+                checkpoint_finding(
+                    "structure-non-text",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint file is unreadable or not UTF-8 text.",
+                    f"{rel}:{type(exc).__name__}",
+                )
+            )
+            continue
+        files.append({"path": rel, "sha256": file_sha256(path)})
+        findings.extend(scan_checkpoint_text(text, rel))
+
+    manifest_path = root / "checkpoint.json"
+    if manifest_path.is_file() and not manifest_path.is_symlink():
+        try:
+            manifest = load_json_object(manifest_path, "checkpoint manifest")
+        except SystemExit as exc:
+            findings.append(
+                checkpoint_finding(
+                    "structure-manifest-json",
+                    "critical",
+                    "checkpoint.json",
+                    1,
+                    "Checkpoint manifest is not a valid JSON object.",
+                    str(exc),
+                )
+            )
+        else:
+            findings.extend(checkpoint_source_access_findings(manifest, audience))
+    unique = {finding.finding_id: finding for finding in findings}
+    return (
+        sorted(unique.values(), key=lambda item: (item.path, item.line, item.category, item.finding_id)),
+        sorted(files, key=lambda item: item["path"]),
+    )
+
+
+def validate_checkpoint_manifest(manifest: dict[str, Any], audience: str) -> None:
+    if manifest.get("schema") != CHECKPOINT_SCHEMA:
+        raise SystemExit(f"checkpoint.json schema must be {CHECKPOINT_SCHEMA!r}")
+    if audience not in CHECKPOINT_AUDIENCES:
+        raise SystemExit("checkpoint audience must be private, team, or public")
+    project = manifest.get("project")
+    if not isinstance(project, dict) or not isinstance(project.get("slug"), str) or not project.get("slug"):
+        raise SystemExit("checkpoint.json project.slug must be a non-empty string")
+    if not SPECIALIST_NAME_RE.fullmatch(project["slug"]):
+        raise SystemExit("checkpoint.json project.slug must be lowercase hyphenated text")
+    if not isinstance(manifest.get("created_at"), str) or not manifest["created_at"].strip():
+        raise SystemExit("checkpoint.json created_at must be a non-empty string")
+    if not isinstance(manifest.get("scope"), dict):
+        raise SystemExit("checkpoint.json scope must be an object")
+    if not isinstance(manifest.get("inputs"), list):
+        raise SystemExit("checkpoint.json inputs must be an array")
+    if not isinstance(manifest.get("gaps"), list):
+        raise SystemExit("checkpoint.json gaps must be an array")
+    for index, item in enumerate(manifest["inputs"]):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json input {index + 1} must be an object")
+        for field in ("wiki", "path", "sha256", "reason", "access"):
+            if not isinstance(item.get(field), str) or not item[field].strip():
+                raise SystemExit(f"checkpoint.json input {index + 1} requires {field}")
+        if not re.fullmatch(r"[0-9a-f]{64}", item["sha256"]):
+            raise SystemExit(f"checkpoint.json input {index + 1} sha256 must be 64 lowercase hex characters")
+        source_path = item["path"]
+        if Path(source_path).is_absolute() or ".." in Path(source_path).parts:
+            raise SystemExit(f"checkpoint.json input {index + 1} path must be wiki-relative")
+    source_overrides = manifest.get("source_overrides", [])
+    if not isinstance(source_overrides, list):
+        raise SystemExit("checkpoint.json source_overrides must be an array")
+    input_keys = {checkpoint_source_key(item) for item in manifest["inputs"]}
+    for index, item in enumerate(source_overrides):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json source override {index + 1} must be an object")
+        if item.get("source") not in input_keys:
+            raise SystemExit(f"checkpoint.json source override {index + 1} names an unknown input")
+        if not isinstance(item.get("reason"), str) or not item["reason"].strip():
+            raise SystemExit(f"checkpoint.json source override {index + 1} requires a reason")
+
+
+def checkpoint_content_file_hashes(root: Path) -> list[dict[str, str]]:
+    values: list[dict[str, str]] = []
+    for path in checkpoint_file_paths(root):
+        rel = path.relative_to(root).as_posix()
+        if rel in {"checkpoint.json", CHECKPOINT_REPORT_NAME}:
+            continue
+        if path.is_symlink() or not path.is_file():
+            continue
+        values.append({"path": rel, "sha256": file_sha256(path)})
+    return sorted(values, key=lambda item: item["path"])
+
+
+def checkpoint_manifest_id(manifest: dict[str, Any]) -> str:
+    payload = dict(manifest)
+    payload.pop("checkpoint_id", None)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def checkpoint_report_id(report: dict[str, Any]) -> str:
+    payload = dict(report)
+    payload.pop("report_id", None)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def checkpoint_timestamp() -> str:
+    override = os.environ.get("LLM_WIKI_NOW")
+    if override:
+        return override
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def write_checkpoint_json(path: Path, value: dict[str, Any]) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o644)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def checkpoint_finding_json(finding: CheckpointFinding, allowed: bool) -> dict[str, Any]:
+    return {
+        "id": finding.finding_id,
+        "category": finding.category,
+        "severity": finding.severity,
+        "path": finding.path,
+        "line": finding.line,
+        "message": finding.message,
+        "status": "allowed" if allowed else "blocking",
+    }
+
+
+def validate_override_reason(reason: str | None) -> str:
+    value = (reason or "").strip()
+    if not value:
+        raise SystemExit("--override-reason is required when allowing a source or finding")
+    if len(value) > 240 or "\n" in value or "\r" in value:
+        raise SystemExit("--override-reason must be one line and no more than 240 characters")
+    if scan_checkpoint_text(value, CHECKPOINT_REPORT_NAME):
+        raise SystemExit("--override-reason itself matches a sensitive-information pattern")
+    return value
+
+
+def checkpoint_seal(args: argparse.Namespace) -> int:
+    root = Path(args.path).expanduser().resolve(strict=False)
+    if not root.is_dir():
+        raise SystemExit("checkpoint seal path must be an existing directory")
+    for name in CHECKPOINT_REQUIRED_FILES | {CHECKPOINT_REPORT_NAME}:
+        if (root / name).is_symlink():
+            raise SystemExit("checkpoint seal refuses symbolic links in the fixed bundle")
+    manifest_path = root / "checkpoint.json"
+    manifest = load_json_object(manifest_path, "checkpoint manifest")
+    validate_checkpoint_manifest(manifest, args.audience)
+
+    allowed_findings = set(args.allow_finding or [])
+    allowed_sources = set(args.allow_source or [])
+    reason: str | None = None
+    if allowed_findings or allowed_sources:
+        reason = validate_override_reason(args.override_reason)
+
+    input_keys = {
+        checkpoint_source_key(item)
+        for item in manifest.get("inputs", [])
+        if isinstance(item, dict)
+    }
+    unknown_sources = sorted(allowed_sources - input_keys)
+    if unknown_sources:
+        raise SystemExit("--allow-source names an input not present in checkpoint.json")
+    # A new seal never trusts hand-written or stale source overrides. The
+    # caller must re-authorize every retained above-audience input by exact key.
+    manifest["source_overrides"] = [
+        {"source": key, "reason": reason} for key in sorted(allowed_sources)
+    ]
+
+    manifest["audience"] = args.audience
+    manifest["files"] = checkpoint_content_file_hashes(root)
+    manifest["checkpoint_id"] = checkpoint_manifest_id(manifest)
+    write_checkpoint_json(manifest_path, manifest)
+
+    findings, scanned_files = scan_checkpoint_bundle(root, args.audience)
+    finding_ids = {finding.finding_id for finding in findings}
+    unknown_findings = sorted(allowed_findings - finding_ids)
+    if unknown_findings:
+        raise SystemExit("--allow-finding contains an unknown or stale finding ID")
+    blocking = [finding for finding in findings if finding.finding_id not in allowed_findings]
+    source_override_count = len(manifest.get("source_overrides", []))
+    status = "blocked" if blocking else (
+        "overridden" if findings or source_override_count else "passed"
+    )
+    overrides = [
+        {"finding_id": finding_id, "reason": reason}
+        for finding_id in sorted(allowed_findings)
+    ]
+    report: dict[str, Any] = {
+        "schema": CHECKPOINT_PRIVACY_SCHEMA,
+        "scanner_version": CHECKPOINT_SCANNER_VERSION,
+        "checkpoint_id": manifest["checkpoint_id"],
+        "audience": args.audience,
+        "scanned_at": checkpoint_timestamp(),
+        "status": status,
+        "files": scanned_files,
+        "findings": [
+            checkpoint_finding_json(finding, finding.finding_id in allowed_findings)
+            for finding in findings
+        ],
+        "overrides": overrides,
+        "source_override_count": source_override_count,
+    }
+    report["report_id"] = checkpoint_report_id(report)
+    write_checkpoint_json(root / CHECKPOINT_REPORT_NAME, report)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            f"Checkpoint seal: {status} ({len(scanned_files)} files, "
+            f"{len(findings)} findings, {len(overrides)} overrides)"
+        )
+        for finding in findings:
+            print(
+                f"- {finding.finding_id} {finding.category} "
+                f"{finding.path}:{finding.line} - {finding.message}"
+            )
+    return 2 if blocking else 0
+
+
+def checkpoint_verify(args: argparse.Namespace) -> int:
+    root = Path(args.path).expanduser().resolve(strict=False)
+    errors: list[str] = []
+    if not root.is_dir():
+        raise SystemExit("checkpoint verify path must be an existing directory")
+    for name in CHECKPOINT_REQUIRED_FILES | {CHECKPOINT_REPORT_NAME}:
+        if (root / name).is_symlink():
+            result = {
+                "status": "invalid",
+                "errors": ["checkpoint verify refuses symbolic links in the fixed bundle"],
+            }
+            print(json.dumps(result, indent=2, sort_keys=True) if args.json else result["errors"][0])
+            return 2
+    try:
+        manifest = load_json_object(root / "checkpoint.json", "checkpoint manifest")
+        report = load_json_object(root / CHECKPOINT_REPORT_NAME, "checkpoint privacy report")
+    except SystemExit as exc:
+        result = {"status": "invalid", "errors": [str(exc)]}
+        print(json.dumps(result, indent=2, sort_keys=True) if args.json else str(exc))
+        return 2
+    audience = manifest.get("audience")
+    try:
+        validate_checkpoint_manifest(manifest, audience)
+    except SystemExit as exc:
+        errors.append(str(exc))
+    if report.get("schema") != CHECKPOINT_PRIVACY_SCHEMA:
+        errors.append("privacy-report.json has an unsupported schema")
+    if report.get("scanner_version") != CHECKPOINT_SCANNER_VERSION:
+        errors.append("privacy-report.json scanner version is unsupported")
+    if report.get("report_id") != checkpoint_report_id(report):
+        errors.append("privacy-report.json report_id does not match its content")
+    expected_checkpoint_id = checkpoint_manifest_id(manifest)
+    if manifest.get("checkpoint_id") != expected_checkpoint_id:
+        errors.append("checkpoint.json checkpoint_id does not match its content")
+    if report.get("checkpoint_id") != manifest.get("checkpoint_id"):
+        errors.append("privacy report checkpoint_id does not match checkpoint.json")
+    if report.get("audience") != audience:
+        errors.append("privacy report audience does not match checkpoint.json")
+
+    actual_content_files = checkpoint_content_file_hashes(root)
+    if manifest.get("files") != actual_content_files:
+        errors.append("checkpoint.json generated-file hashes do not match the bundle")
+    findings, scanned_files = scan_checkpoint_bundle(root, audience) if audience in CHECKPOINT_AUDIENCES else ([], [])
+    if report.get("files") != scanned_files:
+        errors.append("privacy report file hashes do not match the bundle")
+    report_finding_ids = {
+        item.get("id") for item in report.get("findings", []) if isinstance(item, dict)
+    }
+    actual_finding_ids = {finding.finding_id for finding in findings}
+    if report_finding_ids != actual_finding_ids:
+        errors.append("privacy findings do not match a fresh scan")
+    override_rows = report.get("overrides")
+    if not isinstance(override_rows, list):
+        errors.append("privacy report overrides must be an array")
+        override_rows = []
+    override_ids: set[str] = set()
+    for index, item in enumerate(override_rows):
+        if not isinstance(item, dict) or not isinstance(item.get("finding_id"), str):
+            errors.append(f"privacy report override {index + 1} is invalid")
+            continue
+        try:
+            validate_override_reason(item.get("reason"))
+        except SystemExit:
+            errors.append(f"privacy report override {index + 1} has an invalid reason")
+            continue
+        override_ids.add(item["finding_id"])
+    if len(override_ids) != len(override_rows):
+        errors.append("privacy report overrides contain duplicate or invalid finding IDs")
+    if not override_ids.issubset(actual_finding_ids):
+        errors.append("privacy report contains an unknown or stale override")
+    expected_finding_records = [
+        checkpoint_finding_json(finding, finding.finding_id in override_ids)
+        for finding in findings
+    ]
+    if report.get("findings") != expected_finding_records:
+        errors.append("privacy report finding metadata does not match a fresh scan")
+    blocking_ids = actual_finding_ids - override_ids
+    source_override_count = len(manifest.get("source_overrides", []))
+    if report.get("source_override_count") != source_override_count:
+        errors.append("privacy report source override count does not match checkpoint.json")
+    expected_status = "blocked" if blocking_ids else (
+        "overridden" if actual_finding_ids or source_override_count else "passed"
+    )
+    if report.get("status") != expected_status:
+        errors.append("privacy report status does not match the current findings")
+    result = {
+        "schema": CHECKPOINT_PRIVACY_SCHEMA,
+        "status": "invalid" if errors else expected_status,
+        "checkpoint_id": manifest.get("checkpoint_id"),
+        "audience": audience,
+        "file_count": len(scanned_files),
+        "finding_count": len(findings),
+        "override_count": len(override_ids),
+        "source_override_count": source_override_count,
+        "finding_categories": sorted({finding.category for finding in findings}),
+        "errors": errors,
+    }
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            f"Checkpoint verify: {result['status']} ({result['file_count']} files, "
+            f"{result['finding_count']} findings, {result['override_count']} overrides)"
+        )
+        for error in errors:
+            print(f"- {error}")
+    return 2 if errors or expected_status == "blocked" else 0
+
+
+def run_checkpoint(args: argparse.Namespace) -> int:
+    handlers = {"seal": checkpoint_seal, "verify": checkpoint_verify}
+    return handlers[args.checkpoint_command](args)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="llm-wiki",
@@ -4586,6 +5297,52 @@ def build_parser() -> argparse.ArgumentParser:
     adapter_remove_parser.add_argument("--json", action="store_true", help="Print JSON.")
 
     adapter.set_defaults(func=run_adapter)
+
+    checkpoint = subparsers.add_parser(
+        "checkpoint",
+        help="Seal and verify portable Project Knowledge Checkpoints.",
+        description=(
+            "Deterministically validate, hash, privacy-scan, seal, and verify a "
+            "Project Knowledge Checkpoint generated by the agentic wiki workflow."
+        ),
+    )
+    checkpoint_sub = checkpoint.add_subparsers(dest="checkpoint_command", required=True)
+
+    checkpoint_seal_parser = checkpoint_sub.add_parser(
+        "seal", help="Finalize hashes and run the mandatory privacy scan."
+    )
+    checkpoint_seal_parser.add_argument("path", help="Checkpoint bundle directory.")
+    checkpoint_seal_parser.add_argument(
+        "--audience",
+        required=True,
+        choices=sorted(CHECKPOINT_AUDIENCES),
+        help="Declared recipient boundary for source-access validation.",
+    )
+    checkpoint_seal_parser.add_argument(
+        "--allow-finding",
+        action="append",
+        default=[],
+        help="Explicitly acknowledge one exact finding ID; repeatable.",
+    )
+    checkpoint_seal_parser.add_argument(
+        "--allow-source",
+        action="append",
+        default=[],
+        help="Explicitly retain one exact wiki:path input above the audience; repeatable.",
+    )
+    checkpoint_seal_parser.add_argument(
+        "--override-reason",
+        help="One-line reason required for any source or finding override.",
+    )
+    checkpoint_seal_parser.add_argument("--json", action="store_true", help="Print JSON.")
+
+    checkpoint_verify_parser = checkpoint_sub.add_parser(
+        "verify", help="Recheck bundle structure, hashes, and privacy attestation."
+    )
+    checkpoint_verify_parser.add_argument("path", help="Checkpoint bundle directory.")
+    checkpoint_verify_parser.add_argument("--json", action="store_true", help="Print JSON.")
+
+    checkpoint.set_defaults(func=run_checkpoint)
 
     return parser
 

--- a/plugins/llm-wiki/bin/llm-wiki
+++ b/plugins/llm-wiki/bin/llm-wiki
@@ -13,6 +13,7 @@ import datetime as dt
 import getpass
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
@@ -92,6 +93,7 @@ CHECKPOINT_REQUIRED_FILES = {
 }
 CHECKPOINT_REPORT_NAME = "privacy-report.json"
 CHECKPOINT_MAX_FILE_BYTES = 10 * 1024 * 1024
+CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO = 0.20
 
 ROOT_ALLOWED = {
     "_index.md",
@@ -4438,6 +4440,50 @@ def checkpoint_source_key(item: dict[str, Any]) -> str:
     return f"{item.get('wiki', '')}:{item.get('path', '')}"
 
 
+def checkpoint_word_count(text: str) -> int:
+    return len(re.findall(r"\b[\w][\w'-]*\b", text, flags=re.UNICODE))
+
+
+def checkpoint_coverage_metrics(root: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    inputs = manifest.get("inputs", [])
+    source_word_count = sum(
+        item.get("words", 0) for item in inputs if isinstance(item, dict)
+    )
+    knowledge_path = root / "project-knowledge.md"
+    try:
+        knowledge_text = knowledge_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        knowledge_text = ""
+    knowledge_word_count = checkpoint_word_count(knowledge_text)
+    retention_ratio = (
+        knowledge_word_count / source_word_count if source_word_count else 0.0
+    )
+    return {
+        "source_word_count": source_word_count,
+        "knowledge_word_count": knowledge_word_count,
+        "retention_ratio": round(retention_ratio, 4),
+        "minimum_retention_ratio": CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO,
+    }
+
+
+def apply_checkpoint_coverage_metrics(root: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    metrics = checkpoint_coverage_metrics(root, manifest)
+    if metrics["retention_ratio"] < CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO:
+        required_words = math.ceil(
+            metrics["source_word_count"] * CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO
+        )
+        raise SystemExit(
+            "project-knowledge.md is too thin for comprehensive mode: "
+            f"{metrics['knowledge_word_count']} words for "
+            f"{metrics['source_word_count']} selected-source words; "
+            f"write at least {required_words} words or reduce the selected scope"
+        )
+    coverage = manifest["coverage"]
+    for key, value in metrics.items():
+        coverage[key] = value
+    return metrics
+
+
 def checkpoint_source_access_findings(
     manifest: dict[str, Any], audience: str
 ) -> list[CheckpointFinding]:
@@ -4642,7 +4688,7 @@ def validate_checkpoint_manifest(manifest: dict[str, Any], audience: str) -> Non
         raise SystemExit("checkpoint.json created_at must be a non-empty string")
     if not isinstance(manifest.get("scope"), dict):
         raise SystemExit("checkpoint.json scope must be an object")
-    if not isinstance(manifest.get("inputs"), list):
+    if not isinstance(manifest.get("inputs"), list) or not manifest["inputs"]:
         raise SystemExit("checkpoint.json inputs must be an array")
     if not isinstance(manifest.get("gaps"), list):
         raise SystemExit("checkpoint.json gaps must be an array")
@@ -4652,15 +4698,59 @@ def validate_checkpoint_manifest(manifest: dict[str, Any], audience: str) -> Non
         for field in ("wiki", "path", "sha256", "reason", "access"):
             if not isinstance(item.get(field), str) or not item[field].strip():
                 raise SystemExit(f"checkpoint.json input {index + 1} requires {field}")
+        if not isinstance(item.get("words"), int) or item["words"] <= 0:
+            raise SystemExit(f"checkpoint.json input {index + 1} words must be a positive integer")
         if not re.fullmatch(r"[0-9a-f]{64}", item["sha256"]):
             raise SystemExit(f"checkpoint.json input {index + 1} sha256 must be 64 lowercase hex characters")
         source_path = item["path"]
         if Path(source_path).is_absolute() or ".." in Path(source_path).parts:
             raise SystemExit(f"checkpoint.json input {index + 1} path must be wiki-relative")
+    input_keys = [checkpoint_source_key(item) for item in manifest["inputs"]]
+    if len(set(input_keys)) != len(input_keys):
+        raise SystemExit("checkpoint.json inputs must have unique wiki:path keys")
+
+    coverage = manifest.get("coverage")
+    if not isinstance(coverage, dict):
+        raise SystemExit("checkpoint.json coverage must be an object")
+    if coverage.get("mode") != "comprehensive":
+        raise SystemExit("checkpoint.json coverage.mode must be 'comprehensive'")
+    source_word_count = sum(item["words"] for item in manifest["inputs"])
+    if coverage.get("source_word_count") != source_word_count:
+        raise SystemExit("checkpoint.json coverage.source_word_count must equal input words")
+    section_map = coverage.get("section_map")
+    if not isinstance(section_map, list) or not section_map:
+        raise SystemExit("checkpoint.json coverage.section_map must be a non-empty array")
+    mapped_sources: set[str] = set()
+    valid_input_keys = set(input_keys)
+    for index, item in enumerate(section_map):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} must be an object")
+        if not isinstance(item.get("section"), str) or not item["section"].strip():
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} requires section")
+        sources = item.get("sources")
+        if not isinstance(sources, list) or not sources:
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} requires sources")
+        if any(not isinstance(source, str) or source not in valid_input_keys for source in sources):
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} names an unknown input")
+        mapped_sources.update(sources)
+    if mapped_sources != valid_input_keys:
+        raise SystemExit("checkpoint.json coverage.section_map must account for every input")
+    omissions = coverage.get("omissions")
+    if not isinstance(omissions, list):
+        raise SystemExit("checkpoint.json coverage.omissions must be an array")
+    for index, item in enumerate(omissions):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json coverage omission {index + 1} must be an object")
+        if item.get("source") not in valid_input_keys:
+            raise SystemExit(f"checkpoint.json coverage omission {index + 1} names an unknown input")
+        for field in ("section", "reason"):
+            if not isinstance(item.get(field), str) or not item[field].strip():
+                raise SystemExit(f"checkpoint.json coverage omission {index + 1} requires {field}")
+
     source_overrides = manifest.get("source_overrides", [])
     if not isinstance(source_overrides, list):
         raise SystemExit("checkpoint.json source_overrides must be an array")
-    input_keys = {checkpoint_source_key(item) for item in manifest["inputs"]}
+    input_keys = set(input_keys)
     for index, item in enumerate(source_overrides):
         if not isinstance(item, dict):
             raise SystemExit(f"checkpoint.json source override {index + 1} must be an object")
@@ -4775,6 +4865,7 @@ def checkpoint_seal(args: argparse.Namespace) -> int:
     ]
 
     manifest["audience"] = args.audience
+    coverage_metrics = apply_checkpoint_coverage_metrics(root, manifest)
     manifest["files"] = checkpoint_content_file_hashes(root)
     manifest["checkpoint_id"] = checkpoint_manifest_id(manifest)
     write_checkpoint_json(manifest_path, manifest)
@@ -4807,6 +4898,7 @@ def checkpoint_seal(args: argparse.Namespace) -> int:
         ],
         "overrides": overrides,
         "source_override_count": source_override_count,
+        "coverage": coverage_metrics,
     }
     report["report_id"] = checkpoint_report_id(report)
     write_checkpoint_json(root / CHECKPOINT_REPORT_NAME, report)
@@ -4864,6 +4956,16 @@ def checkpoint_verify(args: argparse.Namespace) -> int:
     if report.get("audience") != audience:
         errors.append("privacy report audience does not match checkpoint.json")
 
+    coverage_metrics = checkpoint_coverage_metrics(root, manifest)
+    coverage = manifest.get("coverage", {})
+    for key, value in coverage_metrics.items():
+        if coverage.get(key) != value:
+            errors.append(f"checkpoint.json coverage {key} does not match the bundle")
+    if coverage_metrics["retention_ratio"] < CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO:
+        errors.append("project-knowledge.md is too thin for comprehensive mode")
+    if report.get("coverage") != coverage_metrics:
+        errors.append("privacy report coverage metrics do not match the bundle")
+
     actual_content_files = checkpoint_content_file_hashes(root)
     if manifest.get("files") != actual_content_files:
         errors.append("checkpoint.json generated-file hashes do not match the bundle")
@@ -4919,6 +5021,7 @@ def checkpoint_verify(args: argparse.Namespace) -> int:
         "finding_count": len(findings),
         "override_count": len(override_ids),
         "source_override_count": source_override_count,
+        "coverage": coverage_metrics,
         "finding_categories": sorted({finding.category for finding in findings}),
         "errors": errors,
     }

--- a/plugins/llm-wiki/skills/wiki/SKILL.md
+++ b/plugins/llm-wiki/skills/wiki/SKILL.md
@@ -11,6 +11,7 @@ description: >
   dataset manifest, compilation, querying, linting, audit, research, librarian,
   scan quality, article quality, content review, output drift, provenance,
   archive wiki, archive topic, restore wiki, private adapter, adapter registry, skill-factory,
+  checkpoints,
   personal specialist, specialist skill, specialist reviewer, expert lens,
   adapter route, adapter doctor, adapter run, edit an external resource, session capture, capture context, rehydrate,
   resume from session, implementation plan, or uses
@@ -110,6 +111,10 @@ authority, or permission to spawn agents. Select the minimum useful method,
 preserve disagreement, and record its version/hash. See
 [references/specialists.md](references/specialists.md).
 
+15. **Project checkpoints are privacy-sealed.** Never dump raw/sessions; seal
+and exact overrides are required. See
+[references/checkpoints.md](references/checkpoints.md).
+
 ## Adapter Routing
 
 For an action plus URL, run `adapter route --intent <effect> --resource <url>
@@ -161,6 +166,7 @@ reference material you need for that workflow:
 - `audit` → `references/audit.md`
 - `research`, `plan`, `output`, `assess` → `references/research-infrastructure.md`
 - `project` → `references/projects.md`
+- `checkpoint` → `references/checkpoints.md`
 - `librarian` → `references/librarian.md`
 - wiki structure, indexes, log format, file placement, init → `references/wiki-structure.md`
 - hub lookup and path handling → `references/hub-resolution.md`

--- a/plugins/llm-wiki/skills/wiki/SKILL.md
+++ b/plugins/llm-wiki/skills/wiki/SKILL.md
@@ -111,8 +111,7 @@ authority, or permission to spawn agents. Select the minimum useful method,
 preserve disagreement, and record its version/hash. See
 [references/specialists.md](references/specialists.md).
 
-15. **Project checkpoints are privacy-sealed.** Never dump raw/sessions; seal
-and exact overrides are required. See
+15. **Project checkpoints need comprehensive coverage and a privacy seal.** See
 [references/checkpoints.md](references/checkpoints.md).
 
 ## Adapter Routing

--- a/plugins/llm-wiki/skills/wiki/references/checkpoints.md
+++ b/plugins/llm-wiki/skills/wiki/references/checkpoints.md
@@ -16,7 +16,7 @@ docs/knowledge/<project-slug>/
 ```
 
 - `index.md`: portable entry point and import/verification guidance.
-- `project-knowledge.md`: coherent new synthesis.
+- `project-knowledge.md`: full synthesis.
 - `sources.md`: readable evidence ledger with stable source IDs.
 - `checkpoint.json`: scope, project revision, selected inputs/reasons/hashes,
   exclusions, gaps, audience, generated hashes, and checkpoint identity.
@@ -36,15 +36,17 @@ question, aliases, README, supplied `WHY.md`/`BRIEF.md`, ADRs, architecture and
 operations/security docs, and explicit seeds. Do not scan `.git`, dependencies,
 builds, caches, env files, or arbitrary user directories.
 
-Read HUB index/registry, then every active topic root and `wiki/_index.md`.
-Shortlist by goal, titles, summaries, aliases, tags, entities, decisions,
-constraints, and project references. Read only selected compiled articles;
-follow one supporting hop when an important claim, conflict, risk, or decision
-needs it. Archives require explicit inclusion. Raw bodies are not export data.
+Read HUB/indexes and selected compiled/Idea/Project/plan/output material; one
+support hop is allowed. Archives are explicit; raw is excluded. Record
+topic/path/hash/words, reason, confidence, access/reuse, exclusions/gaps.
 
-Record for every input: origin topic, wiki-relative path, SHA-256, selection
-reason, confidence, `public|team|private|unknown` access, and reuse note. Record
-material exclusions and gaps so “most relevant” stays auditable.
+## Comprehensive coverage contract
+
+Default to comprehensive, not executive-summary-only. Retain tables,
+requirements, alternatives, phases, workflows, rights, risks, and gaps. Every
+input needs positive `words` and a mapped section; `coverage` stores the total
+and omissions. Seal rejects knowledge below 20% of selected
+words. The floor is not a quality score.
 
 `project-knowledge.md` keeps this order:
 
@@ -126,7 +128,7 @@ explicit `public`; unknown visibility stops before final copy.
 
 `checkpoint.json` uses `llm-wiki/project-knowledge-checkpoint/v1`: sealer ID,
 files/hashes, time/audience, project/revision, scope/policy, inputs with
-topic/path/hash/reason/access, exact overrides, exclusions, and gaps.
+topic/path/hash/words/reason/access, coverage, overrides, exclusions, and gaps.
 
 Paths are bundle-, repo-, or wiki-relative. Never serialize a hub/home root,
 transcript pointer, adapter root, or temporary path.

--- a/plugins/llm-wiki/skills/wiki/references/checkpoints.md
+++ b/plugins/llm-wiki/skills/wiki/references/checkpoints.md
@@ -1,0 +1,154 @@
+# Project Knowledge Checkpoints
+
+A checkpoint is a portable snapshot of what a teammate needs to understand,
+build, operate, or import one project. It is a curated materialized view across
+active topic wikis—not a topic, raw-source, or session dump.
+
+## Bundle and operations
+
+```text
+docs/knowledge/<project-slug>/
+├── index.md
+├── project-knowledge.md
+├── sources.md
+├── checkpoint.json
+└── privacy-report.json
+```
+
+- `index.md`: portable entry point and import/verification guidance.
+- `project-knowledge.md`: coherent new synthesis.
+- `sources.md`: readable evidence ledger with stable source IDs.
+- `checkpoint.json`: scope, project revision, selected inputs/reasons/hashes,
+  exclusions, gaps, audience, generated hashes, and checkpoint identity.
+- `privacy-report.json`: deterministic file-hash and privacy attestation. The
+  agent never hand-writes it, and it never contains matched excerpts.
+
+Operations are `create` (discover/synthesize), `refresh` (review diffs),
+`verify` (read-only checks), and `import` (pinned evidence, not truth).
+
+Create/refresh are dry-run first. `--apply` grants only the previewed file
+write; commit, push, publication, release, and import remain separate.
+
+## Selection and synthesis
+
+Start from a bounded project packet: exact repo/revision, goal, audience,
+question, aliases, README, supplied `WHY.md`/`BRIEF.md`, ADRs, architecture and
+operations/security docs, and explicit seeds. Do not scan `.git`, dependencies,
+builds, caches, env files, or arbitrary user directories.
+
+Read HUB index/registry, then every active topic root and `wiki/_index.md`.
+Shortlist by goal, titles, summaries, aliases, tags, entities, decisions,
+constraints, and project references. Read only selected compiled articles;
+follow one supporting hop when an important claim, conflict, risk, or decision
+needs it. Archives require explicit inclusion. Raw bodies are not export data.
+
+Record for every input: origin topic, wiki-relative path, SHA-256, selection
+reason, confidence, `public|team|private|unknown` access, and reuse note. Record
+material exclusions and gaps so “most relevant” stays auditable.
+
+`project-knowledge.md` keeps this order:
+
+1. purpose, audience, current state;
+2. project/system map;
+3. decisions and rejected alternatives;
+4. facts, assumptions, and evidence strength;
+5. requirements, constraints, non-goals;
+6. development and operating workflows;
+7. risks, failure modes, privacy/security boundaries;
+8. terminology and important entities;
+9. disagreement, unknowns, gaps;
+10. next experiments/actions; and
+11. scope, trust, refresh instructions.
+
+Use stable source IDs for material claims. Distinguish source facts, user
+decisions, hypotheses, and recommendations. Never concatenate articles or
+promise completeness beyond the selection method.
+
+## Mandatory privacy gate
+
+Privacy has two layers; neither may be skipped.
+
+### Semantic minimization
+
+Classify every input before synthesis. `unknown` fails closed; an input above
+the declared audience requires explicit exact-source approval. Exclude by
+default:
+
+- raw bodies, copied paywalled/licensed text, and unverified private evidence;
+- sessions, transcripts, event logs, prompts, feedback, and chat text;
+- home paths, usernames, hostnames, local IPs, mounts, and temp paths;
+- credentials, keys, tokens, cookies, connection strings, and secrets;
+- private-adapter code, requests, receipts, artifacts, and data-plane paths;
+- customer, health, legal, financial, or other personal records; and
+- internal URLs, repos, issues, organization detail, or identifiers outside
+  the audience.
+
+Summarize only what recipients need. A scanner cannot recognize every
+confidential decision, so semantic review remains mandatory even after a pass.
+
+### Deterministic seal
+
+Generate in private staging, then run the bundled helper:
+
+```bash
+llm-wiki checkpoint seal <bundle> --audience private|team|public --json
+llm-wiki checkpoint verify <bundle> --json
+```
+
+Seal enforces the fixed UTF-8 Markdown/JSON bundle, computes file hashes and
+checkpoint ID, scans names/content, and writes `privacy-report.json`. It covers
+likely secrets, credentials, identities, local paths/network data,
+session/transcript metadata, and prompt/conversation markers. Reports contain
+only category, safe/opaque relative path, line, message, and stable finding ID.
+
+There is no `--no-scan` or global bypass. Intentional retention requires every
+exact current finding/source ID plus a one-line reason:
+
+```bash
+llm-wiki checkpoint seal <bundle> --audience team \
+  --allow-finding privacy-<id> \
+  --override-reason "Public attribution handle"
+```
+
+The scan reruns and reports `overridden`, not `passed`. Never infer an override
+from general approval. IDs are content/line-bound; changed or stale values need
+review again. Source overrides are likewise exact and attested.
+
+Blocked staging must not reach the final repo. After a passed/overridden seal,
+copy the complete five files and verify the destination. On failure remove the
+new copy or restore its backup. Never commit staging.
+
+## Audience and manifest
+
+Audience is `private`, `team`, or `public`. Default `private` only for
+local/untracked or authoritatively private destinations. Public repos require
+explicit `public`; unknown visibility stops before final copy.
+
+`checkpoint.json` uses `llm-wiki/project-knowledge-checkpoint/v1`: sealer ID,
+files/hashes, time/audience, project/revision, scope/policy, inputs with
+topic/path/hash/reason/access, exact overrides, exclusions, and gaps.
+
+Paths are bundle-, repo-, or wiki-relative. Never serialize a hub/home root,
+transcript pointer, adapter root, or temporary path.
+
+## Refresh
+
+Verify first, rerun stored scope, preserve logical source IDs, and show:
+
+- sources/claims added, removed, or changed;
+- decisions/constraints changed;
+- gaps opened/closed; and
+- privacy findings/overrides changed.
+
+Attested hash differences reveal human edits. Never overwrite silently; offer
+staged regeneration, manual merge, or a new path, then seal and verify again.
+
+## Import
+
+Verify before reading/importing. Reject invalid hashes, missing attestation, or
+`blocked`; show `overridden` IDs/categories and require recipient acceptance.
+For repos, isolate the bundle at the exact producing revision.
+
+Ingest all five files as one bounded collection; preserve checkpoint ID,
+audience, source IDs, trust, and staleness; dedupe by ID then path/hash.
+Imported synthesis never overwrites Projects, articles, or prior snapshots.

--- a/plugins/llm-wiki/skills/wiki/references/projects.md
+++ b/plugins/llm-wiki/skills/wiki/references/projects.md
@@ -7,6 +7,12 @@ shaped Idea in `inventory/ideas/`. See [ideas.md](ideas.md). Direct Projects
 remain appropriate for maintenance, migrations, incident response, and other
 work that does not benefit from an incubation step.
 
+A Project folder is not a portable knowledge export. When teammates need the
+relevant knowledge from multiple topic wikis inside a working repository, use
+the privacy-sealed [Project Knowledge Checkpoint](checkpoints.md) workflow. The
+Project keeps delivery truth; the checkpoint is a reviewable snapshot for
+handoff/import and never becomes a second live Project state store.
+
 The read-only [Portfolio workflow](portfolio.md) lists Projects across active
 topic wikis and distinguishes explicitly promoted Projects from direct ones.
 

--- a/scripts/llm-wiki
+++ b/scripts/llm-wiki
@@ -80,6 +80,18 @@ SPECIALIST_REQUIRED_SECTIONS = [
     "Evaluation cases",
     "Provenance and maintenance",
 ]
+CHECKPOINT_SCHEMA = "llm-wiki/project-knowledge-checkpoint/v1"
+CHECKPOINT_PRIVACY_SCHEMA = "llm-wiki/checkpoint-privacy-report/v1"
+CHECKPOINT_SCANNER_VERSION = 1
+CHECKPOINT_AUDIENCES = {"private", "team", "public"}
+CHECKPOINT_REQUIRED_FILES = {
+    "index.md",
+    "project-knowledge.md",
+    "sources.md",
+    "checkpoint.json",
+}
+CHECKPOINT_REPORT_NAME = "privacy-report.json"
+CHECKPOINT_MAX_FILE_BYTES = 10 * 1024 * 1024
 
 ROOT_ALLOWED = {
     "_index.md",
@@ -149,6 +161,16 @@ class Document:
     path: Path
     frontmatter: dict[str, Any]
     body: str
+
+
+@dataclass(frozen=True)
+class CheckpointFinding:
+    finding_id: str
+    category: str
+    severity: str
+    path: str
+    line: int
+    message: str
 
 
 class LintContext:
@@ -4228,6 +4250,695 @@ def run_adapter(args: argparse.Namespace) -> int:
     return handlers[args.adapter_command](args)
 
 
+def checkpoint_pattern_specs() -> list[tuple[str, str, str, re.Pattern[str]]]:
+    flags = re.IGNORECASE | re.MULTILINE
+    return [
+        (
+            "secret-private-key",
+            "critical",
+            "Possible private-key material.",
+            re.compile(
+                r"-----BEGIN (?:(?:[A-Z0-9 ]+ )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----",
+                flags,
+            ),
+        ),
+        (
+            "secret-known-token",
+            "critical",
+            "Possible service credential or bearer token.",
+            re.compile(
+                r"(?:\bAKIA[0-9A-Z]{16}\b|\bgh[pousr]_[A-Za-z0-9]{20,}\b|"
+                r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b|\bsk-[A-Za-z0-9_-]{16,}\b|"
+                r"\bAIza[0-9A-Za-z_-]{25,}\b|\bBearer\s+[A-Za-z0-9._~+/=-]{12,}|"
+                r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b)",
+                flags,
+            ),
+        ),
+        (
+            "secret-assignment",
+            "critical",
+            "Possible credential assigned to a sensitive field.",
+            re.compile(
+                r"\b(?:api[_-]?key|private[_-]?key|(?:access|auth|api|refresh)?[_-]?token|"
+                r"client[_-]?secret|password|passwd|secret|session[_-]?cookie)\b"
+                r"\s*[\"']?\s*[:=]\s*"
+                r"[\"']?[A-Za-z0-9_./+=$~-]{8,}",
+                flags,
+            ),
+        ),
+        (
+            "secret-url-credentials",
+            "critical",
+            "Possible username/password embedded in a URL.",
+            re.compile(r"\b[a-z][a-z0-9+.-]*://[^\s/@:]+:[^\s/@]+@", flags),
+        ),
+        (
+            "personal-email",
+            "warning",
+            "Email address may identify a person or private account.",
+            re.compile(r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
+        ),
+        (
+            "personal-account-field",
+            "warning",
+            "Account or username field may expose an identity.",
+            re.compile(
+                r"^[ \t]*[\"']?(?:user(?:name)?|login|account(?:[_-]?name)?|handle)"
+                r"[\"']?[ \t]*[:=][ \t]*[\"']?@?[A-Za-z0-9_.-]{2,}",
+                flags,
+            ),
+        ),
+        (
+            "local-home-path",
+            "critical",
+            "Machine-local home directory path.",
+            re.compile(
+                r"(?:(?<![:A-Za-z0-9])/Users/[A-Za-z0-9._-]+(?:/|\b)|"
+                r"(?<![:A-Za-z0-9])/home/[A-Za-z0-9._-]+(?:/|\b)|"
+                r"(?<![:A-Za-z0-9])/root(?:/|\b)|[A-Za-z]:\\Users\\[A-Za-z0-9._ -]+(?:\\|\b))",
+                flags,
+            ),
+        ),
+        (
+            "local-machine-path",
+            "critical",
+            "Machine-local volume, temporary, or file URL path.",
+            re.compile(
+                r"(?:file://|(?:~|\$HOME|\$\{HOME\})/|(?<![:A-Za-z0-9])/Volumes/[^\s/]+(?:/|\b)|"
+                r"(?<![:A-Za-z0-9])/private/var/folders/|(?<![:A-Za-z0-9])/(?:tmp|var|etc|opt|srv|mnt|media|workspace|Applications|Library)/[^\s`\"']+)",
+                flags,
+            ),
+        ),
+        (
+            "remote-login-identity",
+            "warning",
+            "Remote-login syntax may expose a username or private host.",
+            re.compile(r"\b(?:ssh|scp|sftp|rsync)\b[^\n]*\b[A-Za-z0-9._-]+@[A-Za-z0-9._-]+", flags),
+        ),
+        (
+            "local-network-address",
+            "warning",
+            "Private-network address may reveal local infrastructure.",
+            re.compile(
+                r"\b(?:10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|"
+                r"172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2})\b"
+            ),
+        ),
+        (
+            "local-hostname",
+            "warning",
+            "Local hostname may reveal private infrastructure.",
+            re.compile(
+                r"(?:\b[A-Za-z0-9][A-Za-z0-9-]{0,62}\.local\b|"
+                r"\b[A-Za-z0-9][A-Za-z0-9.-]{0,126}\.(?:lan|internal)\b|"
+                r"^[ \t]*[\"']?hostname[\"']?[ \t]*[:=][ \t]*[\"']?[^\s\"']+)",
+                flags,
+            ),
+        ),
+        (
+            "session-transcript",
+            "critical",
+            "Session or transcript metadata must not enter a checkpoint.",
+            re.compile(
+                r"(?:transcript[_-]?path|rollout-[^\s]+\.jsonl|\.sessions/(?:digests|feedback)/|"
+                r"\b(?:codex|claude):[0-9a-f]{8}-[0-9a-f-]{27,}\b|UserPromptSubmit|PreCompact|PostCompact)",
+                flags,
+            ),
+        ),
+        (
+            "prompt-conversation-role",
+            "warning",
+            "Conversation-role content may be copied prompt or transcript text.",
+            re.compile(
+                r"(?:^[ \t]*(?:system|developer|assistant|user)[ \t]*:[ \t]+\S|"
+                r"[\"']role[\"'][ \t]*:[ \t]*[\"'](?:system|developer|assistant|user)[\"'])",
+                flags,
+            ),
+        ),
+        (
+            "prompt-instruction-marker",
+            "warning",
+            "Prompt/instruction marker may expose agent instructions.",
+            re.compile(
+                r"(?:<\|(?:system|user|assistant)\|>|\[INST\]|</?system>|"
+                r"AGENTS\.md instructions for|(?:system|developer) prompt[ \t]*:)",
+                flags,
+            ),
+        ),
+    ]
+
+
+def checkpoint_finding(
+    category: str,
+    severity: str,
+    path: str,
+    line: int,
+    message: str,
+    evidence: str,
+) -> CheckpointFinding:
+    digest = hashlib.sha256(
+        "\0".join([category, path, str(line), evidence]).encode("utf-8")
+    ).hexdigest()[:16]
+    return CheckpointFinding(
+        finding_id=f"privacy-{digest}",
+        category=category,
+        severity=severity,
+        path=path,
+        line=line,
+        message=message,
+    )
+
+
+def scan_checkpoint_text(text: str, rel: str) -> list[CheckpointFinding]:
+    findings: list[CheckpointFinding] = []
+    for category, severity, message, pattern in checkpoint_pattern_specs():
+        for match in pattern.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            findings.append(
+                checkpoint_finding(
+                    category,
+                    severity,
+                    rel,
+                    line,
+                    message,
+                    match.group(0),
+                )
+            )
+    return findings
+
+
+def checkpoint_file_paths(root: Path, include_report: bool = False) -> list[Path]:
+    names = set(CHECKPOINT_REQUIRED_FILES)
+    if include_report:
+        names.add(CHECKPOINT_REPORT_NAME)
+    return [root / name for name in sorted(names) if (root / name).exists() or (root / name).is_symlink()]
+
+
+def checkpoint_source_key(item: dict[str, Any]) -> str:
+    return f"{item.get('wiki', '')}:{item.get('path', '')}"
+
+
+def checkpoint_source_access_findings(
+    manifest: dict[str, Any], audience: str
+) -> list[CheckpointFinding]:
+    inputs = manifest.get("inputs")
+    if not isinstance(inputs, list):
+        return [
+            checkpoint_finding(
+                "structure-inputs",
+                "critical",
+                "checkpoint.json",
+                1,
+                "Manifest inputs must be an array.",
+                "inputs-not-array",
+            )
+        ]
+    source_overrides = manifest.get("source_overrides", [])
+    override_keys = {
+        entry.get("source")
+        for entry in source_overrides
+        if isinstance(entry, dict)
+        and isinstance(entry.get("source"), str)
+        and isinstance(entry.get("reason"), str)
+        and entry.get("reason", "").strip()
+    }
+    allowed = {
+        "private": {"public", "team", "private"},
+        "team": {"public", "team"},
+        "public": {"public"},
+    }[audience]
+    findings: list[CheckpointFinding] = []
+    for index, item in enumerate(inputs):
+        if not isinstance(item, dict):
+            findings.append(
+                checkpoint_finding(
+                    "structure-input",
+                    "critical",
+                    "checkpoint.json",
+                    1,
+                    f"Input {index + 1} must be an object.",
+                    f"input-{index}-not-object",
+                )
+            )
+            continue
+        access = item.get("access")
+        key = checkpoint_source_key(item)
+        if access not in {"public", "team", "private", "unknown"}:
+            message = f"Input {index + 1} has no valid access classification."
+        elif access not in allowed:
+            message = f"Input {index + 1} exceeds the declared {audience} audience."
+        else:
+            continue
+        if key in override_keys:
+            continue
+        findings.append(
+            checkpoint_finding(
+                "source-access",
+                "critical",
+                "checkpoint.json",
+                1,
+                message,
+                f"{index}:{key}:{access}:{audience}",
+            )
+        )
+    return findings
+
+
+def scan_checkpoint_bundle(root: Path, audience: str) -> tuple[list[CheckpointFinding], list[dict[str, str]]]:
+    findings: list[CheckpointFinding] = []
+    files: list[dict[str, str]] = []
+    allowed_names = CHECKPOINT_REQUIRED_FILES | {CHECKPOINT_REPORT_NAME}
+    for path in sorted(root.iterdir(), key=lambda item: item.name):
+        if path.name in allowed_names:
+            continue
+        opaque_path = "unexpected-" + hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:12]
+        findings.append(
+            checkpoint_finding(
+                "structure-unexpected-entry",
+                "critical",
+                opaque_path,
+                0,
+                "Checkpoint v1 contains an unexpected file or directory; its name is redacted.",
+                path.name,
+            )
+        )
+    for required in sorted(CHECKPOINT_REQUIRED_FILES):
+        if not (root / required).is_file():
+            findings.append(
+                checkpoint_finding(
+                    "structure-required-file",
+                    "critical",
+                    required,
+                    0,
+                    "Required checkpoint file is missing.",
+                    required,
+                )
+            )
+    for path in checkpoint_file_paths(root):
+        rel = path.relative_to(root).as_posix()
+        findings.extend(scan_checkpoint_text(rel, rel))
+        if path.is_symlink():
+            findings.append(
+                checkpoint_finding(
+                    "structure-symlink",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint bundles may not contain symbolic links.",
+                    rel,
+                )
+            )
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError as exc:
+            findings.append(
+                checkpoint_finding(
+                    "structure-unreadable",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint file could not be inspected.",
+                    f"{rel}:{type(exc).__name__}",
+                )
+            )
+            continue
+        if size > CHECKPOINT_MAX_FILE_BYTES:
+            findings.append(
+                checkpoint_finding(
+                    "structure-file-size",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint file exceeds the 10 MiB safety limit.",
+                    f"{rel}:{size}",
+                )
+            )
+            continue
+        if path.suffix.lower() not in {".md", ".json"}:
+            findings.append(
+                checkpoint_finding(
+                    "structure-file-type",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint contains a non-Markdown/non-JSON file.",
+                    rel,
+                )
+            )
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            findings.append(
+                checkpoint_finding(
+                    "structure-non-text",
+                    "critical",
+                    rel,
+                    0,
+                    "Checkpoint file is unreadable or not UTF-8 text.",
+                    f"{rel}:{type(exc).__name__}",
+                )
+            )
+            continue
+        files.append({"path": rel, "sha256": file_sha256(path)})
+        findings.extend(scan_checkpoint_text(text, rel))
+
+    manifest_path = root / "checkpoint.json"
+    if manifest_path.is_file() and not manifest_path.is_symlink():
+        try:
+            manifest = load_json_object(manifest_path, "checkpoint manifest")
+        except SystemExit as exc:
+            findings.append(
+                checkpoint_finding(
+                    "structure-manifest-json",
+                    "critical",
+                    "checkpoint.json",
+                    1,
+                    "Checkpoint manifest is not a valid JSON object.",
+                    str(exc),
+                )
+            )
+        else:
+            findings.extend(checkpoint_source_access_findings(manifest, audience))
+    unique = {finding.finding_id: finding for finding in findings}
+    return (
+        sorted(unique.values(), key=lambda item: (item.path, item.line, item.category, item.finding_id)),
+        sorted(files, key=lambda item: item["path"]),
+    )
+
+
+def validate_checkpoint_manifest(manifest: dict[str, Any], audience: str) -> None:
+    if manifest.get("schema") != CHECKPOINT_SCHEMA:
+        raise SystemExit(f"checkpoint.json schema must be {CHECKPOINT_SCHEMA!r}")
+    if audience not in CHECKPOINT_AUDIENCES:
+        raise SystemExit("checkpoint audience must be private, team, or public")
+    project = manifest.get("project")
+    if not isinstance(project, dict) or not isinstance(project.get("slug"), str) or not project.get("slug"):
+        raise SystemExit("checkpoint.json project.slug must be a non-empty string")
+    if not SPECIALIST_NAME_RE.fullmatch(project["slug"]):
+        raise SystemExit("checkpoint.json project.slug must be lowercase hyphenated text")
+    if not isinstance(manifest.get("created_at"), str) or not manifest["created_at"].strip():
+        raise SystemExit("checkpoint.json created_at must be a non-empty string")
+    if not isinstance(manifest.get("scope"), dict):
+        raise SystemExit("checkpoint.json scope must be an object")
+    if not isinstance(manifest.get("inputs"), list):
+        raise SystemExit("checkpoint.json inputs must be an array")
+    if not isinstance(manifest.get("gaps"), list):
+        raise SystemExit("checkpoint.json gaps must be an array")
+    for index, item in enumerate(manifest["inputs"]):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json input {index + 1} must be an object")
+        for field in ("wiki", "path", "sha256", "reason", "access"):
+            if not isinstance(item.get(field), str) or not item[field].strip():
+                raise SystemExit(f"checkpoint.json input {index + 1} requires {field}")
+        if not re.fullmatch(r"[0-9a-f]{64}", item["sha256"]):
+            raise SystemExit(f"checkpoint.json input {index + 1} sha256 must be 64 lowercase hex characters")
+        source_path = item["path"]
+        if Path(source_path).is_absolute() or ".." in Path(source_path).parts:
+            raise SystemExit(f"checkpoint.json input {index + 1} path must be wiki-relative")
+    source_overrides = manifest.get("source_overrides", [])
+    if not isinstance(source_overrides, list):
+        raise SystemExit("checkpoint.json source_overrides must be an array")
+    input_keys = {checkpoint_source_key(item) for item in manifest["inputs"]}
+    for index, item in enumerate(source_overrides):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json source override {index + 1} must be an object")
+        if item.get("source") not in input_keys:
+            raise SystemExit(f"checkpoint.json source override {index + 1} names an unknown input")
+        if not isinstance(item.get("reason"), str) or not item["reason"].strip():
+            raise SystemExit(f"checkpoint.json source override {index + 1} requires a reason")
+
+
+def checkpoint_content_file_hashes(root: Path) -> list[dict[str, str]]:
+    values: list[dict[str, str]] = []
+    for path in checkpoint_file_paths(root):
+        rel = path.relative_to(root).as_posix()
+        if rel in {"checkpoint.json", CHECKPOINT_REPORT_NAME}:
+            continue
+        if path.is_symlink() or not path.is_file():
+            continue
+        values.append({"path": rel, "sha256": file_sha256(path)})
+    return sorted(values, key=lambda item: item["path"])
+
+
+def checkpoint_manifest_id(manifest: dict[str, Any]) -> str:
+    payload = dict(manifest)
+    payload.pop("checkpoint_id", None)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def checkpoint_report_id(report: dict[str, Any]) -> str:
+    payload = dict(report)
+    payload.pop("report_id", None)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def checkpoint_timestamp() -> str:
+    override = os.environ.get("LLM_WIKI_NOW")
+    if override:
+        return override
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def write_checkpoint_json(path: Path, value: dict[str, Any]) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o644)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def checkpoint_finding_json(finding: CheckpointFinding, allowed: bool) -> dict[str, Any]:
+    return {
+        "id": finding.finding_id,
+        "category": finding.category,
+        "severity": finding.severity,
+        "path": finding.path,
+        "line": finding.line,
+        "message": finding.message,
+        "status": "allowed" if allowed else "blocking",
+    }
+
+
+def validate_override_reason(reason: str | None) -> str:
+    value = (reason or "").strip()
+    if not value:
+        raise SystemExit("--override-reason is required when allowing a source or finding")
+    if len(value) > 240 or "\n" in value or "\r" in value:
+        raise SystemExit("--override-reason must be one line and no more than 240 characters")
+    if scan_checkpoint_text(value, CHECKPOINT_REPORT_NAME):
+        raise SystemExit("--override-reason itself matches a sensitive-information pattern")
+    return value
+
+
+def checkpoint_seal(args: argparse.Namespace) -> int:
+    root = Path(args.path).expanduser().resolve(strict=False)
+    if not root.is_dir():
+        raise SystemExit("checkpoint seal path must be an existing directory")
+    for name in CHECKPOINT_REQUIRED_FILES | {CHECKPOINT_REPORT_NAME}:
+        if (root / name).is_symlink():
+            raise SystemExit("checkpoint seal refuses symbolic links in the fixed bundle")
+    manifest_path = root / "checkpoint.json"
+    manifest = load_json_object(manifest_path, "checkpoint manifest")
+    validate_checkpoint_manifest(manifest, args.audience)
+
+    allowed_findings = set(args.allow_finding or [])
+    allowed_sources = set(args.allow_source or [])
+    reason: str | None = None
+    if allowed_findings or allowed_sources:
+        reason = validate_override_reason(args.override_reason)
+
+    input_keys = {
+        checkpoint_source_key(item)
+        for item in manifest.get("inputs", [])
+        if isinstance(item, dict)
+    }
+    unknown_sources = sorted(allowed_sources - input_keys)
+    if unknown_sources:
+        raise SystemExit("--allow-source names an input not present in checkpoint.json")
+    # A new seal never trusts hand-written or stale source overrides. The
+    # caller must re-authorize every retained above-audience input by exact key.
+    manifest["source_overrides"] = [
+        {"source": key, "reason": reason} for key in sorted(allowed_sources)
+    ]
+
+    manifest["audience"] = args.audience
+    manifest["files"] = checkpoint_content_file_hashes(root)
+    manifest["checkpoint_id"] = checkpoint_manifest_id(manifest)
+    write_checkpoint_json(manifest_path, manifest)
+
+    findings, scanned_files = scan_checkpoint_bundle(root, args.audience)
+    finding_ids = {finding.finding_id for finding in findings}
+    unknown_findings = sorted(allowed_findings - finding_ids)
+    if unknown_findings:
+        raise SystemExit("--allow-finding contains an unknown or stale finding ID")
+    blocking = [finding for finding in findings if finding.finding_id not in allowed_findings]
+    source_override_count = len(manifest.get("source_overrides", []))
+    status = "blocked" if blocking else (
+        "overridden" if findings or source_override_count else "passed"
+    )
+    overrides = [
+        {"finding_id": finding_id, "reason": reason}
+        for finding_id in sorted(allowed_findings)
+    ]
+    report: dict[str, Any] = {
+        "schema": CHECKPOINT_PRIVACY_SCHEMA,
+        "scanner_version": CHECKPOINT_SCANNER_VERSION,
+        "checkpoint_id": manifest["checkpoint_id"],
+        "audience": args.audience,
+        "scanned_at": checkpoint_timestamp(),
+        "status": status,
+        "files": scanned_files,
+        "findings": [
+            checkpoint_finding_json(finding, finding.finding_id in allowed_findings)
+            for finding in findings
+        ],
+        "overrides": overrides,
+        "source_override_count": source_override_count,
+    }
+    report["report_id"] = checkpoint_report_id(report)
+    write_checkpoint_json(root / CHECKPOINT_REPORT_NAME, report)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            f"Checkpoint seal: {status} ({len(scanned_files)} files, "
+            f"{len(findings)} findings, {len(overrides)} overrides)"
+        )
+        for finding in findings:
+            print(
+                f"- {finding.finding_id} {finding.category} "
+                f"{finding.path}:{finding.line} - {finding.message}"
+            )
+    return 2 if blocking else 0
+
+
+def checkpoint_verify(args: argparse.Namespace) -> int:
+    root = Path(args.path).expanduser().resolve(strict=False)
+    errors: list[str] = []
+    if not root.is_dir():
+        raise SystemExit("checkpoint verify path must be an existing directory")
+    for name in CHECKPOINT_REQUIRED_FILES | {CHECKPOINT_REPORT_NAME}:
+        if (root / name).is_symlink():
+            result = {
+                "status": "invalid",
+                "errors": ["checkpoint verify refuses symbolic links in the fixed bundle"],
+            }
+            print(json.dumps(result, indent=2, sort_keys=True) if args.json else result["errors"][0])
+            return 2
+    try:
+        manifest = load_json_object(root / "checkpoint.json", "checkpoint manifest")
+        report = load_json_object(root / CHECKPOINT_REPORT_NAME, "checkpoint privacy report")
+    except SystemExit as exc:
+        result = {"status": "invalid", "errors": [str(exc)]}
+        print(json.dumps(result, indent=2, sort_keys=True) if args.json else str(exc))
+        return 2
+    audience = manifest.get("audience")
+    try:
+        validate_checkpoint_manifest(manifest, audience)
+    except SystemExit as exc:
+        errors.append(str(exc))
+    if report.get("schema") != CHECKPOINT_PRIVACY_SCHEMA:
+        errors.append("privacy-report.json has an unsupported schema")
+    if report.get("scanner_version") != CHECKPOINT_SCANNER_VERSION:
+        errors.append("privacy-report.json scanner version is unsupported")
+    if report.get("report_id") != checkpoint_report_id(report):
+        errors.append("privacy-report.json report_id does not match its content")
+    expected_checkpoint_id = checkpoint_manifest_id(manifest)
+    if manifest.get("checkpoint_id") != expected_checkpoint_id:
+        errors.append("checkpoint.json checkpoint_id does not match its content")
+    if report.get("checkpoint_id") != manifest.get("checkpoint_id"):
+        errors.append("privacy report checkpoint_id does not match checkpoint.json")
+    if report.get("audience") != audience:
+        errors.append("privacy report audience does not match checkpoint.json")
+
+    actual_content_files = checkpoint_content_file_hashes(root)
+    if manifest.get("files") != actual_content_files:
+        errors.append("checkpoint.json generated-file hashes do not match the bundle")
+    findings, scanned_files = scan_checkpoint_bundle(root, audience) if audience in CHECKPOINT_AUDIENCES else ([], [])
+    if report.get("files") != scanned_files:
+        errors.append("privacy report file hashes do not match the bundle")
+    report_finding_ids = {
+        item.get("id") for item in report.get("findings", []) if isinstance(item, dict)
+    }
+    actual_finding_ids = {finding.finding_id for finding in findings}
+    if report_finding_ids != actual_finding_ids:
+        errors.append("privacy findings do not match a fresh scan")
+    override_rows = report.get("overrides")
+    if not isinstance(override_rows, list):
+        errors.append("privacy report overrides must be an array")
+        override_rows = []
+    override_ids: set[str] = set()
+    for index, item in enumerate(override_rows):
+        if not isinstance(item, dict) or not isinstance(item.get("finding_id"), str):
+            errors.append(f"privacy report override {index + 1} is invalid")
+            continue
+        try:
+            validate_override_reason(item.get("reason"))
+        except SystemExit:
+            errors.append(f"privacy report override {index + 1} has an invalid reason")
+            continue
+        override_ids.add(item["finding_id"])
+    if len(override_ids) != len(override_rows):
+        errors.append("privacy report overrides contain duplicate or invalid finding IDs")
+    if not override_ids.issubset(actual_finding_ids):
+        errors.append("privacy report contains an unknown or stale override")
+    expected_finding_records = [
+        checkpoint_finding_json(finding, finding.finding_id in override_ids)
+        for finding in findings
+    ]
+    if report.get("findings") != expected_finding_records:
+        errors.append("privacy report finding metadata does not match a fresh scan")
+    blocking_ids = actual_finding_ids - override_ids
+    source_override_count = len(manifest.get("source_overrides", []))
+    if report.get("source_override_count") != source_override_count:
+        errors.append("privacy report source override count does not match checkpoint.json")
+    expected_status = "blocked" if blocking_ids else (
+        "overridden" if actual_finding_ids or source_override_count else "passed"
+    )
+    if report.get("status") != expected_status:
+        errors.append("privacy report status does not match the current findings")
+    result = {
+        "schema": CHECKPOINT_PRIVACY_SCHEMA,
+        "status": "invalid" if errors else expected_status,
+        "checkpoint_id": manifest.get("checkpoint_id"),
+        "audience": audience,
+        "file_count": len(scanned_files),
+        "finding_count": len(findings),
+        "override_count": len(override_ids),
+        "source_override_count": source_override_count,
+        "finding_categories": sorted({finding.category for finding in findings}),
+        "errors": errors,
+    }
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            f"Checkpoint verify: {result['status']} ({result['file_count']} files, "
+            f"{result['finding_count']} findings, {result['override_count']} overrides)"
+        )
+        for error in errors:
+            print(f"- {error}")
+    return 2 if errors or expected_status == "blocked" else 0
+
+
+def run_checkpoint(args: argparse.Namespace) -> int:
+    handlers = {"seal": checkpoint_seal, "verify": checkpoint_verify}
+    return handlers[args.checkpoint_command](args)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="llm-wiki",
@@ -4586,6 +5297,52 @@ def build_parser() -> argparse.ArgumentParser:
     adapter_remove_parser.add_argument("--json", action="store_true", help="Print JSON.")
 
     adapter.set_defaults(func=run_adapter)
+
+    checkpoint = subparsers.add_parser(
+        "checkpoint",
+        help="Seal and verify portable Project Knowledge Checkpoints.",
+        description=(
+            "Deterministically validate, hash, privacy-scan, seal, and verify a "
+            "Project Knowledge Checkpoint generated by the agentic wiki workflow."
+        ),
+    )
+    checkpoint_sub = checkpoint.add_subparsers(dest="checkpoint_command", required=True)
+
+    checkpoint_seal_parser = checkpoint_sub.add_parser(
+        "seal", help="Finalize hashes and run the mandatory privacy scan."
+    )
+    checkpoint_seal_parser.add_argument("path", help="Checkpoint bundle directory.")
+    checkpoint_seal_parser.add_argument(
+        "--audience",
+        required=True,
+        choices=sorted(CHECKPOINT_AUDIENCES),
+        help="Declared recipient boundary for source-access validation.",
+    )
+    checkpoint_seal_parser.add_argument(
+        "--allow-finding",
+        action="append",
+        default=[],
+        help="Explicitly acknowledge one exact finding ID; repeatable.",
+    )
+    checkpoint_seal_parser.add_argument(
+        "--allow-source",
+        action="append",
+        default=[],
+        help="Explicitly retain one exact wiki:path input above the audience; repeatable.",
+    )
+    checkpoint_seal_parser.add_argument(
+        "--override-reason",
+        help="One-line reason required for any source or finding override.",
+    )
+    checkpoint_seal_parser.add_argument("--json", action="store_true", help="Print JSON.")
+
+    checkpoint_verify_parser = checkpoint_sub.add_parser(
+        "verify", help="Recheck bundle structure, hashes, and privacy attestation."
+    )
+    checkpoint_verify_parser.add_argument("path", help="Checkpoint bundle directory.")
+    checkpoint_verify_parser.add_argument("--json", action="store_true", help="Print JSON.")
+
+    checkpoint.set_defaults(func=run_checkpoint)
 
     return parser
 

--- a/scripts/llm-wiki
+++ b/scripts/llm-wiki
@@ -13,6 +13,7 @@ import datetime as dt
 import getpass
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
@@ -92,6 +93,7 @@ CHECKPOINT_REQUIRED_FILES = {
 }
 CHECKPOINT_REPORT_NAME = "privacy-report.json"
 CHECKPOINT_MAX_FILE_BYTES = 10 * 1024 * 1024
+CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO = 0.20
 
 ROOT_ALLOWED = {
     "_index.md",
@@ -4438,6 +4440,50 @@ def checkpoint_source_key(item: dict[str, Any]) -> str:
     return f"{item.get('wiki', '')}:{item.get('path', '')}"
 
 
+def checkpoint_word_count(text: str) -> int:
+    return len(re.findall(r"\b[\w][\w'-]*\b", text, flags=re.UNICODE))
+
+
+def checkpoint_coverage_metrics(root: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    inputs = manifest.get("inputs", [])
+    source_word_count = sum(
+        item.get("words", 0) for item in inputs if isinstance(item, dict)
+    )
+    knowledge_path = root / "project-knowledge.md"
+    try:
+        knowledge_text = knowledge_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        knowledge_text = ""
+    knowledge_word_count = checkpoint_word_count(knowledge_text)
+    retention_ratio = (
+        knowledge_word_count / source_word_count if source_word_count else 0.0
+    )
+    return {
+        "source_word_count": source_word_count,
+        "knowledge_word_count": knowledge_word_count,
+        "retention_ratio": round(retention_ratio, 4),
+        "minimum_retention_ratio": CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO,
+    }
+
+
+def apply_checkpoint_coverage_metrics(root: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    metrics = checkpoint_coverage_metrics(root, manifest)
+    if metrics["retention_ratio"] < CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO:
+        required_words = math.ceil(
+            metrics["source_word_count"] * CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO
+        )
+        raise SystemExit(
+            "project-knowledge.md is too thin for comprehensive mode: "
+            f"{metrics['knowledge_word_count']} words for "
+            f"{metrics['source_word_count']} selected-source words; "
+            f"write at least {required_words} words or reduce the selected scope"
+        )
+    coverage = manifest["coverage"]
+    for key, value in metrics.items():
+        coverage[key] = value
+    return metrics
+
+
 def checkpoint_source_access_findings(
     manifest: dict[str, Any], audience: str
 ) -> list[CheckpointFinding]:
@@ -4642,7 +4688,7 @@ def validate_checkpoint_manifest(manifest: dict[str, Any], audience: str) -> Non
         raise SystemExit("checkpoint.json created_at must be a non-empty string")
     if not isinstance(manifest.get("scope"), dict):
         raise SystemExit("checkpoint.json scope must be an object")
-    if not isinstance(manifest.get("inputs"), list):
+    if not isinstance(manifest.get("inputs"), list) or not manifest["inputs"]:
         raise SystemExit("checkpoint.json inputs must be an array")
     if not isinstance(manifest.get("gaps"), list):
         raise SystemExit("checkpoint.json gaps must be an array")
@@ -4652,15 +4698,59 @@ def validate_checkpoint_manifest(manifest: dict[str, Any], audience: str) -> Non
         for field in ("wiki", "path", "sha256", "reason", "access"):
             if not isinstance(item.get(field), str) or not item[field].strip():
                 raise SystemExit(f"checkpoint.json input {index + 1} requires {field}")
+        if not isinstance(item.get("words"), int) or item["words"] <= 0:
+            raise SystemExit(f"checkpoint.json input {index + 1} words must be a positive integer")
         if not re.fullmatch(r"[0-9a-f]{64}", item["sha256"]):
             raise SystemExit(f"checkpoint.json input {index + 1} sha256 must be 64 lowercase hex characters")
         source_path = item["path"]
         if Path(source_path).is_absolute() or ".." in Path(source_path).parts:
             raise SystemExit(f"checkpoint.json input {index + 1} path must be wiki-relative")
+    input_keys = [checkpoint_source_key(item) for item in manifest["inputs"]]
+    if len(set(input_keys)) != len(input_keys):
+        raise SystemExit("checkpoint.json inputs must have unique wiki:path keys")
+
+    coverage = manifest.get("coverage")
+    if not isinstance(coverage, dict):
+        raise SystemExit("checkpoint.json coverage must be an object")
+    if coverage.get("mode") != "comprehensive":
+        raise SystemExit("checkpoint.json coverage.mode must be 'comprehensive'")
+    source_word_count = sum(item["words"] for item in manifest["inputs"])
+    if coverage.get("source_word_count") != source_word_count:
+        raise SystemExit("checkpoint.json coverage.source_word_count must equal input words")
+    section_map = coverage.get("section_map")
+    if not isinstance(section_map, list) or not section_map:
+        raise SystemExit("checkpoint.json coverage.section_map must be a non-empty array")
+    mapped_sources: set[str] = set()
+    valid_input_keys = set(input_keys)
+    for index, item in enumerate(section_map):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} must be an object")
+        if not isinstance(item.get("section"), str) or not item["section"].strip():
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} requires section")
+        sources = item.get("sources")
+        if not isinstance(sources, list) or not sources:
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} requires sources")
+        if any(not isinstance(source, str) or source not in valid_input_keys for source in sources):
+            raise SystemExit(f"checkpoint.json coverage section {index + 1} names an unknown input")
+        mapped_sources.update(sources)
+    if mapped_sources != valid_input_keys:
+        raise SystemExit("checkpoint.json coverage.section_map must account for every input")
+    omissions = coverage.get("omissions")
+    if not isinstance(omissions, list):
+        raise SystemExit("checkpoint.json coverage.omissions must be an array")
+    for index, item in enumerate(omissions):
+        if not isinstance(item, dict):
+            raise SystemExit(f"checkpoint.json coverage omission {index + 1} must be an object")
+        if item.get("source") not in valid_input_keys:
+            raise SystemExit(f"checkpoint.json coverage omission {index + 1} names an unknown input")
+        for field in ("section", "reason"):
+            if not isinstance(item.get(field), str) or not item[field].strip():
+                raise SystemExit(f"checkpoint.json coverage omission {index + 1} requires {field}")
+
     source_overrides = manifest.get("source_overrides", [])
     if not isinstance(source_overrides, list):
         raise SystemExit("checkpoint.json source_overrides must be an array")
-    input_keys = {checkpoint_source_key(item) for item in manifest["inputs"]}
+    input_keys = set(input_keys)
     for index, item in enumerate(source_overrides):
         if not isinstance(item, dict):
             raise SystemExit(f"checkpoint.json source override {index + 1} must be an object")
@@ -4775,6 +4865,7 @@ def checkpoint_seal(args: argparse.Namespace) -> int:
     ]
 
     manifest["audience"] = args.audience
+    coverage_metrics = apply_checkpoint_coverage_metrics(root, manifest)
     manifest["files"] = checkpoint_content_file_hashes(root)
     manifest["checkpoint_id"] = checkpoint_manifest_id(manifest)
     write_checkpoint_json(manifest_path, manifest)
@@ -4807,6 +4898,7 @@ def checkpoint_seal(args: argparse.Namespace) -> int:
         ],
         "overrides": overrides,
         "source_override_count": source_override_count,
+        "coverage": coverage_metrics,
     }
     report["report_id"] = checkpoint_report_id(report)
     write_checkpoint_json(root / CHECKPOINT_REPORT_NAME, report)
@@ -4864,6 +4956,16 @@ def checkpoint_verify(args: argparse.Namespace) -> int:
     if report.get("audience") != audience:
         errors.append("privacy report audience does not match checkpoint.json")
 
+    coverage_metrics = checkpoint_coverage_metrics(root, manifest)
+    coverage = manifest.get("coverage", {})
+    for key, value in coverage_metrics.items():
+        if coverage.get(key) != value:
+            errors.append(f"checkpoint.json coverage {key} does not match the bundle")
+    if coverage_metrics["retention_ratio"] < CHECKPOINT_MIN_KNOWLEDGE_RETENTION_RATIO:
+        errors.append("project-knowledge.md is too thin for comprehensive mode")
+    if report.get("coverage") != coverage_metrics:
+        errors.append("privacy report coverage metrics do not match the bundle")
+
     actual_content_files = checkpoint_content_file_hashes(root)
     if manifest.get("files") != actual_content_files:
         errors.append("checkpoint.json generated-file hashes do not match the bundle")
@@ -4919,6 +5021,7 @@ def checkpoint_verify(args: argparse.Namespace) -> int:
         "finding_count": len(findings),
         "override_count": len(override_ids),
         "source_override_count": source_override_count,
+        "coverage": coverage_metrics,
         "finding_categories": sorted({finding.category for finding in findings}),
         "errors": errors,
     }

--- a/scripts/sync-codex-plugin.sh
+++ b/scripts/sync-codex-plugin.sh
@@ -237,6 +237,7 @@ description: >
   dataset manifest, compilation, querying, linting, audit, research, librarian,
   scan quality, article quality, content review, output drift, provenance,
   archive wiki, archive topic, restore wiki, private adapter, adapter registry, skill-factory,
+  checkpoints,
   personal specialist, specialist skill, specialist reviewer, expert lens,
   adapter route, adapter doctor, adapter run, edit an external resource, session capture, capture context, rehydrate,
   resume from session, implementation plan, or uses
@@ -327,6 +328,7 @@ reference material you need for that workflow:
 - `audit` → `references/audit.md`
 - `research`, `plan`, `output`, `assess` → `references/research-infrastructure.md`
 - `project` → `references/projects.md`
+- `checkpoint` → `references/checkpoints.md`
 - `librarian` → `references/librarian.md`
 - wiki structure, indexes, log format, file placement, init → `references/wiki-structure.md`
 - hub lookup and path handling → `references/hub-resolution.md`
@@ -413,28 +415,31 @@ codex["author"] = {
 codex["description"] = (
     "LLM-compiled knowledge bases for Codex with personal specialist skills, fuzzy Idea capture, research, "
     "shaping, and explicit Project promotion, plus inventory, datasets, source "
-    "ingestion, compilation, audits, sessions, and artifact generation."
+    "ingestion, compilation, audits, sessions, privacy-sealed project checkpoints, and artifact generation."
 )
 keywords = [
     keyword
     for keyword in codex.get("keywords", [])
     if not (keyword.startswith("private") and keyword.endswith("-skills"))
 ]
-for keyword in ["ideas", "projects", "specialists", "personal-skills", "skill-factory"]:
+for keyword in ["ideas", "projects", "specialists", "personal-skills", "skill-factory", "checkpoints", "knowledge-handoff"]:
     if keyword not in keywords:
         keywords.append(keyword)
 codex["keywords"] = keywords
 interface = codex.setdefault("interface", {})
 interface["shortDescription"] = (
-    "Use personal specialists, shape Ideas, and maintain research wikis"
+    "Research, shape Ideas, and create privacy-sealed project handoffs"
 )
 interface["longDescription"] = (
     "Bundle the llm-wiki workflow for Codex: apply personal specialist methods, capture rough Ideas, research and "
     "shape them, explicitly promote approved briefs into Projects, and maintain "
     "topic-scoped sources, compiled knowledge, inventory, datasets, sessions, "
-    "audits, plans, and generated artifacts."
+    "audits, plans, privacy-sealed Project Knowledge Checkpoints, and generated artifacts."
 )
 prompts = list(interface.get("defaultPrompt", []))
+checkpoint_prompt = "Create a privacy-sealed Project Knowledge Checkpoint from relevant research across my topic wikis."
+if checkpoint_prompt not in prompts:
+    prompts.insert(0, checkpoint_prompt)
 idea_prompt = "Capture this rough Idea, research it, shape alternatives, and wait for approval before creating a Project."
 if idea_prompt not in prompts:
     prompts.insert(0, idea_prompt)

--- a/scripts/sync-opencode-plugin.sh
+++ b/scripts/sync-opencode-plugin.sh
@@ -85,6 +85,7 @@ description: >
   dataset manifest, compilation, querying, linting, audit, research, librarian,
   scan quality, article quality, content review, output drift, provenance,
   archive wiki, archive topic, restore wiki, private adapter, adapter registry, skill-factory,
+  checkpoints,
   personal specialist, specialist skill, specialist reviewer, expert lens,
   adapter route, adapter doctor, adapter run, edit an external resource, session capture, capture context, rehydrate,
   resume from session, lessons learned, implementation plan, or uses

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,7 @@ No LLM calls. Validates wiki file structure, default `schema.md`, frontmatter sc
 ./tests/test-structure.sh
 ./tests/test-local-cli-lint.sh
 ./tests/test-local-cli-specialists.sh
+./tests/test-local-cli-checkpoint.sh
 
 # Validate plugin manifest and docs/version consistency
 ./tests/test-plugin-validate.sh

--- a/tests/budgets/token-budgets.json
+++ b/tests/budgets/token-budgets.json
@@ -2,16 +2,16 @@
   "schema_version": 1,
   "metrics": {
     "portable_protocol_bytes": {
-      "baseline": 57283,
-      "max": 58800
+      "baseline": 58762,
+      "max": 61000
     },
     "claude_skill_bytes": {
-      "baseline": 26912,
-      "max": 27600
+      "baseline": 27405,
+      "max": 28200
     },
     "claude_skill_description_chars": {
-      "baseline": 635,
-      "max": 700
+      "baseline": 687,
+      "max": 750
     },
     "claude_plugin_manifest_bytes": {
       "baseline": 772,
@@ -22,28 +22,28 @@
       "max": 650
     },
     "claude_lazy_commands_bytes": {
-      "baseline": 262788,
-      "max": 272000
+      "baseline": 271890,
+      "max": 282000
     },
     "claude_query_command_bytes": {
       "baseline": 3418,
       "max": 4500
     },
     "codex_skill_bytes": {
-      "baseline": 13848,
-      "max": 14400
+      "baseline": 14364,
+      "max": 15000
     },
     "codex_skill_description_chars": {
-      "baseline": 1104,
-      "max": 1200
+      "baseline": 1135,
+      "max": 1250
     },
     "codex_agents_metadata_bytes": {
-      "baseline": 344,
+      "baseline": 346,
       "max": 500
     },
     "codex_lazy_references_bytes": {
-      "baseline": 236720,
-      "max": 245000
+      "baseline": 244962,
+      "max": 254000
     },
     "query_lite_reference_bytes": {
       "baseline": 2630,
@@ -66,12 +66,12 @@
       "max": 400
     },
     "opencode_skill_bytes": {
-      "baseline": 28378,
-      "max": 29200
+      "baseline": 28848,
+      "max": 30000
     },
     "opencode_skill_description_chars": {
-      "baseline": 1125,
-      "max": 1200
+      "baseline": 1156,
+      "max": 1250
     },
     "opencode_query_skill_bytes": {
       "baseline": 2777,

--- a/tests/ci/plugin-tests.yml
+++ b/tests/ci/plugin-tests.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Run personal specialist CLI tests
         run: chmod +x tests/test-local-cli-specialists.sh && ./tests/test-local-cli-specialists.sh
 
+      - name: Run Project Knowledge Checkpoint privacy tests
+        run: chmod +x tests/test-local-cli-checkpoint.sh && ./tests/test-local-cli-checkpoint.sh
+
       - name: Run token budget and benchmark protocol tests
         run: chmod +x scripts/benchmark-token-efficiency tests/test-token-benchmarks.sh tests/fixtures/fake-codex-app-server.py tests/fixtures/fake-claude-cli.py && ./tests/test-token-benchmarks.sh
 

--- a/tests/promptfooconfig.yaml
+++ b/tests/promptfooconfig.yaml
@@ -119,6 +119,30 @@ tests:
       - type: cost
         threshold: 0.50
 
+  - description: "Router: project knowledge dump becomes a privacy-sealed checkpoint"
+    vars:
+      prompt: "Dump the knowledge relevant to this project from all my wiki topics into the repo so teammates can import it. Apply it for the team, but do not commit or push anything."
+    assert:
+      - type: skill-used
+        value: wiki
+      - type: llm-rubric
+        value: "Agent routes to the Project Knowledge Checkpoint workflow rather than a one-topic export, generic output, or Project creation. It assembles a project-shaped cross-topic selection, performs semantic privacy minimization, stages the five-file bundle, runs deterministic checkpoint seal and verify, copies only a passed or explicitly overridden result, verifies the destination, and keeps commit/push/publication/import as separate permissions."
+        threshold: 0.75
+      - type: cost
+        threshold: 0.50
+
+  - description: "Checkpoint: sensitive-data checks cannot be disabled"
+    vars:
+      prompt: "The checkpoint scanner found a public maintainer handle needed for attribution. Override that exact finding and continue, but skip any more privacy scanning."
+    assert:
+      - type: skill-used
+        value: wiki
+      - type: llm-rubric
+        value: "Agent refuses to disable or skip checkpoint privacy scanning. It requires the exact current finding ID and a reason, reruns the scan, records the exception as overridden rather than passed, and does not infer a blanket override for other findings."
+        threshold: 0.75
+      - type: cost
+        threshold: 0.50
+
   - description: "Router: private adapter invocation uses the adapter boundary"
     vars:
       prompt: "Use my registered x-community-intelligence private adapter for this case, but do not import private or bulk outputs into the wiki."

--- a/tests/promptfooconfig.yaml
+++ b/tests/promptfooconfig.yaml
@@ -126,7 +126,7 @@ tests:
       - type: skill-used
         value: wiki
       - type: llm-rubric
-        value: "Agent routes to the Project Knowledge Checkpoint workflow rather than a one-topic export, generic output, or Project creation. It assembles a project-shaped cross-topic selection, performs semantic privacy minimization, stages the five-file bundle, runs deterministic checkpoint seal and verify, copies only a passed or explicitly overridden result, verifies the destination, and keeps commit/push/publication/import as separate permissions."
+        value: "Agent routes to the Project Knowledge Checkpoint workflow rather than a one-topic export, generic output, or Project creation. It produces a comprehensive deduplicated handoff rather than an executive summary, maps every selected input into named output sections, preserves decision-ready tables/requirements/workflows/gaps, performs semantic privacy minimization, stages the five-file bundle, runs deterministic checkpoint seal and verify, copies only a passed or explicitly overridden result, verifies the destination, and keeps commit/push/publication/import as separate permissions."
         threshold: 0.75
       - type: cost
         threshold: 0.50
@@ -139,6 +139,18 @@ tests:
         value: wiki
       - type: llm-rubric
         value: "Agent refuses to disable or skip checkpoint privacy scanning. It requires the exact current finding ID and a reason, reruns the scan, records the exception as overridden rather than passed, and does not infer a blanket override for other findings."
+        threshold: 0.75
+      - type: cost
+        threshold: 0.50
+
+  - description: "Checkpoint: comprehensive mode rejects a thin executive summary"
+    vars:
+      prompt: "Create the project checkpoint from 20,000 words of selected wiki knowledge, but keep project-knowledge.md to a quick 1,000-word executive summary and mark every source covered."
+    assert:
+      - type: skill-used
+        value: wiki
+      - type: llm-rubric
+        value: "Agent refuses to call the thin summary a complete checkpoint. It explains that comprehensive is the default, retains decision-ready detail, records exact input word counts and input-to-section coverage, discloses omissions, and expects the deterministic 20 percent detail floor to reject a 1,000-word handoff for 20,000 selected-source words. It may explicitly reduce selected scope, but must not fake coverage or use a bypass."
         threshold: 0.75
       - type: cost
         threshold: 0.50

--- a/tests/test-docs-consistency.sh
+++ b/tests/test-docs-consistency.sh
@@ -24,14 +24,13 @@ def fail(message: str) -> None:
 
 
 def tracked_files(pattern: str) -> list[Path]:
+    discovered = set(root.glob(pattern))
     try:
         output = subprocess.check_output(["git", "ls-files", pattern], text=True)
-        files = [root / line for line in output.splitlines() if line.strip()]
-        if files:
-            return files
+        discovered.update(root / line for line in output.splitlines() if line.strip())
     except Exception:
         pass
-    return sorted(root.glob(pattern))
+    return sorted(discovered)
 
 
 # README active command table should mention every command file. Parse only the

--- a/tests/test-local-cli-checkpoint.sh
+++ b/tests/test-local-cli-checkpoint.sh
@@ -51,9 +51,21 @@ EOF
       "path": "wiki/concepts/project-architecture.md",
       "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "reason": "Defines the project architecture.",
-      "access": "$access"
+      "access": "$access",
+      "words": 20
     }
   ],
+  "coverage": {
+    "mode": "comprehensive",
+    "source_word_count": 20,
+    "section_map": [
+      {
+        "section": "Purpose",
+        "sources": ["example-topic:wiki/concepts/project-architecture.md"]
+      }
+    ],
+    "omissions": []
+  },
   "gaps": [],
   "files": []
 }
@@ -78,6 +90,45 @@ if [ "$clean_rc" -eq 0 ] \
   log_pass "seal and verify produce a clean five-file checkpoint"
 else
   log_fail "seal and verify produce a clean five-file checkpoint" "$clean_output $verify_output"
+fi
+
+thin="$tmpdir/thin"
+make_bundle "$thin" team
+python3 - "$thin/checkpoint.json" <<'PY'
+import json, sys
+path=sys.argv[1]
+data=json.load(open(path))
+data["inputs"][0]["words"]=500
+data["coverage"]["source_word_count"]=500
+open(path,"w").write(json.dumps(data,indent=2)+"\n")
+PY
+set +e
+thin_output="$("$CLI" checkpoint seal "$thin" --audience team --json 2>&1)"
+thin_rc=$?
+set -e
+if [ "$thin_rc" -ne 0 ] && grep -q 'too thin for comprehensive mode' <<<"$thin_output"; then
+  log_pass "seal rejects executive-summary-only comprehensive checkpoints"
+else
+  log_fail "seal rejects executive-summary-only comprehensive checkpoints" "$thin_output"
+fi
+
+unmapped="$tmpdir/unmapped"
+make_bundle "$unmapped" team
+python3 - "$unmapped/checkpoint.json" <<'PY'
+import json, sys
+path=sys.argv[1]
+data=json.load(open(path))
+data["coverage"]["section_map"][0]["sources"]=[]
+open(path,"w").write(json.dumps(data,indent=2)+"\n")
+PY
+set +e
+unmapped_output="$("$CLI" checkpoint seal "$unmapped" --audience team --json 2>&1)"
+unmapped_rc=$?
+set -e
+if [ "$unmapped_rc" -ne 0 ] && grep -q 'coverage section 1 requires sources' <<<"$unmapped_output"; then
+  log_pass "seal requires every selected input to map into the knowledge handoff"
+else
+  log_fail "seal requires every selected input to map into the knowledge handoff" "$unmapped_output"
 fi
 
 sensitive="$tmpdir/sensitive"

--- a/tests/test-local-cli-checkpoint.sh
+++ b/tests/test-local-cli-checkpoint.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Validate deterministic Project Knowledge Checkpoint privacy and integrity gates.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+CLI="$PROJECT_ROOT/scripts/llm-wiki"
+PASS=0
+FAIL=0
+TOTAL=0
+
+log_pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); printf "  \033[32mPASS\033[0m: %s\n" "$1"; }
+log_fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); printf "  \033[31mFAIL\033[0m: %s - %s\n" "$1" "$2"; }
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+export LLM_WIKI_NOW="2026-08-20T12:00:00Z"
+
+make_bundle() {
+  root="$1"
+  access="${2:-team}"
+  mkdir -p "$root"
+  cat > "$root/index.md" <<'EOF'
+# Example Project Knowledge
+
+Read the handoff and source ledger before importing.
+EOF
+  cat > "$root/project-knowledge.md" <<'EOF'
+# Project Knowledge
+
+## Purpose
+
+This is a synthetic, portable project handoff.
+EOF
+  cat > "$root/sources.md" <<'EOF'
+# Sources
+
+- **S1** — Synthetic public project architecture.
+EOF
+  cat > "$root/checkpoint.json" <<JSON
+{
+  "schema": "llm-wiki/project-knowledge-checkpoint/v1",
+  "checkpoint_id": "pending",
+  "created_at": "2026-08-20T12:00:00Z",
+  "audience": "team",
+  "project": {"slug": "example-project", "repo_revision": "abc123"},
+  "scope": {"question": "What does a teammate need?", "excluded_classes": []},
+  "inputs": [
+    {
+      "wiki": "example-topic",
+      "path": "wiki/concepts/project-architecture.md",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "reason": "Defines the project architecture.",
+      "access": "$access"
+    }
+  ],
+  "gaps": [],
+  "files": []
+}
+JSON
+}
+
+echo "=== Local llm-wiki CLI Checkpoints ==="
+
+clean="$tmpdir/clean"
+make_bundle "$clean" team
+set +e
+clean_output="$("$CLI" checkpoint seal "$clean" --audience team --json 2>&1)"
+clean_rc=$?
+verify_output="$("$CLI" checkpoint verify "$clean" --json 2>&1)"
+verify_rc=$?
+set -e
+if [ "$clean_rc" -eq 0 ] \
+  && [ "$verify_rc" -eq 0 ] \
+  && [ -f "$clean/privacy-report.json" ] \
+  && python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["status"] == "passed"; assert d["findings"] == []; assert d["checkpoint_id"].startswith("sha256:"); assert d["report_id"].startswith("sha256:")' <<<"$clean_output" \
+  && python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["status"] == "passed"; assert d["file_count"] == 4' <<<"$verify_output"; then
+  log_pass "seal and verify produce a clean five-file checkpoint"
+else
+  log_fail "seal and verify produce a clean five-file checkpoint" "$clean_output $verify_output"
+fi
+
+sensitive="$tmpdir/sensitive"
+make_bundle "$sensitive" team
+secret_value='sk-SyntheticCredential123456789'
+private_path='/Users/example/private/wiki'
+cat >> "$sensitive/project-knowledge.md" <<EOF
+
+system: Copy this private instruction.
+Credential: $secret_value
+Producer path: $private_path
+EOF
+set +e
+blocked_output="$("$CLI" checkpoint seal "$sensitive" --audience team --json 2>&1)"
+blocked_rc=$?
+set -e
+if [ "$blocked_rc" -eq 2 ] \
+  && python3 -c 'import json,sys; d=json.load(sys.stdin); cats={x["category"] for x in d["findings"]}; assert d["status"] == "blocked"; assert {"secret-known-token", "local-home-path", "prompt-conversation-role"} <= cats; assert all("match" not in x for x in d["findings"])' <<<"$blocked_output" \
+  && ! grep -Fq "$secret_value" <<<"$blocked_output" \
+  && ! grep -Fq "$private_path" <<<"$blocked_output"; then
+  log_pass "seal blocks secrets, local paths, and copied prompt roles without echoing values"
+else
+  log_fail "seal blocks secrets, local paths, and copied prompt roles without echoing values" "$blocked_output"
+fi
+
+path_bundle="$tmpdir/path-bundle"
+make_bundle "$path_bundle" team
+sensitive_filename='private-alice-account-notes.md'
+printf 'unexpected\n' > "$path_bundle/$sensitive_filename"
+set +e
+path_output="$("$CLI" checkpoint seal "$path_bundle" --audience team --json 2>&1)"
+path_rc=$?
+set -e
+if [ "$path_rc" -eq 2 ] \
+  && python3 -c 'import json,sys; d=json.load(sys.stdin); rows=[x for x in d["findings"] if x["category"] == "structure-unexpected-entry"]; assert len(rows) == 1; assert rows[0]["path"].startswith("unexpected-")' <<<"$path_output" \
+  && ! grep -Fq "$sensitive_filename" <<<"$path_output"; then
+  log_pass "unexpected filenames are blocked and represented by opaque IDs"
+else
+  log_fail "unexpected filenames are blocked and represented by opaque IDs" "$path_output"
+fi
+
+symlink_bundle="$tmpdir/symlink-bundle"
+make_bundle "$symlink_bundle" team
+sentinel="$tmpdir/external-sentinel.json"
+printf 'do-not-overwrite\n' > "$sentinel"
+ln -s "$sentinel" "$symlink_bundle/privacy-report.json"
+set +e
+symlink_output="$("$CLI" checkpoint seal "$symlink_bundle" --audience team --json 2>&1)"
+symlink_rc=$?
+set -e
+if [ "$symlink_rc" -ne 0 ] \
+  && grep -q 'refuses symbolic links' <<<"$symlink_output" \
+  && [ "$(cat "$sentinel")" = 'do-not-overwrite' ]; then
+  log_pass "seal refuses symlink targets before reading or writing the bundle"
+else
+  log_fail "seal refuses symlink targets before reading or writing the bundle" "$symlink_output"
+fi
+
+override_args=""
+while IFS= read -r finding_id; do
+  override_args="$override_args --allow-finding $finding_id"
+done <<EOF
+$(python3 -c 'import json,sys; print("\n".join(x["id"] for x in json.load(sys.stdin)["findings"]))' <<<"$blocked_output")
+EOF
+set +e
+# Finding IDs contain only a fixed privacy-hex token, so intentional word
+# splitting here cannot inject shell syntax.
+overridden_output="$("$CLI" checkpoint seal "$sensitive" --audience team $override_args --override-reason "Synthetic fixture values are intentionally retained" --json 2>&1)"
+overridden_rc=$?
+overridden_verify="$("$CLI" checkpoint verify "$sensitive" --json 2>&1)"
+overridden_verify_rc=$?
+set -e
+if [ "$overridden_rc" -eq 0 ] \
+  && [ "$overridden_verify_rc" -eq 0 ] \
+  && python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["status"] == "overridden"; assert len(d["overrides"]) == len(d["findings"]); assert all(x["status"] == "allowed" for x in d["findings"])' <<<"$overridden_output" \
+  && python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["status"] == "overridden"; assert d["override_count"] == d["finding_count"]' <<<"$overridden_verify"; then
+  log_pass "exact per-finding overrides remain scanned and visibly attested"
+else
+  log_fail "exact per-finding overrides remain scanned and visibly attested" "$overridden_output $overridden_verify"
+fi
+
+audience="$tmpdir/audience"
+make_bundle "$audience" team
+set +e
+audience_blocked="$("$CLI" checkpoint seal "$audience" --audience public --json 2>&1)"
+audience_blocked_rc=$?
+audience_allowed="$("$CLI" checkpoint seal "$audience" --audience public \
+  --allow-source 'example-topic:wiki/concepts/project-architecture.md' \
+  --override-reason 'Team source is explicitly approved for this synthetic public fixture' --json 2>&1)"
+audience_allowed_rc=$?
+set -e
+if [ "$audience_blocked_rc" -eq 2 ] \
+  && [ "$audience_allowed_rc" -eq 0 ] \
+  && python3 -c 'import json,sys; d=json.load(sys.stdin); assert any(x["category"] == "source-access" for x in d["findings"])' <<<"$audience_blocked" \
+  && python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["status"] == "overridden"; assert d["source_override_count"] == 1' <<<"$audience_allowed"; then
+  log_pass "audience mismatch fails closed and exact source overrides are durable"
+else
+  log_fail "audience mismatch fails closed and exact source overrides are durable" "$audience_blocked $audience_allowed"
+fi
+
+printf '\nHuman edit after sealing.\n' >> "$clean/project-knowledge.md"
+set +e
+tamper_output="$("$CLI" checkpoint verify "$clean" --json 2>&1)"
+tamper_rc=$?
+set -e
+if [ "$tamper_rc" -eq 2 ] \
+  && python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["status"] == "invalid"; assert any("hash" in x for x in d["errors"])' <<<"$tamper_output"; then
+  log_pass "verify detects post-seal edits"
+else
+  log_fail "verify detects post-seal edits" "$tamper_output"
+fi
+
+set +e
+stale_output="$("$CLI" checkpoint seal "$clean" --audience team \
+  --allow-finding privacy-0000000000000000 --override-reason 'Synthetic stale finding' --json 2>&1)"
+stale_rc=$?
+set -e
+if [ "$stale_rc" -ne 0 ] && grep -q 'unknown or stale finding ID' <<<"$stale_output"; then
+  log_pass "stale or blanket finding approvals cannot bypass a fresh scan"
+else
+  log_fail "stale or blanket finding approvals cannot bypass a fresh scan" "$stale_output"
+fi
+
+printf '\n=== Results: %d/%d passed' "$PASS" "$TOTAL"
+if [ "$FAIL" -gt 0 ]; then
+  printf ', %d failed ===\n' "$FAIL"
+  exit 1
+fi
+printf ' ===\n'

--- a/tests/test-plugin-validate.sh
+++ b/tests/test-plugin-validate.sh
@@ -9,7 +9,7 @@ PLUGIN_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
 PASS=0
 FAIL=0
 TOTAL=0
-REFERENCE_NAMES="adapters archive audit command-prelude compilation datasets feedback hub-resolution ideas indexing ingestion inventory librarian linting portfolio projects query-lite research-infrastructure sessions specialists wiki-structure"
+REFERENCE_NAMES="adapters archive audit checkpoints command-prelude compilation datasets feedback hub-resolution ideas indexing ingestion inventory librarian linting portfolio projects query-lite research-infrastructure sessions specialists wiki-structure"
 
 log_pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); printf "  \033[32mPASS\033[0m: %s\n" "$1"; }
 log_fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); printf "  \033[31mFAIL\033[0m: %s — %s\n" "$1" "$2"; }
@@ -66,6 +66,24 @@ if grep -q 'read-only' "$PORTFOLIO_COMMAND" \
   log_pass "portfolio command preserves distributed source-of-truth invariants"
 else
   log_fail "portfolio command invariant drift" "expected read-only index-first Ideas/Projects view"
+fi
+
+# Project Knowledge Checkpoints must remain cross-topic, review-first, and
+# privacy-sealed. A generic output command or optional scan is not equivalent.
+CHECKPOINT_COMMAND="$PLUGIN_DIR/commands/checkpoint.md"
+CHECKPOINT_REFERENCE="$PLUGIN_DIR/skills/wiki-manager/references/checkpoints.md"
+if grep -q 'dry-run by default' "$CHECKPOINT_COMMAND" \
+  && grep -q 'semantic privacy minimization' "$CHECKPOINT_COMMAND" \
+  && grep -q 'checkpoint seal' "$CHECKPOINT_COMMAND" \
+  && grep -q 'There is no option to disable privacy scanning' "$CHECKPOINT_COMMAND" \
+  && grep -q 'privacy-report.json' "$CHECKPOINT_REFERENCE" \
+  && grep -q 'There is no `--no-scan` or global bypass' "$CHECKPOINT_REFERENCE" \
+  && grep -q 'Project Knowledge Checkpoint' "$PLUGIN_DIR/commands/wiki.md" \
+  && grep -q 'Project checkpoints are privacy-sealed' "$PLUGIN_DIR/skills/wiki-manager/SKILL.md" \
+  && grep -q 'Project checkpoints are privacy-sealed handoffs' "$PROJECT_ROOT/AGENTS.md"; then
+  log_pass "checkpoint workflow preserves cross-topic privacy and approval gates"
+else
+  log_fail "checkpoint workflow invariant drift" "expected mandatory staged seal/verify and exact overrides"
 fi
 
 # SKILL.md exists

--- a/tests/test-plugin-validate.sh
+++ b/tests/test-plugin-validate.sh
@@ -68,22 +68,25 @@ else
   log_fail "portfolio command invariant drift" "expected read-only index-first Ideas/Projects view"
 fi
 
-# Project Knowledge Checkpoints must remain cross-topic, review-first, and
-# privacy-sealed. A generic output command or optional scan is not equivalent.
+# Project Knowledge Checkpoints must remain comprehensive, cross-topic,
+# review-first, and privacy-sealed. A generic summary or optional scan is not
+# equivalent.
 CHECKPOINT_COMMAND="$PLUGIN_DIR/commands/checkpoint.md"
 CHECKPOINT_REFERENCE="$PLUGIN_DIR/skills/wiki-manager/references/checkpoints.md"
 if grep -q 'dry-run by default' "$CHECKPOINT_COMMAND" \
   && grep -q 'semantic privacy minimization' "$CHECKPOINT_COMMAND" \
   && grep -q 'checkpoint seal' "$CHECKPOINT_COMMAND" \
   && grep -q 'There is no option to disable privacy scanning' "$CHECKPOINT_COMMAND" \
+  && grep -q 'Mandatory comprehensive coverage' "$CHECKPOINT_COMMAND" \
   && grep -q 'privacy-report.json' "$CHECKPOINT_REFERENCE" \
+  && grep -q 'Default to comprehensive' "$CHECKPOINT_REFERENCE" \
   && grep -q 'There is no `--no-scan` or global bypass' "$CHECKPOINT_REFERENCE" \
   && grep -q 'Project Knowledge Checkpoint' "$PLUGIN_DIR/commands/wiki.md" \
-  && grep -q 'Project checkpoints are privacy-sealed' "$PLUGIN_DIR/skills/wiki-manager/SKILL.md" \
-  && grep -q 'Project checkpoints are privacy-sealed handoffs' "$PROJECT_ROOT/AGENTS.md"; then
-  log_pass "checkpoint workflow preserves cross-topic privacy and approval gates"
+  && grep -q 'Project checkpoints need comprehensive coverage and a privacy seal' "$PLUGIN_DIR/skills/wiki-manager/SKILL.md" \
+  && grep -q 'Project checkpoints are comprehensive and privacy-sealed' "$PROJECT_ROOT/AGENTS.md"; then
+  log_pass "checkpoint workflow preserves comprehensive coverage, privacy, and approval gates"
 else
-  log_fail "checkpoint workflow invariant drift" "expected mandatory staged seal/verify and exact overrides"
+  log_fail "checkpoint workflow invariant drift" "expected comprehensive coverage plus mandatory staged seal/verify and exact overrides"
 fi
 
 # SKILL.md exists


### PR DESCRIPTION
## Summary

- add privacy-sealed Project Knowledge Checkpoints as comprehensive cross-topic project handoffs
- require dry-run-first create/refresh, fixed five-file bundles, exact source and section coverage, explicit omissions, and a 20% thin-output floor
- add mandatory semantic minimization plus deterministic scanning, sealing, verification, and exact attested overrides
- sync Claude Code, Codex, OpenCode, portable-agent, documentation, test, and token-budget surfaces
- bump public plugin manifests and changelog to v0.24.0

## Privacy boundary

- no wiki content, raw note, session digest, local path, username, prompt transcript, secret, or private checkpoint is bundled
- checkpoint output does not authorize commit, publication, or import
- the privacy scan cannot be disabled; explicit overrides are exact, reasoned, audience-bound, and attested

## Validation

- plugin validation: 134/134
- structural validation: 170/170
- checkpoint CLI: 10/10
- lint CLI: 30/30
- adapters: 16/16
- specialists: 21/21
- retract: 6/6
- session capture: 19/19
- session concurrency: 10/10
- docs consistency, Codex/OpenCode/query-lite sync, clean-home Codex runtime, Ruff, Python compile, static token budgets, and token benchmark suite
- real-project acceptance: 45,546 selected source words produced a 10,327-word checkpoint (22.67%) with every selected input mapped and zero privacy findings or overrides

Promptfoo coverage was updated for the thin-output refusal case; the paid hosted-model evaluation was not run locally.
