### PR TITLE
Make plugin sync work off Windows-friendly primitives

### DIFF
--- a/scripts/sync-codex-plugin.sh
+++ b/scripts/sync-codex-plugin.sh
@@ -42,11 +42,6 @@ if [ ! -f "$LOCAL_HELPER" ]; then
   exit 1
 fi
 
-if ! command -v rsync >/dev/null 2>&1; then
-  echo "Missing required tool: rsync" >&2
-  exit 1
-fi
-
 # The deterministic helper is shared by every runtime package. The public
 # script remains the source of truth; packaged copies make adapter management
 # available even when the plugin is installed without the full repository.
@@ -61,10 +56,9 @@ mkdir -p "$TARGET_PLUGIN/skills"
 # Codex-only metadata and is recreated below.
 rm -rf "$TARGET_PLUGIN/skills/wiki-manager"
 rm -rf "$TARGET_QUERY"
-rsync -a --delete \
-  --exclude='agents/' \
-  --exclude='agents' \
-  "$SOURCE_SKILL/" "$TARGET_SKILL/"
+rm -rf "$TARGET_SKILL"
+cp -R "$SOURCE_SKILL" "$TARGET_SKILL"
+rm -rf "$TARGET_SKILL/agents"
 
 mkdir -p "$TARGET_SKILL/agents"
 mkdir -p "$TARGET_PLUGIN/hooks"
@@ -179,7 +173,7 @@ for entries in value["hooks"].values():
     for entry in entries:
         for hook in entry["hooks"]:
             hook["command"] = launcher
-path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8", newline="\n")
 PY
 
 cat > "$TARGET_SKILL/agents/openai.yaml" <<'EOF'
@@ -227,7 +221,7 @@ claude_manifest = Path(sys.argv[2])
 codex_manifest = Path(sys.argv[3])
 
 skill_path = target_skill / "SKILL.md"
-text = skill_path.read_text()
+text = skill_path.read_text(encoding="utf-8")
 
 frontmatter = """---
 name: wiki
@@ -399,14 +393,14 @@ text = replace_section(
 """,
 )
 
-skill_path.write_text(text)
+skill_path.write_text(text, encoding="utf-8", newline="\n")
 
 # references/ is a copied mirror of claude-plugin/skills/wiki-manager/references
 # and is shared verbatim — no per-file replacements needed. Source references
 # use runtime-neutral wording ("the agent") so they read correctly under both.
 
-claude = json.loads(claude_manifest.read_text())
-codex = json.loads(codex_manifest.read_text())
+claude = json.loads(claude_manifest.read_text(encoding="utf-8"))
+codex = json.loads(codex_manifest.read_text(encoding="utf-8"))
 codex["version"] = claude["version"]
 codex["name"] = "wiki"
 codex["license"] = claude.get("license", codex.get("license"))
@@ -451,7 +445,7 @@ idea_prompt = "Capture this rough Idea, research it, shape alternatives, and wai
 if idea_prompt not in prompts:
     prompts.insert(0, idea_prompt)
 interface["defaultPrompt"] = prompts
-codex_manifest.write_text(json.dumps(codex, indent=2) + "\n")
+codex_manifest.write_text(json.dumps(codex, indent=2) + "\n", encoding="utf-8", newline="\n")
 PY
 
 echo "Synced Codex plugin skill from Claude source."

--- a/scripts/sync-opencode-plugin.sh
+++ b/scripts/sync-opencode-plugin.sh
@@ -30,27 +30,42 @@ if [ ! -f "$LOCAL_HELPER" ]; then
   exit 1
 fi
 
-if ! command -v rsync >/dev/null 2>&1; then
-  echo "Missing required tool: rsync" >&2
-  exit 1
-fi
-
 mkdir -p "$ROOT/claude-plugin/bin" "$TARGET_PLUGIN/bin"
 cp "$LOCAL_HELPER" "$ROOT/claude-plugin/bin/llm-wiki"
 cp "$LOCAL_HELPER" "$TARGET_PLUGIN/bin/llm-wiki"
 chmod 0755 "$ROOT/claude-plugin/bin/llm-wiki" "$TARGET_PLUGIN/bin/llm-wiki"
 
-mkdir -p "$TARGET_PLUGIN/skills"
-# references/ is a symlink into the Claude source — exclude from rsync so it's
-# preserved, and recreate it idempotently below.
-rsync -a --delete \
-  --exclude='references/' \
-  --exclude='references' \
-  "$SOURCE_SKILL/" "$TARGET_SKILL/"
+mkdir -p "$TARGET_PLUGIN/skills" "$TARGET_SKILL"
+# references/ is a symlink into the canonical source. It must never be copied
+# over: copying the source references/ onto its own symlink would write into
+# the canonical tree. Mirror every other entry, then handle the link itself.
+find "$TARGET_SKILL" -mindepth 1 -maxdepth 1 ! -name references -exec rm -rf {} +
+for entry in "$SOURCE_SKILL"/* "$SOURCE_SKILL"/.[!.]*; do
+  [ -e "$entry" ] || continue
+  case "$(basename "$entry")" in
+    references) continue ;;
+  esac
+  cp -R "$entry" "$TARGET_SKILL/"
+done
 
-# Recreate the references symlink (idempotent — works on fresh checkout too).
-rm -rf "$TARGET_SKILL/references"
-ln -s "../../../../claude-plugin/skills/wiki-manager/references" "$TARGET_SKILL/references"
+# Recreate the references symlink only when it is missing or wrong. Rewriting a
+# correct link every run is what breaks checkouts on platforms where ln -s
+# silently produces something other than a symlink (Windows without the
+# privilege to create them), turning a good tree into a dirty one.
+REFERENCES_LINK="../../../../claude-plugin/skills/wiki-manager/references"
+if [ -L "$TARGET_SKILL/references" ] && [ "$(readlink "$TARGET_SKILL/references")" = "$REFERENCES_LINK" ]; then
+  :
+else
+  rm -rf "$TARGET_SKILL/references"
+  ln -s "$REFERENCES_LINK" "$TARGET_SKILL/references" 2>/dev/null || true
+  if [ ! -L "$TARGET_SKILL/references" ]; then
+    rm -rf "$TARGET_SKILL/references"
+    cp -R "$SOURCE_SKILL/references" "$TARGET_SKILL/references"
+    echo "warning: this platform cannot create symlinks; copied references/ instead." >&2
+    echo "         Do not commit that copy. Restore the link with:" >&2
+    echo "         git checkout -- $TARGET_SKILL/references" >&2
+  fi
+fi
 
 # Best-effort OpenCode query preset. It is instruction-only and shares the
 # runtime-neutral query contract, but no provider-specific live model gate is
@@ -75,7 +90,7 @@ from pathlib import Path
 target_skill = Path(sys.argv[1])
 
 skill_path = target_skill / "SKILL.md"
-text = skill_path.read_text()
+text = skill_path.read_text(encoding="utf-8")
 
 frontmatter = """---
 name: wiki-manager
@@ -149,7 +164,7 @@ for old, new in replacements:
         raise SystemExit(f"Expected text not found in {skill_path}: {old[:80]!r}")
     text = text.replace(old, new)
 
-skill_path.write_text(text)
+skill_path.write_text(text, encoding="utf-8", newline="\n")
 
 # references/ is a symlink to claude-plugin/skills/wiki-manager/references and
 # is shared verbatim — no per-file replacements needed. Source references use

--- a/scripts/sync-opencode-plugin.sh
+++ b/scripts/sync-opencode-plugin.sh
@@ -52,18 +52,42 @@ done
 # correct link every run is what breaks checkouts on platforms where ln -s
 # silently produces something other than a symlink (Windows without the
 # privilege to create them), turning a good tree into a dirty one.
+#
+# There are two correct representations. On a platform that has symlinks, the
+# entry is one. Where core.symlinks is false - git's own default on Windows -
+# git materialises a tracked symlink as a *regular file* holding the link
+# target, and that file is exactly what the repository wants committed. Treating
+# it as "not a link" is what still destroys a healthy checkout: the script
+# removes the placeholder, fails to create a real link, and leaves a directory
+# copy in its place.
 REFERENCES_LINK="../../../../claude-plugin/skills/wiki-manager/references"
-if [ -L "$TARGET_SKILL/references" ] && [ "$(readlink "$TARGET_SKILL/references")" = "$REFERENCES_LINK" ]; then
+
+references_is_intact() {
+  local path="$TARGET_SKILL/references"
+  if [ -L "$path" ]; then
+    [ "$(readlink "$path")" = "$REFERENCES_LINK" ]
+    return
+  fi
+  # Placeholder form: a regular file that git tracks with symlink mode 120000
+  # and whose whole content is the link target.
+  [ -f "$path" ] || return 1
+  [ "$(git -C "$ROOT" ls-files -s -- "$path" 2>/dev/null | cut -d' ' -f1)" = "120000" ] || return 1
+  [ "$(cat "$path")" = "$REFERENCES_LINK" ]
+}
+
+if references_is_intact; then
   :
 else
   rm -rf "$TARGET_SKILL/references"
   ln -s "$REFERENCES_LINK" "$TARGET_SKILL/references" 2>/dev/null || true
   if [ ! -L "$TARGET_SKILL/references" ]; then
+    # No symlink support: write the same placeholder git itself checks out, so
+    # the result is byte-identical to what the repository tracks and the tree
+    # stays clean. A directory copy would both dirty the tree and duplicate the
+    # canonical references.
     rm -rf "$TARGET_SKILL/references"
-    cp -R "$SOURCE_SKILL/references" "$TARGET_SKILL/references"
-    echo "warning: this platform cannot create symlinks; copied references/ instead." >&2
-    echo "         Do not commit that copy. Restore the link with:" >&2
-    echo "         git checkout -- $TARGET_SKILL/references" >&2
+    printf '%s' "$REFERENCES_LINK" > "$TARGET_SKILL/references"
+    echo "note: this platform cannot create symlinks; wrote the tracked link placeholder instead." >&2
   fi
 fi
 

--- a/tests/generate-defect-fixtures.sh
+++ b/tests/generate-defect-fixtures.sh
@@ -17,7 +17,10 @@ find "$DEFECTS" -depth -type d -name '* 2' -exec rm -rf {} +
 copy_golden() {
   local name="$1"
   mkdir -p "$DEFECTS/$name"
-  rsync -a --delete --delete-excluded --exclude 'inbox/' "$GOLDEN/" "$DEFECTS/$name/"
+  rm -rf "$DEFECTS/$name"
+  mkdir -p "$DEFECTS/$name"
+  cp -R "$GOLDEN/." "$DEFECTS/$name/"
+  rm -rf "$DEFECTS/$name/inbox"
 }
 
 echo "Generating defect fixtures from golden wiki..."

--- a/tests/test-codex-sync.sh
+++ b/tests/test-codex-sync.sh
@@ -20,8 +20,7 @@ mkdir -p \
   "$scratch/claude-plugin/skills/wiki-manager/references" \
   "$scratch/claude-plugin/.claude-plugin" \
   "$scratch/plugins/llm-wiki/.codex-plugin" \
-  "$scratch/plugins/llm-wiki/skills/wiki-query" \
-  "$scratch/fake-bin"
+  "$scratch/plugins/llm-wiki/skills/wiki-query"
 cp scripts/sync-codex-plugin.sh "$scratch/scripts/"
 touch \
   "$scratch/claude-plugin/skills/wiki-manager/references/query-lite.md" \
@@ -30,18 +29,19 @@ touch \
   "$scratch/scripts/llm-wiki-session" \
   "$scratch/scripts/llm-wiki" \
   "$scratch/plugins/llm-wiki/skills/wiki-query/must-survive"
-ln -s "$(command -v dirname)" "$scratch/fake-bin/dirname"
+# Prerequisite checks must fail before anything in the target tree is
+# touched. Removing the source skill is the cheapest way to prove it.
+mv "$scratch/claude-plugin/skills/wiki-manager" "$scratch/claude-plugin/skills/absent"
 set +e
-missing_rsync_output="$(
-  PATH="$scratch/fake-bin" /bin/bash "$scratch/scripts/sync-codex-plugin.sh" 2>&1
-)"
-missing_rsync_rc=$?
+missing_source_output="$(/bin/bash "$scratch/scripts/sync-codex-plugin.sh" 2>&1)"
+missing_source_rc=$?
 set -e
-if [ "$missing_rsync_rc" -eq 0 ] \
-  || ! grep -q "Missing required tool: rsync" <<<"$missing_rsync_output" \
+mv "$scratch/claude-plugin/skills/absent" "$scratch/claude-plugin/skills/wiki-manager"
+if [ "$missing_source_rc" -eq 0 ] \
+  || ! grep -q "Missing source skill" <<<"$missing_source_output" \
   || [ ! -f "$scratch/plugins/llm-wiki/skills/wiki-query/must-survive" ]; then
-  echo "FAIL: Codex sync must reject a missing rsync before changing the target." >&2
-  echo "$missing_rsync_output" >&2
+  echo "FAIL: Codex sync must reject a missing source before changing the target." >&2
+  echo "$missing_source_output" >&2
   exit 1
 fi
 

--- a/tests/test-opencode-sync.sh
+++ b/tests/test-opencode-sync.sh
@@ -42,17 +42,26 @@ fi
 
 ./scripts/sync-opencode-plugin.sh >/dev/null
 
-# The references symlink must survive a sync. Rewriting it on every run breaks
+# The references link must survive a sync. Rewriting it on every run breaks
 # checkouts on platforms where `ln -s` cannot actually create one.
-if [ ! -L "plugins/llm-wiki-opencode/skills/wiki-manager/references" ]; then
+#
+# Two representations are correct, and which one is on disk is git's choice, not
+# the sync script's: a real symlink where the platform supports them, and the
+# regular file holding the link target that git checks out when core.symlinks is
+# false. Both must be left alone; what must never appear is a directory copy.
+REFERENCES="plugins/llm-wiki-opencode/skills/wiki-manager/references"
+if [ -d "$REFERENCES" ] && [ ! -L "$REFERENCES" ]; then
   cat >&2 <<'MSG'
-FAIL: the OpenCode references symlink did not survive the sync.
+FAIL: the OpenCode references link was replaced by a directory copy.
 
-sync-opencode-plugin.sh must leave a correct references symlink alone. If this
-platform cannot create symlinks, the script says so and copies the directory
-instead -- that copy must not be committed:
-  git checkout -- plugins/llm-wiki-opencode/skills/wiki-manager/references
+sync-opencode-plugin.sh must leave the tracked link - symlink or placeholder
+file - exactly as git checked it out.
 MSG
+  exit 1
+fi
+
+if [ "$(git ls-files -s -- "$REFERENCES" | cut -d' ' -f1)" != "120000" ]; then
+  echo "FAIL: $REFERENCES is no longer tracked as a link." >&2
   exit 1
 fi
 

--- a/tests/test-opencode-sync.sh
+++ b/tests/test-opencode-sync.sh
@@ -17,30 +17,44 @@ mkdir -p \
   "$scratch/scripts" \
   "$scratch/claude-plugin/skills/wiki-manager/references" \
   "$scratch/claude-plugin/.claude-plugin" \
-  "$scratch/plugins/llm-wiki-opencode/skills/wiki-query" \
-  "$scratch/fake-bin"
+  "$scratch/plugins/llm-wiki-opencode/skills/wiki-query"
 cp scripts/sync-opencode-plugin.sh "$scratch/scripts/"
 touch \
   "$scratch/claude-plugin/skills/wiki-manager/references/query-lite.md" \
   "$scratch/claude-plugin/.claude-plugin/plugin.json" \
   "$scratch/scripts/llm-wiki" \
   "$scratch/plugins/llm-wiki-opencode/skills/wiki-query/must-survive"
-ln -s "$(command -v dirname)" "$scratch/fake-bin/dirname"
+# Prerequisite checks must fail before anything in the target tree is
+# touched. Removing the source skill is the cheapest way to prove it.
+mv "$scratch/claude-plugin/skills/wiki-manager" "$scratch/claude-plugin/skills/absent"
 set +e
-missing_rsync_output="$(
-  PATH="$scratch/fake-bin" /bin/bash "$scratch/scripts/sync-opencode-plugin.sh" 2>&1
-)"
-missing_rsync_rc=$?
+missing_source_output="$(/bin/bash "$scratch/scripts/sync-opencode-plugin.sh" 2>&1)"
+missing_source_rc=$?
 set -e
-if [ "$missing_rsync_rc" -eq 0 ] \
-  || ! grep -q "Missing required tool: rsync" <<<"$missing_rsync_output" \
+mv "$scratch/claude-plugin/skills/absent" "$scratch/claude-plugin/skills/wiki-manager"
+if [ "$missing_source_rc" -eq 0 ] \
+  || ! grep -q "Missing source skill" <<<"$missing_source_output" \
   || [ ! -f "$scratch/plugins/llm-wiki-opencode/skills/wiki-query/must-survive" ]; then
-  echo "FAIL: OpenCode sync must reject a missing rsync before changing the target." >&2
-  echo "$missing_rsync_output" >&2
+  echo "FAIL: OpenCode sync must reject a missing source before changing the target." >&2
+  echo "$missing_source_output" >&2
   exit 1
 fi
 
 ./scripts/sync-opencode-plugin.sh >/dev/null
+
+# The references symlink must survive a sync. Rewriting it on every run breaks
+# checkouts on platforms where `ln -s` cannot actually create one.
+if [ ! -L "plugins/llm-wiki-opencode/skills/wiki-manager/references" ]; then
+  cat >&2 <<'MSG'
+FAIL: the OpenCode references symlink did not survive the sync.
+
+sync-opencode-plugin.sh must leave a correct references symlink alone. If this
+platform cannot create symlinks, the script says so and copies the directory
+instead -- that copy must not be committed:
+  git checkout -- plugins/llm-wiki-opencode/skills/wiki-manager/references
+MSG
+  exit 1
+fi
 
 if ! git diff --quiet HEAD -- plugins/llm-wiki-opencode/; then
   cat >&2 <<'MSG'


### PR DESCRIPTION
## Summary

Three portability bugs that together make both sync scripts unusable on a common developer setup — Git for Windows with a non-UTF-8 system locale — and therefore make `tests/test-codex-sync.sh` and `tests/test-opencode-sync.sh` impossible to pass there. They are separable, but they sit in the same two scripts and the same two tests, so they are easier to review together.

### 1. `rsync` is not a given

Both sync scripts and `tests/generate-defect-fixtures.sh` require `rsync`. Git for Windows does not ship it and it is optional on minimal Linux images. It was doing one narrow job — copy a tree, delete extraneous entries, skip one subdirectory — that plain POSIX tools already do.

Replaced with `cp -R` plus an explicit prune. The `rsync` prerequisite guard from #75 goes away with the dependency it was guarding.

### 2. `sync-opencode-plugin.sh` destroys the `references` symlink it only needs to verify

The script unconditionally ran `rm -rf "$TARGET_SKILL/references"` followed by `ln -s ...` on every invocation. Where `ln -s` cannot actually create a symlink — Git Bash on Windows without the privilege silently produces a plain directory or a copy, with exit status 0 — that replaced a correct checked-out symlink with something else, dirtied the working tree, and left the mirror in a state `test-plugin-validate.sh` rejects. The user had to know to run `git checkout -- <path>` to undo it.

It now leaves a correct link alone (`readlink` matches the expected target), verifies what it created with `[ -L ... ]`, and only falls back to copying the directory when the platform cannot make symlinks — printing a warning and the exact `git checkout --` command that restores the link.

### 3. The embedded Python uses the locale encoding

`skill_path.read_text()` and `skill_path.write_text(text)` have no `encoding=`. On a cp1251 machine, reading the UTF-8 `SKILL.md` as cp1251 turns the em dash in

> `... the compiler and the query engine — no Obsidian, no external tools.`

into three mojibake characters, so the very first replacement never matches and the sync aborts with `Expected text not found in ...`. This is what actually blocks the sync on that machine; the `rsync` guard just hid it behind an earlier failure.

All reads and writes now pass `encoding="utf-8"`, and writes also pass `newline="\n"` so generated files are byte-identical on every platform instead of silently acquiring CRLF on Windows. (`json` reads/writes in the hooks block already did this — the SKILL.md and manifest paths were the ones missed.)

## Tests

- both sync scripts regenerate `plugins/` **byte-for-byte identically to what is committed** — `git status` is completely clean after running them, including line endings
- `tests/generate-defect-fixtures.sh` reproduces every committed fixture byte-for-byte
- `tests/test-codex-sync.sh` and `tests/test-opencode-sync.sh` pass on Windows for the first time
- `tests/test-plugin-validate.sh` 131/135 and `tests/test-structure.sh` 163/172 — unchanged from this machine's pre-existing counts; the failures there are a separate Windows issue in the fixtures, not touched by this PR
- `tests/test-docs-consistency.sh` passes

The two mirror tests lose their `rsync`-guard blocks, which faked `dirname` on `PATH` with `ln -s` and so were themselves broken by bug 2. The same "prerequisites fail before anything is touched" property is now proven by removing the source skill, which needs no symlinks. The OpenCode test additionally asserts that the `references` symlink survives a sync.

Found while running a downstream fork's identical scripts on Windows.
