### PR TITLE
session: don't lose state writes when a replace meets an open reader

### DIFF
--- a/scripts/llm-wiki-session
+++ b/scripts/llm-wiki-session
@@ -19,6 +19,7 @@ import re
 import subprocess
 import sys
 import textwrap
+import time
 import uuid
 from pathlib import Path
 from typing import Any
@@ -219,7 +220,19 @@ def atomic_write(path: Path, text: str) -> None:
     tmp = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
     try:
         tmp.write_text(text, encoding="utf-8")
-        os.replace(tmp, path)
+        # POSIX rename always succeeds; Windows refuses to replace a file that
+        # another process currently has open, which concurrent hooks reading the
+        # same state file do constantly. The window is short, so retry briefly
+        # rather than losing the write - and still raise if it never clears.
+        deadline = time.monotonic() + 2.0
+        while True:
+            try:
+                os.replace(tmp, path)
+                break
+            except PermissionError:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.01)
     finally:
         if tmp.exists():
             try:
@@ -231,7 +244,20 @@ def atomic_write(path: Path, text: str) -> None:
 def read_json(path: Path, default: Any) -> Any:
     if not path.exists():
         return default
-    text = path.read_text(encoding="utf-8")
+    # Windows also refuses to open a file while it is being replaced, so a reader
+    # that meets a writer sees a sharing violation rather than either version of
+    # the file. The window is very short; retry briefly before giving up.
+    deadline = time.monotonic() + 1.0
+    while True:
+        try:
+            text = path.read_text(encoding="utf-8")
+            break
+        except FileNotFoundError:
+            return default
+        except PermissionError:
+            if time.monotonic() >= deadline:
+                return default
+            time.sleep(0.005)
     try:
         return json.loads(text)
     except json.JSONDecodeError:

--- a/tests/test-session-concurrency.sh
+++ b/tests/test-session-concurrency.sh
@@ -106,6 +106,16 @@ def stress(impl, seconds=1.5, nproc=8):
         def payload(i):
             return json.dumps({"w": i, "pad": "x" * (2000 if i % 2 == 0 else 200000)}) + "\n"
 
+        def read_with_retry(target):
+            # Windows cannot open a file mid-replace; a real reader retries, so the
+            # measurement here must too, or it counts the platform, not a lost write.
+            for _ in range(200):
+                try:
+                    return json.loads(target.read_text(encoding="utf-8"))
+                except PermissionError:
+                    time.sleep(0.005)
+            return json.loads(target.read_text(encoding="utf-8"))
+        
         aw = old_atomic_write if impl == "old" else sut.atomic_write
         p = Path(path_s)
         text = payload(int(idx_s))
@@ -118,7 +128,7 @@ def stress(impl, seconds=1.5, nproc=8):
                 repl += 1
                 continue
             try:
-                json.loads(p.read_text(encoding="utf-8"))
+                read_with_retry(p)
             except json.JSONDecodeError:
                 torn += 1
             except FileNotFoundError:


### PR DESCRIPTION
## Problem

`atomic_write` in `scripts/llm-wiki-session` assumes rename semantics that only POSIX provides. Windows refuses to replace a file that another process currently has open — which is exactly what concurrent session hooks do: one writes state while others read it.

This is silent data loss rather than a crash: the write simply does not land.

`tests/test-session-concurrency.sh` measures it on Windows, before this change:

```
FAIL: current atomic_write under concurrent writers - NEW_RACE 3789 (replace=3726 torn=0 other=63 exits=0 missing=0)
FAIL: 96 concurrent live Stop hooks - nonzero-exits=30 tracebacks=8
```

3726 writes raised instead of landing, and 30 of the 96 live Stop hooks exited non-zero with a traceback.

## Change

- retry the `os.replace` for up to two seconds, and re-raise if the window never clears, so a genuine permission problem still surfaces;
- give `read_json` the same tolerance: a reader that meets a writer mid-replace sees a sharing violation rather than either version of the file, and that should not propagate into a hook;
- let the test's own raw reader retry as well — otherwise it measures the platform rather than a lost write.

## Verification

`tests/test-session-concurrency.sh` now passes 10/10 on Windows. Its control case still reproduces the shared-tmp race it was written to catch (`OLD_RACE 7879 (replace=7847 torn=32 ...)`), so the assertion has not been weakened.

Nothing changes on POSIX: neither retry path is ever entered there.