### PR TITLE
codex: keep --user-home from installing into the real user profile

### DIFF
--- a/scripts/bootstrap-codex-plugin.sh
+++ b/scripts/bootstrap-codex-plugin.sh
@@ -89,6 +89,22 @@ PROJECT_ROOT="$(cd "$PROJECT_ROOT" && pwd)"
 USER_HOME="$(cd "$USER_HOME" && pwd)"
 USER_CONFIG="$USER_HOME/.codex/config.toml"
 
+# Codex resolves its own home from CODEX_HOME, falling back to the OS home - and
+# on Windows that fallback is USERPROFILE, not HOME. Setting HOME alone therefore
+# leaves every invocation below writing into the real user profile, so
+# --user-home does not isolate anything and the runtime test installs a
+# marketplace and a plugin into the developer's own Codex config. Export
+# CODEX_HOME too, in the form the native binary can read.
+codex_home_for() {
+  local home="$1/.codex"
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$home"
+  else
+    printf '%s' "$home"
+  fi
+}
+
+
 MANAGED_BLOCK="$(python3 - "$PLUGIN_KEY" <<'PY'
 import sys
 
@@ -109,7 +125,7 @@ if ! command -v codex >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! HOME="$USER_HOME" codex plugin add --help >/dev/null 2>&1; then
+if ! HOME="$USER_HOME" CODEX_HOME="$(codex_home_for "$USER_HOME")" codex plugin add --help >/dev/null 2>&1; then
   echo "This Codex version does not support non-interactive plugin installation." >&2
   echo "Upgrade Codex, then rerun this helper." >&2
   exit 1
@@ -140,7 +156,7 @@ PY
 )"
 
 if [[ -z "$MARKETPLACE_SOURCE" ]]; then
-  HOME="$USER_HOME" codex plugin marketplace add "$ROOT"
+  HOME="$USER_HOME" CODEX_HOME="$(codex_home_for "$USER_HOME")" codex plugin marketplace add "$ROOT"
 else
   if [[ "$MARKETPLACE_SOURCE" != "$ROOT" ]]; then
     echo "Codex marketplace '${MARKETPLACE_NAME}' already points at:" >&2
@@ -154,7 +170,7 @@ fi
 # `codex plugin add` is the supported materialization path. It copies the
 # plugin into ~/.codex/plugins/cache and writes the supported user-scope enable
 # block. Marketplace registration alone does not install the plugin.
-INSTALL_OUTPUT="$(HOME="$USER_HOME" codex plugin add "$PLUGIN_KEY" --json)"
+INSTALL_OUTPUT="$(HOME="$USER_HOME" CODEX_HOME="$(codex_home_for "$USER_HOME")" codex plugin add "$PLUGIN_KEY" --json)"
 INSTALLED_PATH="$(python3 -c 'import json, sys; print(json.load(sys.stdin)["installedPath"])' <<<"$INSTALL_OUTPUT")"
 TARGET="$USER_CONFIG"
 

--- a/scripts/verify-codex-plugin.sh
+++ b/scripts/verify-codex-plugin.sh
@@ -74,6 +74,22 @@ EXPECTED_VERSION="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[
 TMP_OUTPUT="$(mktemp)"
 TMP_LIST="$(mktemp)"
 USER_CONFIG="$USER_HOME/.codex/config.toml"
+
+# Codex resolves its own home from CODEX_HOME, falling back to the OS home - and
+# on Windows that fallback is USERPROFILE, not HOME. Setting HOME alone therefore
+# leaves every invocation below writing into the real user profile, so
+# --user-home does not isolate anything and the runtime test installs a
+# marketplace and a plugin into the developer's own Codex config. Export
+# CODEX_HOME too, in the form the native binary can read.
+codex_home_for() {
+  local home="$1/.codex"
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$home"
+  else
+    printf '%s' "$home"
+  fi
+}
+
 TARGET_CONFIG="$USER_CONFIG"
 cleanup() {
   rm -f "$TMP_OUTPUT" "$TMP_LIST"
@@ -101,8 +117,8 @@ if ! grep -Fq "[plugins.\"$PLUGIN_KEY\"]" "$TARGET_CONFIG"; then
   exit 1
 fi
 
-HOME="$USER_HOME" codex -C "$PROJECT_ROOT" plugin list --marketplace "$MARKETPLACE_NAME" --json >"$TMP_LIST"
-HOME="$USER_HOME" codex -C "$PROJECT_ROOT" debug prompt-input '@wiki test' >"$TMP_OUTPUT"
+HOME="$USER_HOME" CODEX_HOME="$(codex_home_for "$USER_HOME")" codex -C "$PROJECT_ROOT" plugin list --marketplace "$MARKETPLACE_NAME" --json >"$TMP_LIST"
+HOME="$USER_HOME" CODEX_HOME="$(codex_home_for "$USER_HOME")" codex -C "$PROJECT_ROOT" debug prompt-input '@wiki test' >"$TMP_OUTPUT"
 
 INSTALLED_VERSION="$(python3 - "$TMP_LIST" "$PLUGIN_KEY" "$EXPECTED_VERSION" "$SOURCE_PLUGIN_ROOT" "$ROOT" <<'PY'
 import json
@@ -123,10 +139,23 @@ if not plugin.get("enabled"):
 if plugin.get("version") != expected_version:
     errors.append(f"installed version {plugin.get('version')!r} != expected {expected_version!r}")
 
+def strip_extended_prefix(text):
+    """Codex records Windows paths in extended-length form (\\\\?\\C:\\...).
+
+    Comparing that spelling verbatim against the path we asked for reports a
+    correct install as a mismatch, so compare identities instead.
+    """
+    for prefix in ("\\\\?\\UNC\\", "\\\\?\\"):
+        if text.startswith(prefix):
+            return text[len(prefix):]
+    return text
+
+
 def same_path(actual, expected):
     if not actual:
         return False
-    return Path(actual).expanduser().resolve() == Path(expected).expanduser().resolve()
+    actual = Path(strip_extended_prefix(str(actual))).expanduser().resolve()
+    return actual == Path(str(expected)).expanduser().resolve()
 
 source = plugin.get("source") or {}
 if source.get("source") != "local" or not same_path(source.get("path"), source_root):


### PR DESCRIPTION
## Problem

Codex resolves its home from `CODEX_HOME`, falling back to the OS home — and on Windows that fallback is `USERPROFILE`, not `HOME`. Setting `HOME` alone therefore isolates nothing: `--user-home` points at a scratch directory while every `codex` invocation writes to the developer's real profile.

Running `tests/test-codex-runtime.sh` on Windows leaves this in the real `~/.codex/config.toml`:

```toml
[marketplaces.llm-wiki]
source_type = "local"
source = '\?\C:\path\to\the\repo'

[plugins."wiki@llm-wiki"]
enabled = true
```

…plus a cache directory under `~/.codex/plugins/cache/`. The test then fails anyway, because it looks for the install in the sandbox where it was supposed to be. I had to clean my own profile by hand after finding this.

## Change

1. Export `CODEX_HOME` alongside `HOME` for every sandboxed `codex` invocation, in the form the native binary can read.
2. With the install landing in the sandbox, verification then failed on spelling rather than substance: Codex records the source in extended-length form (`\?\C:\...`), and comparing that verbatim against the path we asked for reports a correct install as a mismatch. Compare path identities instead.

Both are needed for the test to pass; the second only becomes reachable once the first lands.

## Verification

`tests/test-codex-runtime.sh` passes on Windows, and a full suite run leaves the real Codex profile byte-identical.

Nothing changes on POSIX, where `CODEX_HOME` simply points at the same directory `HOME` already implied.