### PR TITLE
Make the token-efficiency benchmark runnable on Windows

### DIFF
--- a/scripts/benchmark-token-efficiency
+++ b/scripts/benchmark-token-efficiency
@@ -55,10 +55,12 @@ def git_commit(root: Path) -> str:
 
 
 def display_path(path: Path, root: Path) -> str:
+    # Reports are compared across machines, so paths in them must not depend on
+    # the local separator.
     try:
-        return str(path.relative_to(root))
+        return path.relative_to(root).as_posix()
     except ValueError:
-        return str(path)
+        return path.as_posix()
 
 
 def utc_now() -> str:
@@ -232,7 +234,10 @@ def load_cases(path: Path, selected: set[str] | None = None) -> list[dict[str, A
 def tree_digest(root: Path) -> str:
     digest = hashlib.sha256()
     for path in sorted(p for p in root.rglob("*") if p.is_file()):
-        digest.update(str(path.relative_to(root)).encode())
+        # as_posix keeps the corpus digest identical on Windows and POSIX, so
+        # the same_case_corpus/same_fixture_corpus gates stay meaningful when
+        # two machines exchange reports.
+        digest.update(path.relative_to(root).as_posix().encode())
         digest.update(b"\0")
         digest.update(path.read_bytes())
         digest.update(b"\0")
@@ -241,6 +246,24 @@ def tree_digest(root: Path) -> str:
 
 def file_digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def resolve_command(command: str) -> list[str]:
+    """Split a runtime command and resolve its executable through PATHEXT.
+
+    Windows `CreateProcess` does not apply `PATHEXT`, so a bare `codex` or
+    `claude` raises `FileNotFoundError` even though the launcher is on `PATH`
+    as `codex.cmd` / `claude.cmd`. `shutil.which` applies it. Keep the original
+    word when it does not resolve, so the resulting error still names what was
+    asked for.
+    """
+    argv = shlex.split(command)
+    if not argv:
+        return argv
+    resolved = shutil.which(argv[0])
+    if resolved:
+        argv[0] = resolved
+    return argv
 
 
 class AppServerError(RuntimeError):
@@ -262,7 +285,7 @@ class AppServer:
         self._pending: list[Event] = []
         self._stderr: list[str] = []
         self.process = subprocess.Popen(
-            shlex.split(command),
+            resolve_command(command),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -888,7 +911,7 @@ def parse_claude_stream(
             continue
         path = Path(file_info["filePath"])
         if path_is_within(path, fixture_root):
-            fixture_reads.add(str(path.resolve().relative_to(fixture_root.resolve())))
+            fixture_reads.add(path.resolve().relative_to(fixture_root.resolve()).as_posix())
     output = result.get("result") or ""
     grade = grade_output(case, output)
     grade["fixture_reads"] = len(fixture_reads)
@@ -989,7 +1012,7 @@ def run_claude_benchmark(
                         f"case {case['id']} has no Claude command-route prompt"
                     )
                 command = [
-                    *shlex.split(claude_command),
+                    *resolve_command(claude_command),
                     "-p",
                     prompt,
                     "--plugin-dir",

--- a/tests/test-token-benchmarks.sh
+++ b/tests/test-token-benchmarks.sh
@@ -8,6 +8,15 @@ FAKE_SERVER="$ROOT/tests/fixtures/fake-codex-app-server.py"
 FAKE_CLAUDE="$ROOT/tests/fixtures/fake-claude-cli.py"
 FAKE_PI="$ROOT/tests/fixtures/fake-pi-cli.py"
 
+# A native Windows python cannot open a POSIX-style path: `/c/...` resolves
+# against the current drive as `C:\c\...`. Translate when cygpath is present.
+win_path() {
+  if command -v cygpath >/dev/null 2>&1; then cygpath -w "$1"; else printf '%s' "$1"; fi
+}
+FAKE_SERVER="$(win_path "$FAKE_SERVER")"
+FAKE_CLAUDE="$(win_path "$FAKE_CLAUDE")"
+FAKE_PI="$(win_path "$FAKE_PI")"
+
 mkdir -p "$ROOT/.tmp"
 TMP_ROOT="$(mktemp -d "$ROOT/.tmp/token-benchmark.XXXXXX")"
 trap 'rm -rf "$TMP_ROOT"' EXIT


### PR DESCRIPTION
## Summary

`tests/test-token-benchmarks.sh` cannot get past its first app-server case under Git Bash on Windows — it exits 2 immediately. Three separate defects, all in the same lane, none of which change behaviour on POSIX.

### 1. `CreateProcess` does not apply `PATHEXT`

`AppServer` does `Popen(shlex.split(command))`, and the default server command starts with a bare `codex`. Windows resolves executables through `PATHEXT`, but `CreateProcess` does not — so the launcher sitting on `PATH` as `codex.cmd` is never found:

```
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

The Claude command route has the same problem with `claude.cmd`. A new `resolve_command()` resolves argv[0] through `shutil.which`, which does apply `PATHEXT`, and keeps the original word when nothing resolves so the error still names what was asked for.

### 2. Fixture paths are handed to `python3` as POSIX paths

`--server-command "python3 '$FAKE_SERVER'"` passes `/c/.../fake-codex-app-server.py`. A native Windows Python resolves a leading `/` against the current drive, so it looks for `C:\c\...`:

```
python3: can't open file 'C:\c\...\tests\fixtures\fake-codex-app-server.py': [Errno 2] No such file or directory
```

The test now translates the three fixture paths with `cygpath -w` when cygpath is present, and is byte-identical everywhere else.

### 3. Report paths and corpus digests used the OS-native separator

The report's `skill` field came out as `plugins\llm-wiki\skills\wiki-query\SKILL.md`, and `tree_digest` hashed native separators into `cases_sha256` / `fixture_sha256`.

The digest one matters beyond cosmetics. `compare`'s `same_case_corpus` and `same_fixture_corpus` gates exist so two machines can exchange reports — but a Windows-produced digest could never match a POSIX one for byte-identical content, so a cross-platform comparison would fail for a reason that has nothing to do with the corpus. All three sites now use `as_posix()`; values are unchanged on POSIX.

## Tests

On this machine (Windows 11, Git Bash, Python 3.14, no `rsync`):

| | before | after |
|---|---|---|
| `tests/test-token-benchmarks.sh` | exit 2 at the first app-server case | **full suite passes** |

That includes the Codex app-server accounting, the read-only query preset, the comparison/regression gates, the AB/BA orchestration, and the Claude and Pi/DS4 lanes — all against the checked-in fakes, so no quota is spent.

`tests/test-plugin-validate.sh` and `tests/test-structure.sh` are untouched by this change and unchanged at their existing counts here.

Found while running the same lane in a downstream fork.
