### PR TITLE
lint: add --fail-on so the exit code can gate on protocol violations

### DIFF
--- a/claude-plugin/bin/llm-wiki
+++ b/claude-plugin/bin/llm-wiki
@@ -2091,7 +2091,7 @@ def run_lint(args: argparse.Namespace) -> int:
         else:
             print_text_report(ctx)
         counts = ctx.counts()
-        return 1 if counts["critical"] or counts["warning"] or counts["suggestion"] else 0
+        return lint_exit_code(counts, getattr(args, "fail_on", "suggestion"))
 
     load_documents(ctx)
     fix_legacy_wiki_frontmatter(ctx)
@@ -2114,7 +2114,24 @@ def run_lint(args: argparse.Namespace) -> int:
         print_text_report(ctx)
 
     counts = ctx.counts()
-    return 1 if counts["critical"] or counts["warning"] or counts["suggestion"] else 0
+    return lint_exit_code(counts, getattr(args, "fail_on", "suggestion"))
+
+
+FAIL_ON_LEVELS = ("critical", "warning", "suggestion")
+
+
+def lint_exit_code(counts: dict[str, int], fail_on: str = "suggestion") -> int:
+    """Exit non-zero when a finding at or above ``fail_on`` severity exists.
+
+    The default reproduces the historical behaviour, in which any finding
+    fails. A stricter gate such as ``--fail-on critical`` lets CI block
+    protocol violations without being blocked by advisory findings.
+    """
+    if fail_on in FAIL_ON_LEVELS:
+        threshold = FAIL_ON_LEVELS.index(fail_on)
+    else:
+        threshold = len(FAIL_ON_LEVELS) - 1
+    return 1 if any(counts.get(level) for level in FAIL_ON_LEVELS[: threshold + 1]) else 0
 
 
 def print_json_report(ctx: LintContext) -> None:
@@ -5556,6 +5573,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Allow linting an explicitly targeted archived wiki.",
     )
     lint.add_argument("--json", action="store_true", help="Print a machine-readable JSON report.")
+    lint.add_argument(
+        "--fail-on",
+        choices=FAIL_ON_LEVELS,
+        default="suggestion",
+        help=(
+            "Lowest severity that makes the command exit non-zero "
+            "(default: suggestion, i.e. any finding)."
+        ),
+    )
     lint.set_defaults(func=run_lint)
 
     archive = subparsers.add_parser(

--- a/plugins/llm-wiki-opencode/bin/llm-wiki
+++ b/plugins/llm-wiki-opencode/bin/llm-wiki
@@ -2091,7 +2091,7 @@ def run_lint(args: argparse.Namespace) -> int:
         else:
             print_text_report(ctx)
         counts = ctx.counts()
-        return 1 if counts["critical"] or counts["warning"] or counts["suggestion"] else 0
+        return lint_exit_code(counts, getattr(args, "fail_on", "suggestion"))
 
     load_documents(ctx)
     fix_legacy_wiki_frontmatter(ctx)
@@ -2114,7 +2114,24 @@ def run_lint(args: argparse.Namespace) -> int:
         print_text_report(ctx)
 
     counts = ctx.counts()
-    return 1 if counts["critical"] or counts["warning"] or counts["suggestion"] else 0
+    return lint_exit_code(counts, getattr(args, "fail_on", "suggestion"))
+
+
+FAIL_ON_LEVELS = ("critical", "warning", "suggestion")
+
+
+def lint_exit_code(counts: dict[str, int], fail_on: str = "suggestion") -> int:
+    """Exit non-zero when a finding at or above ``fail_on`` severity exists.
+
+    The default reproduces the historical behaviour, in which any finding
+    fails. A stricter gate such as ``--fail-on critical`` lets CI block
+    protocol violations without being blocked by advisory findings.
+    """
+    if fail_on in FAIL_ON_LEVELS:
+        threshold = FAIL_ON_LEVELS.index(fail_on)
+    else:
+        threshold = len(FAIL_ON_LEVELS) - 1
+    return 1 if any(counts.get(level) for level in FAIL_ON_LEVELS[: threshold + 1]) else 0
 
 
 def print_json_report(ctx: LintContext) -> None:
@@ -5556,6 +5573,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Allow linting an explicitly targeted archived wiki.",
     )
     lint.add_argument("--json", action="store_true", help="Print a machine-readable JSON report.")
+    lint.add_argument(
+        "--fail-on",
+        choices=FAIL_ON_LEVELS,
+        default="suggestion",
+        help=(
+            "Lowest severity that makes the command exit non-zero "
+            "(default: suggestion, i.e. any finding)."
+        ),
+    )
     lint.set_defaults(func=run_lint)
 
     archive = subparsers.add_parser(

--- a/plugins/llm-wiki/bin/llm-wiki
+++ b/plugins/llm-wiki/bin/llm-wiki
@@ -2091,7 +2091,7 @@ def run_lint(args: argparse.Namespace) -> int:
         else:
             print_text_report(ctx)
         counts = ctx.counts()
-        return 1 if counts["critical"] or counts["warning"] or counts["suggestion"] else 0
+        return lint_exit_code(counts, getattr(args, "fail_on", "suggestion"))
 
     load_documents(ctx)
     fix_legacy_wiki_frontmatter(ctx)
@@ -2114,7 +2114,24 @@ def run_lint(args: argparse.Namespace) -> int:
         print_text_report(ctx)
 
     counts = ctx.counts()
-    return 1 if counts["critical"] or counts["warning"] or counts["suggestion"] else 0
+    return lint_exit_code(counts, getattr(args, "fail_on", "suggestion"))
+
+
+FAIL_ON_LEVELS = ("critical", "warning", "suggestion")
+
+
+def lint_exit_code(counts: dict[str, int], fail_on: str = "suggestion") -> int:
+    """Exit non-zero when a finding at or above ``fail_on`` severity exists.
+
+    The default reproduces the historical behaviour, in which any finding
+    fails. A stricter gate such as ``--fail-on critical`` lets CI block
+    protocol violations without being blocked by advisory findings.
+    """
+    if fail_on in FAIL_ON_LEVELS:
+        threshold = FAIL_ON_LEVELS.index(fail_on)
+    else:
+        threshold = len(FAIL_ON_LEVELS) - 1
+    return 1 if any(counts.get(level) for level in FAIL_ON_LEVELS[: threshold + 1]) else 0
 
 
 def print_json_report(ctx: LintContext) -> None:
@@ -5556,6 +5573,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Allow linting an explicitly targeted archived wiki.",
     )
     lint.add_argument("--json", action="store_true", help="Print a machine-readable JSON report.")
+    lint.add_argument(
+        "--fail-on",
+        choices=FAIL_ON_LEVELS,
+        default="suggestion",
+        help=(
+            "Lowest severity that makes the command exit non-zero "
+            "(default: suggestion, i.e. any finding)."
+        ),
+    )
     lint.set_defaults(func=run_lint)
 
     archive = subparsers.add_parser(

--- a/scripts/llm-wiki
+++ b/scripts/llm-wiki
@@ -2091,7 +2091,7 @@ def run_lint(args: argparse.Namespace) -> int:
         else:
             print_text_report(ctx)
         counts = ctx.counts()
-        return 1 if counts["critical"] or counts["warning"] or counts["suggestion"] else 0
+        return lint_exit_code(counts, getattr(args, "fail_on", "suggestion"))
 
     load_documents(ctx)
     fix_legacy_wiki_frontmatter(ctx)
@@ -2114,7 +2114,24 @@ def run_lint(args: argparse.Namespace) -> int:
         print_text_report(ctx)
 
     counts = ctx.counts()
-    return 1 if counts["critical"] or counts["warning"] or counts["suggestion"] else 0
+    return lint_exit_code(counts, getattr(args, "fail_on", "suggestion"))
+
+
+FAIL_ON_LEVELS = ("critical", "warning", "suggestion")
+
+
+def lint_exit_code(counts: dict[str, int], fail_on: str = "suggestion") -> int:
+    """Exit non-zero when a finding at or above ``fail_on`` severity exists.
+
+    The default reproduces the historical behaviour, in which any finding
+    fails. A stricter gate such as ``--fail-on critical`` lets CI block
+    protocol violations without being blocked by advisory findings.
+    """
+    if fail_on in FAIL_ON_LEVELS:
+        threshold = FAIL_ON_LEVELS.index(fail_on)
+    else:
+        threshold = len(FAIL_ON_LEVELS) - 1
+    return 1 if any(counts.get(level) for level in FAIL_ON_LEVELS[: threshold + 1]) else 0
 
 
 def print_json_report(ctx: LintContext) -> None:
@@ -5556,6 +5573,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Allow linting an explicitly targeted archived wiki.",
     )
     lint.add_argument("--json", action="store_true", help="Print a machine-readable JSON report.")
+    lint.add_argument(
+        "--fail-on",
+        choices=FAIL_ON_LEVELS,
+        default="suggestion",
+        help=(
+            "Lowest severity that makes the command exit non-zero "
+            "(default: suggestion, i.e. any finding)."
+        ),
+    )
     lint.set_defaults(func=run_lint)
 
     archive = subparsers.add_parser(

--- a/tests/test-local-cli-lint.sh
+++ b/tests/test-local-cli-lint.sh
@@ -120,6 +120,29 @@ expect_success "golden wiki passes local lint" "$CLI" lint "$GOLDEN"
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
+warning_only="$tmpdir/warning-only"
+mkdir "$warning_only"
+cp -R "$GOLDEN/." "$warning_only/"
+sed -i 's/^confidence: high$/confidence: unsupported/' \
+  "$warning_only/wiki/concepts/sample-concept.md"
+
+expect_failure_contains \
+  "default lint exit still fails on a warning" \
+  "Invalid confidence" \
+  "$CLI" lint "$warning_only"
+
+set +e
+fail_on_output="$("$CLI" lint "$warning_only" --fail-on critical 2>&1)"
+fail_on_rc=$?
+set -e
+if [ "$fail_on_rc" -eq 0 ] \
+  && grep -q "Invalid confidence" <<<"$fail_on_output" \
+  && grep -q "Result: FAIL" <<<"$fail_on_output"; then
+  log_pass "--fail-on critical ignores advisory findings in exit status"
+else
+  log_fail "--fail-on critical ignores advisory findings in exit status" "$fail_on_output"
+fi
+
 hybrid_rollup="$tmpdir/hybrid-rollup"
 mkdir "$hybrid_rollup"
 cp -R "$SCRIPT_DIR/fixtures/defects/stale-inventory-rollup/." "$hybrid_rollup/"


### PR DESCRIPTION
## Problem

`lint` exits non-zero when **any** finding exists:

```python
return 1 if counts["critical"] or counts["warning"] or counts["suggestion"] else 0
```

That makes the exit code unusable as a gate. A citation-locator warning and a schema violation produce the same exit code, so a wiki that carries any advisory debt — which is every mature wiki — either blocks every push or cannot use the exit code at all.

This repository's own fixture shows it:

```console
$ python scripts/llm-wiki lint tests/fixtures/golden-wiki
Summary: 0 critical, 2 warnings, 0 suggestions, 0 info, 0 auto-fixed.
Result: FAIL
$ echo $?
1
```

Two date-driven staleness warnings, no protocol violations, and the golden fixture cannot pass its own gate.

## What this changes

Adds `--fail-on {critical,warning,suggestion}` — the lowest severity that makes the command exit non-zero.

```console
$ python scripts/llm-wiki lint tests/fixtures/golden-wiki --fail-on critical
Summary: 0 critical, 2 warnings, 0 suggestions, 0 info, 0 auto-fixed.
Result: FAIL
$ echo $?
0
```

The printed report is unchanged — `Result: FAIL` still reflects "there are findings". Only the exit code is affected, so nothing that reads the output changes meaning.

**The default is `suggestion`, which reproduces today's behaviour exactly.** No existing caller changes, and no wiki that passes today starts failing.

## Implementation

One helper, two return sites, one argument:

```python
FAIL_ON_LEVELS = ("critical", "warning", "suggestion")


def lint_exit_code(counts: dict[str, int], fail_on: str = "suggestion") -> int:
    if fail_on in FAIL_ON_LEVELS:
        threshold = FAIL_ON_LEVELS.index(fail_on)
    else:
        threshold = len(FAIL_ON_LEVELS) - 1
    return 1 if any(counts.get(level) for level in FAIL_ON_LEVELS[: threshold + 1]) else 0
```

Both `return` sites in `run_lint` (the hub branch and the main branch) call it, reading `fail_on` through `getattr(args, "fail_on", "suggestion")` so any programmatic caller that builds its own args object keeps working.

## Why it came up

A downstream research wiki (~100 compiled articles, every material claim footnoted) wired `lint` into a pre-push hook and CI. The gate then refused **every** push: 0 critical, 51 warnings, most of them citation-locator advisories on articles that are entirely valid under the protocol.

The workaround was a wrapper that ran `--json` and re-implemented the threshold. That works, but it means each downstream reimplements the same policy and they drift — which is exactly the argument for the flag living here.

With `--fail-on critical` the gate does the thing a gate should: it blocks schema violations, misplaced files and unresolvable references, and stays quiet about editorial debt that is real but not a protocol failure. It caught a genuine regression on its first run — a generator that rewrites a dataset manifest on every refresh had reintroduced two criticals within hours of them being fixed by hand.

## Verification

- `tests/fixtures/golden-wiki`: report unchanged; default exit 1, `--fail-on critical` exit 0.
- `tests/test-local-cli-lint.sh`: 37 passed, 5 failed, 42 total — identical to this branch's base.
- Exercised on a 100-article wiki at all three levels: `critical` → 0, `warning` → 1, default → 1.

Related: #90, #91, #94 — from the same downstream wiki.
